### PR TITLE
Adds maximum bounds to map.

### DIFF
--- a/store/map.js
+++ b/store/map.js
@@ -35,6 +35,11 @@ function getBaseMapAndLayers() {
 		}
 	);
 
+	// // Set maximum bounds of main map
+	let southWest = L.latLng("50", "-175");
+	let northEast = L.latLng("65", "-98");
+	let bounds = L.latLngBounds(southWest, northEast);
+
 	// Map base configuration
 	var config = {
 		zoom: 1,
@@ -48,6 +53,7 @@ function getBaseMapAndLayers() {
 		doubleClickZoom: false,
 		attributionControl: false,
 		layers: [baseLayer],
+		maxBounds: bounds
 	};
 
 	return config;


### PR DESCRIPTION
This PR adds the maximum bounds to the map for each plate.

You can still see the distorted map if you really pull down and try to do so, but it will snap back to the top latitude immediately upon mouse release. I'm not sure if there really is a better way to do this.

Fixes #51 