### PR TITLE
Remove Plotly library and related files and references

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -48,7 +48,6 @@ export default {
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [
-    '~/plugins/plotly.client',
     '~/plugins/leaflet.client.js',
     '~/plugins/vuex-router-sync',
     '~/plugins/gtag',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11084,11 +11084,6 @@
         "find-up": "^4.0.0"
       }
     },
-    "plotly.js-dist-min": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.12.0.tgz",
-      "integrity": "sha512-B4q1o9TiyQFOKvggpAesI2k1G5ZY6ngZMFzuCcC5nN968mhVdqJHcgxlaKxXfYDYxKBqYPC06WQZD1hCmjA2PQ=="
-    },
     "pnp-webpack-plugin": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "nuxt-buefy": "^0.4.22",
     "nuxt-leaflet": "0.0.25",
     "nuxt-vuex-router-sync": "0.0.3",
-    "plotly.js-dist-min": "^2.12.0",
     "proj4": "^2.8.0",
     "proj4leaflet": "^1.0.2",
     "raw-loader": "^4.0.2",

--- a/plugins/plotly.client.js
+++ b/plugins/plotly.client.js
@@ -1,6 +1,0 @@
-import Vue from 'vue'
-import Plotly from 'plotly.js-dist-min'
-
-export default ({ app }, inject) => {
-  inject('Plotly', Plotly)
-}


### PR DESCRIPTION
Closes #173.

This PR simply removes all Plotly files and references, including:

- the Plotly library
- the Plotly plugin file
- the Plotly reference in `nuxt.config.js`

To test, run the app like you normally would. Everything should continue to work without Plotly!