### PR TITLE
Removes the ncarccsm prefix on the historical data layers for the Engineering plates

### DIFF
--- a/components/plates/freezing_index/layers.js
+++ b/components/plates/freezing_index/layers.js
@@ -1,6 +1,6 @@
 export default [
   {
-    id: 'ncarccsm4_freezing_index_condensed_historical',
+    id: 'freezing_index_condensed_historical',
     title: 'Modeled Historical (1980&ndash;2009, ERA Interim)',
     source: 'rasdaman',
     wmsLayerName: 'freezing_index',

--- a/components/plates/heating_degree_days/layers.js
+++ b/components/plates/heating_degree_days/layers.js
@@ -1,6 +1,6 @@
 export default [
   {
-    id: 'ncarccsm4_heating_degree_days_index_condensed_historical',
+    id: 'heating_degree_days_index_condensed_historical',
     title: 'Modeled Historical (1980&ndash;2009, ERA Interim)',
     source: 'rasdaman',
     wmsLayerName: 'heating_degree_days',

--- a/components/plates/thawing_index/layers.js
+++ b/components/plates/thawing_index/layers.js
@@ -1,6 +1,6 @@
 export default [
   {
-    id: 'ncarccsm4_thawing_index_condensed_historical',
+    id: 'thawing_index_condensed_historical',
     title: 'Modeled Historical (1980&ndash;2009, ERA Interim)',
     source: 'rasdaman',
     wmsLayerName: 'thawing_index',


### PR DESCRIPTION
This PR removes the ncarccsm prefix from the ID of the layer.

Closes #149 