### PR TITLE
Fixes L is not defined error message in console

### DIFF
--- a/components/MapLayer.vue
+++ b/components/MapLayer.vue
@@ -38,7 +38,7 @@ export default {
       return this.layer.default;
     },
   },
-  created() {
+  mounted() {
     if (this.layer.default) {
       // We need to wait for Vue to render the full DOM which
       // includes the `#map` element before we can trigger this.


### PR DESCRIPTION
This is a minor PR.

Fixes the 'L is not defined' error message when reloading a plate. Needs to be in mounted() to allow for dependencies to be loaded before attempting to use Leaflet.

Testing:
- On main, try going to a plate map and clicking the reload button. Note the error message in the Terminal window.
- On this branch, try going to a plate map and clicking the reload button. Note the lack of error message.