### PR TITLE
Show eras instead of individual years for Thawing Index and Heating Degree Days map layers

### DIFF
--- a/components/plates/heating_degree_days/layers.js
+++ b/components/plates/heating_degree_days/layers.js
@@ -1,25 +1,17 @@
 export default [
   {
-    id: 'historical_heating_degree_days',
-    title: 'Historical (1979)',
+    id: 'ncarccsm4_heating_degree_days_index_condensed_historical',
+    title: 'Modeled Historical (1980&ndash;2009, ERA Interim)',
     source: 'rasdaman',
     wmsLayerName: 'heating_degree_days',
-    rasdamanConfiguration: {
-      dim_model: 0,
-      time: '1979-01-01T00:00:00.000Z',
-    },
-    style: 'arctic_eds',
+    style: 'arctic_eds_heating_degree_days_historical_condensed',
     default: true,
   },
   {
-    id: 'ncarccsm4_heating_degree_days',
-    title: 'Projected (2100, NCAR CCSM4, RCP 8.5)',
+    id: 'ncarccsm4_heating_degree_days_midcentury',
+    title: 'Projected Mid&ndash;Century (2040&ndash;2069, NCAR CCSM4, RCP 8.5)',
     source: 'rasdaman',
     wmsLayerName: 'heating_degree_days',
-    rasdamanConfiguration: {
-      dim_model: 2,
-      time: '2100-01-01T00:00:00.000Z',
-    },
-    style: 'arctic_eds',
+    style: 'arctic_eds_heating_degree_days_future_condensed',
   },
 ]

--- a/components/plates/thawing_index/layers.js
+++ b/components/plates/thawing_index/layers.js
@@ -1,25 +1,17 @@
 export default [
   {
-    id: 'historical_thawing_index',
-    title: 'Historical (1979)',
+    id: 'ncarccsm4_thawing_index_condensed_historical',
+    title: 'Modeled Historical (1980&ndash;2009, ERA Interim)',
     source: 'rasdaman',
     wmsLayerName: 'thawing_index',
-    rasdamanConfiguration: {
-      dim_model: 0,
-      time: '1979-01-01T00:00:00.000Z',
-    },
-    style: 'arctic_eds',
+    style: 'arctic_eds_thawing_index_historical_condensed',
     default: true,
   },
   {
-    id: 'ncarccsm4_thawing_index',
-    title: 'Projected (2100, NCAR CCSM4, RCP 8.5)',
+    id: 'ncarccsm4_thawing_index_midcentury',
+    title: 'Projected Mid&ndash;Century (2040&ndash;2069, NCAR CCSM4, RCP 8.5)',
     source: 'rasdaman',
     wmsLayerName: 'thawing_index',
-    rasdamanConfiguration: {
-      dim_model: 2,
-      time: '2100-01-01T00:00:00.000Z',
-    },
-    style: 'arctic_eds',
+    style: 'arctic_eds_thawing_index_future_condensed',
   },
 ]


### PR DESCRIPTION
Closes #77.

This PR changes the Thawing Index and Heating Degree Days historical & projected map layers to show averages over eras (performed via WCPS queries through Rasdaman) instead of individual years. This work had already been done for the Freezing Index map layers, so this PR basically just does the same thing for Thawing Index and Heating Degree Days.

I had originally thought that the Design Freezing Index and Design Thawing Index would need fixed, too, but they are already using pre-baked era calculations.

Testing this is tricky, but what I did while working on this was to load a couple of the new WCPS + color map styles in Rasdaman and temporarily change the denominator to something ridiculous (e.g., `100` instead of `30`) and double check that the map layer in the web app looks similarly ridiculous (very pale) to confirm that the web app was loading the correct style and performing the math operation.