### PR TITLE
Add CSV download button to permafrost report

### DIFF
--- a/components/plates/permafrost/Report.vue
+++ b/components/plates/permafrost/Report.vue
@@ -117,6 +117,11 @@
             </li>
           </ul>
         </div>
+        <DownloadCsvButton
+          text="Download permafrost data as CSV"
+          endpoint="permafrost/point"
+          class="mt-3 mb-5"
+        />
       </div>
     </div>
   </div>
@@ -124,6 +129,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import DownloadCsvButton from '~/components/DownloadCsvButton'
 import MiniMap from '~/components/MiniMap'
 import LoadingStatus from '~/components/LoadingStatus'
 import UnitWidget from '~/components/UnitWidget'
@@ -131,6 +137,7 @@ import UnitWidget from '~/components/UnitWidget'
 export default {
   name: 'PermafrostReport',
   components: {
+    DownloadCsvButton,
     MiniMap,
     LoadingStatus,
     UnitWidget,


### PR DESCRIPTION
Closes #112.

To test:

- Load the Permafrost plate, then click a point or choose a community.
- Observe that a CSV download button appears below the permafrost data table/info. Click it to verify that the download and file work as expected.