### PR TITLE
update permafrost extent styles and legends

### DIFF
--- a/components/plates/permafrost/Legend.vue
+++ b/components/plates/permafrost/Legend.vue
@@ -7,7 +7,7 @@
       <template v-slot:introduction>
         <p>
           This layer shows the extent of permafrost across Alaska, classified
-          into four categories.
+          into seven categories.
         </p>
       </template>
       <template v-slot:legend>
@@ -36,6 +36,24 @@
                 <div class="colorbox sporadic"></div>
               </td>
               <td>Sporadic (&lt; 10%)</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox unfrozen"></div>
+              </td>
+              <td>Unfrozen</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox water"></div>
+              </td>
+              <td>Water</td>
+            </tr>
+            <tr>
+              <td>
+                <div class="colorbox glacial"></div>
+              </td>
+              <td>Glacial</td>
             </tr>
           </tbody>
         </table>
@@ -540,18 +558,28 @@ table.table td {
 }
 .pfextent .colorbox {
   &.continuous {
-    background-color: #eafdfd;
+    background-color: #253494;
     border: 1px solid #98a09c;
   }
   &.discontinuous {
-    background-color: #79bed0;
+    background-color: #41b6c4;
   }
   &.sporadic {
-    background-color: #427ab7;
+    background-color: #c7e9b4;
   }
   &.isolated {
-    background-color: #383873;
+    background-color: #7fcdbb;
   }
+  &.unfrozen {
+  background-color: #ffffcc;
+  }
+  &.water {
+  background-color: #a5bfdd;
+  }
+  &.glacial {
+  background-color: #edf8fb;
+  }
+
 }
 .temps .colorbox {
   &.tas-4 {


### PR DESCRIPTION
This PR replaces the color maps used to represent permafrost extent for two layers in the permafrost plate by updating the corresponding styles on GeoServer. The legend colors are updated to match these new map styles.

To test this PR
 - Go to the permafrost plate and look at the map and legend on the Jorgenson et al. permafrost extent layer (verify that they match and that the color scheme is adequate)
 - Toggle to the Obu et al. permafrost extent layer and verify that the colors on the map and legend match and that both are in sync with the colors used in the previous Jorgenson permafrost extent layer. Note that Obu et al does not distinguish glacial, unfrozen, or water categories.

Closes #139
XREF #27 and consider moving out of beta milestone