### PR TITLE
Minimap bug fix

### DIFF
--- a/components/MiniMap.vue
+++ b/components/MiniMap.vue
@@ -24,6 +24,7 @@ export default {
   computed: {
     ...mapGetters({
       latLng: 'report/latLng',
+      isPlaceDefined: 'report/isPlaceDefined',
     }),
   },
   data() {
@@ -33,7 +34,7 @@ export default {
     }
   },
   mounted() {
-    if (this.latLng.lat && this.latLng.lng) {
+    if (this.isPlaceDefined) {
       this.map = L.map('report--minimmap--map', this.getBaseMapAndLayers())
 
       this.marker = L.marker(this.latLng).addTo(this.map)


### PR DESCRIPTION
This PR modifies the MiniMap component to use isPlaceDefined from the report store to prevent attempting to use latLng.lat or latLng.lng before being defined.

Without this change, both the Geology and Physiographic Provinces were failing to load due to an attempt to use latitude and longitude before it was available.