### PR TITLE
Remove malformed and unused script tags

### DIFF
--- a/components/plates/ecoregions/Controller.vue
+++ b/components/plates/ecoregions/Controller.vue
@@ -19,7 +19,6 @@
     </div>
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import Plate from '~/components/Plate'
 import EcoregionsReport from '~/components/plates/ecoregions/Report'

--- a/components/plates/geology/Controller.vue
+++ b/components/plates/geology/Controller.vue
@@ -19,7 +19,6 @@
     </div>
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import Plate from '~/components/Plate'
 import GeologyLegend from '~/components/plates/geology/Legend'

--- a/components/plates/permafrost/Controller.vue
+++ b/components/plates/permafrost/Controller.vue
@@ -19,7 +19,6 @@
     </div>
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import Plate from '~/components/Plate'
 import PermafrostReport from '~/components/plates/permafrost/Report'

--- a/pages/climate/precipitation.vue
+++ b/pages/climate/precipitation.vue
@@ -17,7 +17,6 @@
     <PrecipitationController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import PrecipitationController from '~/components/plates/precipitation/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/climate/snowfall.vue
+++ b/pages/climate/snowfall.vue
@@ -17,7 +17,6 @@
     <SnowfallController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import SnowfallController from '~/components/plates/snowfall/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/climate/temperature.vue
+++ b/pages/climate/temperature.vue
@@ -18,7 +18,6 @@
     <TemperatureController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import TemperatureController from '~/components/plates/temperature/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/engineering/design-freezing-index.vue
+++ b/pages/engineering/design-freezing-index.vue
@@ -16,7 +16,6 @@
     <DesignFreezingIndexController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import DesignFreezingIndexController from '~/components/plates/design_freezing_index/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/engineering/design-thawing-index.vue
+++ b/pages/engineering/design-thawing-index.vue
@@ -15,7 +15,6 @@
     <DesignThawingIndexController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import DesignThawingIndexController from '~/components/plates/design_thawing_index/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/engineering/freezing-index.vue
+++ b/pages/engineering/freezing-index.vue
@@ -17,7 +17,6 @@
     <FreezingIndexController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import FreezingIndexController from '~/components/plates/freezing_index/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/engineering/heating-degree-days.vue
+++ b/pages/engineering/heating-degree-days.vue
@@ -15,7 +15,6 @@
     <HeatingDegreeDaysController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import HeatingDegreeDaysController from '~/components/plates/heating_degree_days/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/engineering/thawing-index.vue
+++ b/pages/engineering/thawing-index.vue
@@ -16,7 +16,6 @@
     <ThawingIndexController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import ThawingIndexController from '~/components/plates/thawing_index/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/physiography/ecoregions.vue
+++ b/pages/physiography/ecoregions.vue
@@ -18,7 +18,6 @@
     <EcoregionsController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import EcoregionsController from '~/components/plates/ecoregions/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/physiography/geology.vue
+++ b/pages/physiography/geology.vue
@@ -20,7 +20,6 @@
     <GeologyController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import GeologyController from '~/components/plates/geology/Controller'
 import PlateInstructions from '~/components/PlateInstructions'

--- a/pages/physiography/permafrost.vue
+++ b/pages/physiography/permafrost.vue
@@ -27,7 +27,6 @@
     <PermafrostController />
   </div>
 </template>
-<script lang="scss" scoped></script>
 <script>
 import PermafrostController from '~/components/plates/permafrost/Controller'
 import PlateInstructions from '~/components/PlateInstructions'


### PR DESCRIPTION
Closes #175.

This PR simply removes every instance of the following malformed script tag where it is present:

```
<script lang="scss" scoped></script>
```

To test, just make sure everything still works like it did before.