### PR TITLE
Change this could take up to "30 seconds" to "a few minutes"

### DIFF
--- a/components/LoadingStatus.vue
+++ b/components/LoadingStatus.vue
@@ -6,7 +6,7 @@
         Loading data for
         {{ placeName }}&hellip;
       </h4>
-      <p>Hang on, this could take up to 30 seconds!</p>
+      <p>Hang on, this could take up to a few minutes!</p>
       <b-progress type="is-info"></b-progress>
     </div>
 


### PR DESCRIPTION
Closes #153.

This PR changes the "this could take up to 30 seconds" message to "this could take up to a few minutes" when you click a plate map. To test, click any plate map to see the new text.