### PR TITLE
Fixes the route for the Geology community ID report

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -80,7 +80,7 @@ export default {
     extendRoutes(routes, resolve) {
       // Order matters here; lat/lng needs to go last because it's "globby"
       routes.push({
-        path: '/ecoregions/geology/report/community/:communityId',
+        path: '/physiography/geology/report/community/:communityId',
         component: resolve(__dirname, 'pages/physiography/geology'),
       })
       routes.push({


### PR DESCRIPTION
This PR changes a route that accidentally got modified that was breaking the community selection for the Geology plate.

Fixes #135 