### PR TITLE
Use imperial units for all map legends and improve legend consistency

### DIFF
--- a/components/plates/design_freezing_index/Legend.vue
+++ b/components/plates/design_freezing_index/Legend.vue
@@ -13,49 +13,49 @@
               <td>
                 <div class="colorbox dd0"></div>
               </td>
-              <td>0 &ndash; 1000</td>
+              <td>0</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd1000"></div>
               </td>
-              <td>1000 &ndash; 2000</td>
+              <td>1000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd2000"></div>
               </td>
-              <td>2000 &ndash; 3000</td>
+              <td>2000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd3000"></div>
               </td>
-              <td>3000 &ndash; 4000</td>
+              <td>3000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd4000"></div>
               </td>
-              <td>4000 &ndash; 5000</td>
+              <td>4000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd5000"></div>
               </td>
-              <td>5000 &ndash; 6000</td>
+              <td>5000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd6000"></div>
               </td>
-              <td>6000 &ndash; 7000</td>
+              <td>6000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd7000"></div>
               </td>
-              <td>&gt; 7000</td>
+              <td>&ge; 7000</td>
             </tr>
           </tbody>
         </table>

--- a/components/plates/design_thawing_index/Legend.vue
+++ b/components/plates/design_thawing_index/Legend.vue
@@ -13,49 +13,49 @@
               <td>
                 <div class="colorbox dd0"></div>
               </td>
-              <td>0 &ndash; 1000</td>
+              <td>0</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd1000"></div>
               </td>
-              <td>1000 &ndash; 2000</td>
+              <td>1000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd2000"></div>
               </td>
-              <td>2000 &ndash; 3000</td>
+              <td>2000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd3000"></div>
               </td>
-              <td>3000 &ndash; 4000</td>
+              <td>3000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd4000"></div>
               </td>
-              <td>4000 &ndash; 5000</td>
+              <td>4000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd5000"></div>
               </td>
-              <td>5000 &ndash; 6000</td>
+              <td>5000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd6000"></div>
               </td>
-              <td>6000 &ndash; 7000</td>
+              <td>6000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd7000"></div>
               </td>
-              <td>&gt; 7000</td>
+              <td>&ge; 7000</td>
             </tr>
           </tbody>
         </table>

--- a/components/plates/freezing_index/Legend.vue
+++ b/components/plates/freezing_index/Legend.vue
@@ -13,49 +13,49 @@
               <td>
                 <div class="colorbox dd0"></div>
               </td>
-              <td>0 &ndash; 1000</td>
+              <td>0</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd1000"></div>
               </td>
-              <td>1000 &ndash; 2000</td>
+              <td>1000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd2000"></div>
               </td>
-              <td>2000 &ndash; 3000</td>
+              <td>2000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd3000"></div>
               </td>
-              <td>3000 &ndash; 4000</td>
+              <td>3000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd4000"></div>
               </td>
-              <td>4000 &ndash; 5000</td>
+              <td>4000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd5000"></div>
               </td>
-              <td>5000 &ndash; 6000</td>
+              <td>5000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd6000"></div>
               </td>
-              <td>6000 &ndash; 7000</td>
+              <td>6000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd7000"></div>
               </td>
-              <td>&gt; 7000</td>
+              <td>&ge; 7000</td>
             </tr>
           </tbody>
         </table>

--- a/components/plates/heating_degree_days/Legend.vue
+++ b/components/plates/heating_degree_days/Legend.vue
@@ -16,49 +16,49 @@
               <td>
                 <div class="colorbox dd0"></div>
               </td>
-              <td>0 &ndash; 3000</td>
+              <td>0</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd3000"></div>
               </td>
-              <td>3000 &ndash; 6000</td>
+              <td>3000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd6000"></div>
               </td>
-              <td>6000 &ndash; 9000</td>
+              <td>6000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd9000"></div>
               </td>
-              <td>9000 &ndash; 12000</td>
+              <td>9000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd12000"></div>
               </td>
-              <td>12000 &ndash; 15000</td>
+              <td>12000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd15000"></div>
               </td>
-              <td>15000 &ndash; 18000</td>
+              <td>15000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd18000"></div>
               </td>
-              <td>18000 &ndash; 21000</td>
+              <td>18000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd21000"></div>
               </td>
-              <td>&gt; 21000</td>
+              <td>&ge; 21000</td>
             </tr>
           </tbody>
         </table>

--- a/components/plates/permafrost/Legend.vue
+++ b/components/plates/permafrost/Legend.vue
@@ -128,51 +128,51 @@
           <tbody>
             <tr>
               <td>
-                <div class="colorbox tas-20"></div>
-              </td>
-              <td>&minus;20&deg;C</td>
-            </tr>
-            <tr>
-              <td>
-                <div class="colorbox tas-6"></div>
-              </td>
-              <td>&minus;6&deg;C</td>
-            </tr>
-            <tr>
-              <td>
                 <div class="colorbox tas-4"></div>
               </td>
-              <td>&minus;4&deg;C</td>
+              <td>&le; &minus;4&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas-2"></div>
+                <div class="colorbox tas20"></div>
               </td>
-              <td>&minus;2&deg;C</td>
+              <td>20&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas-1"></div>
+                <div class="colorbox tas24"></div>
               </td>
-              <td>&minus;1&deg;C</td>
+              <td>24&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas0"></div>
+                <div class="colorbox tas28"></div>
               </td>
-              <td>0&deg;C</td>
+              <td>28&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas1"></div>
+                <div class="colorbox tas30"></div>
               </td>
-              <td>1&deg;C</td>
+              <td>30&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas2"></div>
+                <div class="colorbox tas32"></div>
               </td>
-              <td>2&deg;C</td>
+              <td>32&deg;F</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox tas34"></div>
+              </td>
+              <td>34&deg;F</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox tas36"></div>
+              </td>
+              <td>&ge; 36&deg;F</td>
             </tr>
           </tbody>
         </table>
@@ -204,51 +204,51 @@
           <tbody>
             <tr>
               <td>
-                <div class="colorbox tas-20"></div>
-              </td>
-              <td>&minus;20&deg;C</td>
-            </tr>
-            <tr>
-              <td>
-                <div class="colorbox tas-6"></div>
-              </td>
-              <td>&minus;6&deg;C</td>
-            </tr>
-            <tr>
-              <td>
                 <div class="colorbox tas-4"></div>
               </td>
-              <td>&minus;4&deg;C</td>
+              <td>&le; &minus;4&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas-2"></div>
+                <div class="colorbox tas20"></div>
               </td>
-              <td>&minus;2&deg;C</td>
+              <td>20&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas-1"></div>
+                <div class="colorbox tas24"></div>
               </td>
-              <td>&minus;1&deg;C</td>
+              <td>24&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas0"></div>
+                <div class="colorbox tas28"></div>
               </td>
-              <td>0&deg;C</td>
+              <td>28&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas1"></div>
+                <div class="colorbox tas30"></div>
               </td>
-              <td>1&deg;C</td>
+              <td>30&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas2"></div>
+                <div class="colorbox tas32"></div>
               </td>
-              <td>2&deg;C</td>
+              <td>32&deg;F</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox tas34"></div>
+              </td>
+              <td>34&deg;F</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox tas36"></div>
+              </td>
+              <td>&ge; 36&deg;F</td>
             </tr>
           </tbody>
         </table>
@@ -289,37 +289,37 @@
               <td>
                 <div class="colorbox d0"></div>
               </td>
-              <td>0m</td>
+              <td>0in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d05"></div>
+                <div class="colorbox d20"></div>
               </td>
-              <td>0.5m</td>
+              <td>20in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d1"></div>
+                <div class="colorbox d40"></div>
               </td>
-              <td>1m</td>
+              <td>40in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d15"></div>
+                <div class="colorbox d60"></div>
               </td>
-              <td>1.5m</td>
+              <td>60in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d2"></div>
+                <div class="colorbox d80"></div>
               </td>
-              <td>2m</td>
+              <td>80in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d25"></div>
+                <div class="colorbox d100"></div>
               </td>
-              <td>2.5m</td>
+              <td>&ge; 100in</td>
             </tr>
           </tbody>
         </table>
@@ -361,37 +361,37 @@
               <td>
                 <div class="colorbox d0"></div>
               </td>
-              <td>0m</td>
+              <td>0in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d05"></div>
+                <div class="colorbox d20"></div>
               </td>
-              <td>0.5m</td>
+              <td>20in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d1"></div>
+                <div class="colorbox d40"></div>
               </td>
-              <td>1m</td>
+              <td>40in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d15"></div>
+                <div class="colorbox d60"></div>
               </td>
-              <td>1.5m</td>
+              <td>60in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d2"></div>
+                <div class="colorbox d80"></div>
               </td>
-              <td>2m</td>
+              <td>80in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox d25"></div>
+                <div class="colorbox d100"></div>
               </td>
-              <td>2.5m</td>
+              <td>&ge; 100in</td>
             </tr>
           </tbody>
         </table>
@@ -420,39 +420,39 @@
           <tbody>
             <tr>
               <td>
-                <div class="colorbox tas-10"></div>
+                <div class="colorbox tas14"></div>
               </td>
-              <td>&minus;10&deg;C</td>
+              <td>&le; 14&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas-5"></div>
+                <div class="colorbox tas23"></div>
               </td>
-              <td>&minus;5&deg;C</td>
+              <td>23&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas-1"></div>
+                <div class="colorbox tas30"></div>
               </td>
-              <td>&minus;1&deg;C</td>
+              <td>30&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas1"></div>
+                <div class="colorbox tas34"></div>
               </td>
-              <td>1&deg;C</td>
+              <td>34&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas3"></div>
+                <div class="colorbox tas37"></div>
               </td>
-              <td>3&deg;C</td>
+              <td>37&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas5"></div>
+                <div class="colorbox tas41"></div>
               </td>
-              <td>5&deg;C</td>
+              <td>&ge; 41&deg;F</td>
             </tr>
           </tbody>
         </table>
@@ -554,28 +554,29 @@ table.table td {
   }
 }
 .temps .colorbox {
-  &.tas-20 {
+  &.tas-4 {
     background-color: rgb(33, 102, 172);
   }
-  &.tas-6 {
+  &.tas20 {
     background-color: rgb(67, 147, 195);
   }
-  &.tas-4 {
+  &.tas24 {
     background-color: rgb(146, 197, 222);
   }
-  &.tas-2 {
+  &.tas28 {
     background-color: rgb(209, 229, 240);
   }
-  &.tas-1 {
+  &.tas30 {
     background-color: rgb(247, 247, 247);
+    border: 1px solid #ddd;
   }
-  &.tas0 {
+  &.tas32 {
     background-color: rgb(253, 219, 199);
   }
-  &.tas1 {
+  &.tas34 {
     background-color: rgb(244, 165, 130);
   }
-  &.tas2 {
+  &.tas36 {
     background-color: rgb(214, 96, 77);
   }
 }
@@ -587,39 +588,39 @@ table.table td {
   &.d0 {
     background-color: #fdfecc;
   }
-  &.d05 {
+  &.d20 {
     background-color: #92d8a4;
   }
-  &.d1 {
+  &.d40 {
     background-color: #52a9a3;
   }
-  &.d15 {
+  &.d60 {
     background-color: #417799;
   }
-  &.d2 {
+  &.d80 {
     background-color: #424380;
   }
-  &.d25 {
+  &.d100 {
     background-color: #2b1d32;
   }
 }
 .obutemps .colorbox {
-  &.tas-10 {
+  &.tas14 {
     background-color: #08306b;
   }
-  &.tas-5 {
+  &.tas23 {
     background-color: #3787c0;
   }
-  &.tas-1 {
+  &.tas30 {
     background-color: #94c4df;
   }
-  &.tas1 {
+  &.tas34 {
     background-color: #f14432;
   }
-  &.tas3 {
+  &.tas37 {
     background-color: #bc141a;
   }
-  &.tas5 {
+  &.tas41 {
     background-color: #67000d;
   }
 }

--- a/components/plates/permafrost/layers.js
+++ b/components/plates/permafrost/layers.js
@@ -67,6 +67,7 @@ export default [
     title:
       'Mean annual ground temperature at top of permafrost, 2000&ndash;2016 (modeled)',
     wmsLayerName: 'obu_2018_magt',
+    style: 'ground_temperature_blue_to_red_arctic_eds',
   },
   {
     id: 'icevol_jorgenson',

--- a/components/plates/precipitation/Legend.vue
+++ b/components/plates/precipitation/Legend.vue
@@ -14,49 +14,43 @@
               <td>
                 <div class="colorbox pr0"></div>
               </td>
-              <td>0mm &ndash; 1mm</td>
-            </tr>
-            <tr>
-              <td>
-                <div class="colorbox pr1"></div>
-              </td>
-              <td>1mm &ndash; 10mm</td>
+              <td>0in</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox pr10"></div>
               </td>
-              <td>10mm &ndash; 25mm</td>
+              <td>10in</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox pr25"></div>
+                <div class="colorbox pr20"></div>
               </td>
-              <td>25mm &ndash; 50mm</td>
+              <td>20in</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox pr50"></div>
               </td>
-              <td>50mm &ndash; 100mm</td>
+              <td>50in</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox pr100"></div>
               </td>
-              <td>100mm &ndash; 200mm</td>
+              <td>100in</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox pr200"></div>
               </td>
-              <td>200mm &ndash; 400mm</td>
+              <td>200in</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox pr400"></div>
               </td>
-              <td>&gt; 400mm</td>
+              <td>&ge; 400in</td>
             </tr>
           </tbody>
         </table>
@@ -98,30 +92,23 @@ table.table td {
 }
 .precipitation .colorbox {
   &.pr0 {
-    /* Color map has half opacity at 0 */
-    background-color: #8c510a80;
-  }
-  &.pr1 {
     background-color: #8c510a;
   }
-  &.pr5 {
+  &.pr10 {
     background-color: #d8b365;
   }
-  &.pr10 {
+  &.pr20 {
     background-color: #f6e8c3;
   }
-  &.pr25 {
+  &.pr50 {
     background-color: #f5f5f5;
     border: 1px solid #ddd;
   }
-  &.pr50 {
+  &.pr100 {
     background-color: #c7eae5;
   }
-  &.pr100 {
-    background-color: #5ab4ac;
-  }
   &.pr200 {
-    background-color: #01665e;
+    background-color: #5ab4ac;
   }
   &.pr400 {
     background-color: #01665e;

--- a/components/plates/snowfall/Legend.vue
+++ b/components/plates/snowfall/Legend.vue
@@ -12,31 +12,43 @@
               <td>
                 <div class="colorbox in0"></div>
               </td>
-              <td>0in &ndash; 5in</td>
+              <td>0in</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox in2"></div>
+              </td>
+              <td>2.5in</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox in5"></div>
               </td>
-              <td>5in &ndash; 50in</td>
+              <td>5in</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox in10"></div>
+              </td>
+              <td>10in</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox in20"></div>
+              </td>
+              <td>20in</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox in50"></div>
               </td>
-              <td>50in &ndash; 100in</td>
+              <td>50in</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox in100"></div>
               </td>
-              <td>100in &ndash; 150in</td>
-            </tr>
-            <tr>
-              <td>
-                <div class="colorbox in150"></div>
-              </td>
-              <td>&gt; 150in</td>
+              <td>&ge; 100in</td>
             </tr>
           </tbody>
         </table>
@@ -78,22 +90,26 @@ table.table td {
 }
 .snowfall .colorbox {
   &.in0 {
-    /* Color map has 0 opacity. This is here as a placeholder for now */
-    background-color: #edf8fb00;
-    border: 1px solid #ddd;
-  }
-  &.in5 {
     background-color: #edf8fb;
     border: 1px solid #ddd;
   }
-  &.in50 {
-    background-color: #b3cde3;
+  &.in2 {
+    background-color: #bfd3e6;
   }
-  &.in100 {
+  &.in5 {
+    background-color: #9ebcda;
+  }
+  &.in10 {
     background-color: #8c96c6;
   }
-  &.in150 {
-    background-color: #88419d;
+  &.in20 {
+    background-color: #8c6bb1;
+  }
+  &.in50 {
+    background-color: #8841a7;
+  }
+  &.in100 {
+    background-color: #6e016b;
   }
 }
 </style>

--- a/components/plates/temperature/Legend.vue
+++ b/components/plates/temperature/Legend.vue
@@ -40,51 +40,45 @@
           <tbody>
             <tr>
               <td>
-                <div class="colorbox tas-30"></div>
+                <div class="colorbox tas-22"></div>
               </td>
-              <td>&lt; &minus;30&deg;C</td>
-            </tr>
-            <tr>
-              <td>
-                <div class="colorbox tas-15"></div>
-              </td>
-              <td>&minus;30&deg;C &ndash; &minus;15&deg;C</td>
-            </tr>
-            <tr>
-              <td>
-                <div class="colorbox tas-5"></div>
-              </td>
-              <td>&minus;15&deg;C &ndash; &minus;5&deg;C</td>
-            </tr>
-            <tr>
-              <td>
-                <div class="colorbox tas0"></div>
-              </td>
-              <td>&minus;5&deg;C &ndash; 0&deg;C</td>
+              <td>&le; &minus;22&deg;F</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox tas5"></div>
               </td>
-              <td>0&deg;C &ndash; 5&deg;C</td>
+              <td>5&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas15"></div>
+                <div class="colorbox tas23"></div>
               </td>
-              <td>5&deg;C &ndash; 15&deg;C</td>
+              <td>23&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas30"></div>
+                <div class="colorbox tas32"></div>
               </td>
-              <td>15&deg;C &ndash; 30&deg;C</td>
+              <td>32&deg;F</td>
             </tr>
             <tr>
               <td>
-                <div class="colorbox tas30"></div>
+                <div class="colorbox tas41"></div>
               </td>
-              <td>&gt; 30&deg;C</td>
+              <td>41&deg;F</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox tas59"></div>
+              </td>
+              <td>59&deg;F</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox tas86"></div>
+              </td>
+              <td>&ge; 86&deg;F</td>
             </tr>
           </tbody>
         </table>
@@ -125,26 +119,26 @@ table.table td {
   width: 2rem;
 }
 .temperature .colorbox {
-  &.tas-30 {
+  &.tas-22 {
     background-color: #2166ac;
   }
-  &.tas-15 {
+  &.tas5 {
     background-color: #67a9cf;
   }
-  &.tas-5 {
+  &.tas23 {
     background-color: #d1e5f0;
   }
-  &.tas0 {
+  &.tas32 {
     background-color: #f7f7f7;
     border: 1px solid #ddd;
   }
-  &.tas5 {
+  &.tas41 {
     background-color: #fddbc7;
   }
-  &.tas15 {
+  &.tas59 {
     background-color: #ef8a62;
   }
-  &.tas30 {
+  &.tas86 {
     background-color: #b2182b;
   }
 }

--- a/components/plates/thawing_index/Legend.vue
+++ b/components/plates/thawing_index/Legend.vue
@@ -13,49 +13,49 @@
               <td>
                 <div class="colorbox dd0"></div>
               </td>
-              <td>0 &ndash; 1000</td>
+              <td>0</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd1000"></div>
               </td>
-              <td>1000 &ndash; 2000</td>
+              <td>1000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd2000"></div>
               </td>
-              <td>2000 &ndash; 3000</td>
+              <td>2000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd3000"></div>
               </td>
-              <td>3000 &ndash; 4000</td>
+              <td>3000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd4000"></div>
               </td>
-              <td>4000 &ndash; 5000</td>
+              <td>4000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd5000"></div>
               </td>
-              <td>5000 &ndash; 6000</td>
+              <td>5000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd6000"></div>
               </td>
-              <td>6000 &ndash; 7000</td>
+              <td>6000</td>
             </tr>
             <tr>
               <td>
                 <div class="colorbox dd7000"></div>
               </td>
-              <td>&gt; 7000</td>
+              <td>&ge; 7000</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Closes #70.

In this PR:

- Map legends that had been in metric units have been updated to imperial units.
- Color map breakpoints have been nudged to whole numbers for imperial units, and styles on Rasdaman and GeoServer have been updated accordingly. For example, instead of simply converting 2°C to 35.6°F and having this arbitrary decimal value in the legend, I rounded up to 36°F and changed the corresponding color map breakpoint to 2.2°C on Rasdaman to make the legend cleaner looking.
- I've removed value ranges (e.g., 1mm – 10mm) to make them consistent with the legends that didn't have them, but also I realized these value ranges are not actually correct. Since our color maps are continuous gradients, it's not accurate to claim that the entire range from 1mm – 10mm is the same color, for example.
- I've added `≤` and `≥` symbols to the legends where appropriate. Legends that cannot have negative numbers (precipitation, degree days, snowfall) get a `≥` whereas legends that can have negative numbers (temperature) get both a `≤` and `≥`.
- In some cases the legend in the web app no longer corresponded exactly to the color map on Rasdaman, so I've synced them back up again before performing the metric/imperial conversion work.

To test, check out the legends on the following plates and layers to make sure they are in imperial units:

- Permafrost
  - Mean annual ground temperature at active layer, 1986–2005, GIPL model
  - Mean annual ground temperature at active layer, 2036–2065 (NCAR–CCSM4, RCP 8.5), GIPL model
  - Active layer thickness, 1986–2005, GIPL model
  - Active layer thickness, 2036–2065 (NCAR–CCSM4, RCP 8.5), GIPL model
  - Mean annual ground temperature at top of permafrost, 2000–2016 (modeled)
- Precipitation
- Temperature