### PR TITLE
Show era map layers instead of individual years for Precipitation plate

### DIFF
--- a/components/plates/precipitation/layers.js
+++ b/components/plates/precipitation/layers.js
@@ -1,27 +1,17 @@
 export default [
   {
-    id: 'historical_mean_annual_precip',
-    title: 'Historical (1901)',
+    id: 'historical_era_precip',
+    title: 'Historical (1980&ndash;2009)',
     source: 'rasdaman',
     wmsLayerName: 'annual_precip_totals_mm',
-    rasdamanConfiguration: {
-      dim_model: 0,
-      dim_scenario: 0,
-      time: '1901-01-01T00:00:00.000Z',
-    },
-    style: 'precip_mm',
+    style: 'precip_mm_historical_era',
     default: true,
   },
   {
-    id: 'future_midcentury_precip',
-    title: 'Projected (2099, MRI CGCM3, RCP 8.5)',
+    id: 'midcentury_era_precip',
+    title: 'Projected Mid&ndash;Century (2040&ndash;2069, NCAR CCSM4, RCP 8.5)',
     source: 'rasdaman',
     wmsLayerName: 'annual_precip_totals_mm',
-    rasdamanConfiguration: {
-      dim_model: 5,
-      dim_scenario: 3,
-      time: '2099-01-01T00:00:00.000Z',
-    },
-    style: 'precip_mm',
+    style: 'precip_mm_midcentury_era',
   },
 ]


### PR DESCRIPTION
Closes #125.

This PR replaces the individual year map layers on the Precipitation plate with era mean map layers, calculated via WCPS query on Rasdaman using the same year ranges as the Temperature plate.

To test, try temporarily changing the denominator of the corresponding WCPS styles on Rasdaman to make sure the client app is picking up the correct styles and doing the math properly.