### PR TITLE
replace 'Physiographic Provinces' with 'Ecoregions'

### DIFF
--- a/components/Breadcrumbs.vue
+++ b/components/Breadcrumbs.vue
@@ -52,7 +52,7 @@ export default {
         plate = plate.replace(/-/g, ' ')
         switch (plate) {
           case 'physiography':
-            return 'Physiographic Provinces'
+            return 'Ecoregions'
           case 'beta':
             return false
           case 'climate modeling':

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -93,7 +93,7 @@
                 </li>
                 <li>
                   <NuxtLink to="/physiography/physiography"
-                    >Physiographic Provinces</NuxtLink
+                    >Ecoregions</NuxtLink
                   >
                 </li>
               </ul>

--- a/pages/physiography/index.vue
+++ b/pages/physiography/index.vue
@@ -15,7 +15,7 @@
               </li>
               <li>
                 <NuxtLink to="/physiography/physiography"
-                  >Physiographic Provinces</NuxtLink
+                  >Ecoregions</NuxtLink
                 >
               </li>
             </ul>

--- a/pages/physiography/physiography.vue
+++ b/pages/physiography/physiography.vue
@@ -2,20 +2,18 @@
   <div>
     <div class="container">
       <section class="section">
-        <h1 class="title is-2">Physiographic Provinces</h1>
+        <h1 class="title is-2">Ecoregions</h1>
         <div class="content content-clamp is-size-4">
           <p>
-            Ecoregions are essentially equivalent to the more archaic
-            "physiographic provinces." Ecoregions do combine landscape and
+            Ecoregions combine landscape, topographic, and
             vegetation variables, but have less detail about vegetation when
-            compared to "land cover" or "forest type" datasets. Topography plays
-            a prominent role.
+            compared to "land cover" or "forest type" datasets.
           </p>
         </div>
         <div class="content content-clamp is-size-5">
           <p>
             Click any point on the map, or enter a lat/lon, to get the
-            geological unit for that point.
+            ecoregion for that point.
           </p>
         </div>
       </section>


### PR DESCRIPTION
This PR replaces all instances of "Physiographic Provinces" with "Ecoregions" to better reflect the actual data present in that plate and is a useful modernization of the previous Environmental Atlas. The former term is largely outdated at this point and is also just hard to say and type.

This PR **does not** change any of the routing - so the Ecoregions plate is still at http://localhost:3000/physiography/physiography

if desired, changing the above can be done in another PR / Issue. This might be a good idea to create some more distinction between the "Physiography" set of plates (includes Geology, Forest Type, etc.) and the tail-level individual plates.

To test this PR,

 - Verify the plate name on the home page reads "Ecoregions" and not "Physiographic Provinces"
 - Click the "Ecoregions" link and verify all text references are "Ecoregions" and not "Physiographic Provinces"
 - Go to the [category page for Physiography](http://localhost:3000/physiography) and verify the link to the plate reads "Ecoregions" and not "Physiographic Provinces"

Closes #113 