### PR TITLE
Adds navbar link to Climate Modeling, fixes breadcrumbs

### DIFF
--- a/components/Breadcrumbs.vue
+++ b/components/Breadcrumbs.vue
@@ -42,10 +42,10 @@ import _ from 'lodash'
 export default {
   name: 'Breadcrumbs',
   computed: {
-    category: function () {
-      return this.$route.path.split('/')[1]
+    category: function() {
+      return this.$route.path.split('/')[1].replace(/-/, ' ')
     },
-    plate: function () {
+    plate: function() {
       // Handle custom names independent of route
       if (this.$route.path.split('/').length > 2) {
         let plate = _.slice(this.$route.path.split('/'), 2)[0]
@@ -54,8 +54,6 @@ export default {
           case 'physiography':
             return 'Ecoregions'
           case 'beta':
-            return false
-          case 'climate modeling':
             return false
           default:
             if (plate) return plate

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -12,6 +12,9 @@
           <b-navbar-item tag="nuxt-link" to="/beta">
             Beta test
           </b-navbar-item>
+          <b-navbar-item tag="nuxt-link" to="/climate-modeling">
+            Climate modeling
+          </b-navbar-item>
         </b-navbar-dropdown>
         <b-navbar-dropdown label="Data">
           <b-navbar-item tag="nuxt-link" to="/climate">


### PR DESCRIPTION
Closes #122 

Test by:

 * Navigate somewhere from the home page so you see the navbar.  There should be "Climate Modeling" in the "About" menu and it should go to the Climate Modeling page.
 * On the Climate Modeling page, the Breadcrumb should be "Home > Climate Modeling"
 * Other breadcrumbs should be the same as they were / not changed or broken in any way!