### PR TITLE
Switch the minimap to use USGS National Map

### DIFF
--- a/components/MiniMap.vue
+++ b/components/MiniMap.vue
@@ -52,7 +52,7 @@ export default {
 	methods: {
 		getBaseMapAndLayers() {
 			var baseLayer = new L.tileLayer.wms(
-				"https://basemap.nationalmap.gov:443/arcgis/services/USGSTopo/MapServer/WmsServer?",
+				"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WmsServer?",
 				{
 					transparent: true,
 					format: "image/png",


### PR DESCRIPTION
Click on a point to load data.  See that the MiniMap is now the USGS National Map, which is a lot better at that zoom level.  (We can fine-tune that zoom level more, too).