### PR TITLE
Adds the ability to rehydrate with the JSON routing rules on the S3 bucket

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -184,5 +184,11 @@
 export default {
   name: 'HomePage',
   layout: 'home',
+  created() {
+    const path = (/#!(\/.*)$/.exec(this.$route.fullPath) || [])[1]
+    if (path) {
+      this.$router.push({ path: path })
+    }
+  },
 }
 </script>


### PR DESCRIPTION
This PR adds the small amount of code required for the S3 bucket to rehydrate the app based on the URL. Without this code, going to a routed URL showing a report would instead result in the home page being shown.

This PR requires the following JSON to be added to the S3 bucket redirect rules:

[
    {
        "Condition": {
            "HttpErrorCodeReturnedEquals": "404"
        },
        "Redirect": {
            "HostName": "dev.arcticeds.org",
            "Protocol": "http",
            "ReplaceKeyPrefixWith": "#!/"
        }
    },
    {
        "Condition": {
            "HttpErrorCodeReturnedEquals": "403"
        },
        "Redirect": {
            "HostName": "dev.arcticeds.org",
            "Protocol": "http",
            "ReplaceKeyPrefixWith": "#!/"
        }
    }
]