### PR TITLE
Fixes bug with community ID / name kept after closing report

### DIFF
--- a/store/map.js
+++ b/store/map.js
@@ -108,6 +108,8 @@ export default {
 			state.reportIsVisible = true;
 		},
 		closeReport(state) {
+			state.placeName = undefined;
+			state.placeID = undefined;
 			state.reportIsVisible = false;
 		},
 		toggleLayer(state, layer) {


### PR DESCRIPTION
Clears community name and ID when closing report. This prevents the community name and ID being kept when choosing a different lat / lon after closing report.

Testing:
- On main, choose a community, hit back button, click on map. Note the community name is kept from the last selection.
- On this branch, choose a community, hit back button, click on map. Note the lat / lon chosen is shown, not the last community name.