### PR TITLE
Removes unavailable plate listings in category pages, alphabetizes lists

### DIFF
--- a/pages/climate/index.vue
+++ b/pages/climate/index.vue
@@ -6,11 +6,9 @@
           <img src="~/assets/images/PHYS_alaska_dem.jpg" />
           <div class="content is-size-5">
             <ul>
-              <li>Climatic Zones</li>
               <li>
                 <NuxtLink to="/climate/precipitation">Precipitation</NuxtLink>
               </li>
-              <li>Wet Days Per Year</li>
               <li>
                 <NuxtLink to="/climate/snowfall">Snowfall</NuxtLink>
               </li>
@@ -52,6 +50,6 @@
 export default {
   name: 'Ecoregions',
   layout: 'category',
-  created: function () {},
+  created: function() {},
 }
 </script>

--- a/pages/engineering/index.vue
+++ b/pages/engineering/index.vue
@@ -7,18 +7,8 @@
           <div class="content is-size-5">
             <ul>
               <li>
-                <NuxtLink to="/engineering/freezing-index"
-                  >Freezing Index</NuxtLink
-                >
-              </li>
-              <li>
                 <NuxtLink to="/engineering/design-freezing-index"
                   >Design Freezing Index</NuxtLink
-                >
-              </li>
-              <li>
-                <NuxtLink to="/engineering/thawing-index"
-                  >Thawing Index</NuxtLink
                 >
               </li>
               <li>
@@ -27,11 +17,20 @@
                 >
               </li>
               <li>
+                <NuxtLink to="/engineering/freezing-index"
+                  >Freezing Index</NuxtLink
+                >
+              </li>
+              <li>
                 <NuxtLink to="/engineering/heating-degree-days"
                   >Heating Degree Days</NuxtLink
                 >
               </li>
-              <li>Building Design Criteria</li>
+              <li>
+                <NuxtLink to="/engineering/thawing-index"
+                  >Thawing Index</NuxtLink
+                >
+              </li>
             </ul>
           </div>
         </div>
@@ -83,6 +82,6 @@
 export default {
   name: 'Engineering',
   layout: 'category',
-  created: function () {},
+  created: function() {},
 }
 </script>

--- a/pages/physiography/index.vue
+++ b/pages/physiography/index.vue
@@ -6,15 +6,12 @@
           <img src="~/assets/images/PHYS_alaska_dem.jpg" />
           <div class="content is-size-5">
             <ul>
-              <li>Earthquakes</li>
-              <li><NuxtLink to="/physiography/geology">Geology</NuxtLink></li>
-              <li>Forest Types</li>
-              <li>Glaciation</li>
-              <li>
-                <NuxtLink to="/physiography/permafrost">Permafrost</NuxtLink>
-              </li>
               <li>
                 <NuxtLink to="/physiography/ecoregions">Ecoregions</NuxtLink>
+              </li>
+              <li><NuxtLink to="/physiography/geology">Geology</NuxtLink></li>
+              <li>
+                <NuxtLink to="/physiography/permafrost">Permafrost</NuxtLink>
               </li>
             </ul>
           </div>
@@ -78,6 +75,6 @@
 export default {
   name: 'Physiography',
   layout: 'category',
-  created: function () {},
+  created: function() {},
 }
 </script>


### PR DESCRIPTION
Closes #127 

Check by visiting each category landing page, and verifying that there are no un-linked plates, and the plates are alphabetized.