### PR TITLE
Remove extra space between IARC and period in footer

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -26,8 +26,7 @@
             at the
             <a href="https://uaf-iarc.org"
               >International Arctic Research Center</a
-            >
-            .
+            >.
           </p>
 
           <p>


### PR DESCRIPTION
Closes #176.

To test, observe how there is no longer a space between "International Arctic Research Center" and the period after it in the footer.