### PR TITLE
Remixes home page to remove un-implemented sections

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -28,15 +28,13 @@
           <a class="navbar-link"> Categories </a>
 
           <div class="navbar-dropdown">
-            <NuxtLink class="navbar-item" to="/physiography"
-              >Physiography</NuxtLink
-            >
-            <NuxtLink class="navbar-item" to="/water">Water</NuxtLink>
-            <NuxtLink class="navbar-item" to="/light">Light</NuxtLink>
             <NuxtLink class="navbar-item" to="/climate">Climate</NuxtLink>
             <NuxtLink class="navbar-item" to="/engineering"
               >Engineering</NuxtLink
             >
+            <NuxtLink class="navbar-item" to="/physiography"
+              >Physiography</NuxtLink
+            ><p></p>
           </div>
         </div>
       </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,27 +26,6 @@
         <div class="columns">
           <div class="column is-one-third">
             <div class="toc--panel">
-              <NuxtLink to="/physiography">
-                <h3>Physiography</h3>
-                <div class="toc--panel--image image--physiography"></div>
-              </NuxtLink>
-              <ul>
-                <li>
-                  <NuxtLink to="/physiography/geology">Geology</NuxtLink>
-                </li>
-                <li>
-                  <NuxtLink to="/physiography/permafrost">Permafrost</NuxtLink>
-                </li>
-                <li>
-                  <NuxtLink to="/physiography/physiography"
-                    >Physiographic Provinces</NuxtLink
-                  >
-                </li>
-              </ul>
-            </div>
-          </div>
-          <div class="column is-one-third">
-            <div class="toc--panel">
               <NuxtLink to="/climate">
                 <h3>Climate</h3>
                 <div class="toc--panel--image image--climate"></div>
@@ -94,6 +73,27 @@
                 <li>
                   <NuxtLink to="/engineering/thawing-index"
                     >Thawing Index</NuxtLink
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="column is-one-third">
+            <div class="toc--panel">
+              <NuxtLink to="/physiography">
+                <h3>Physiography</h3>
+                <div class="toc--panel--image image--physiography"></div>
+              </NuxtLink>
+              <ul>
+                <li>
+                  <NuxtLink to="/physiography/geology">Geology</NuxtLink>
+                </li>
+                <li>
+                  <NuxtLink to="/physiography/permafrost">Permafrost</NuxtLink>
+                </li>
+                <li>
+                  <NuxtLink to="/physiography/physiography"
+                    >Physiographic Provinces</NuxtLink
                   >
                 </li>
               </ul>


### PR DESCRIPTION
Closes #80 
Closes #26 

Revises home page layout.  Test by ...looking at it, compare it to Carolyn's mockup here (there are some minor layout / spacing differences):
![Screen Shot 2022-06-15 at 1 59 26 PM](https://user-images.githubusercontent.com/525049/174215488-060e2c59-88d2-468c-9988-10f459185f29.png)

Known issues:
 * The "Read more" link button goes to `/about` which isn't implemented yet (soon).
 * Narrow screen widths and mobile are kind of horrible for too many reasons to list.  (#97)
 * Words aren't identical between the mockup (the section on the left) and what I implemented, we can get more revision from folks next week if needed but this felt like a fair compromise.