### PR TITLE
Update unit widget to incorporate ºF•days

### DIFF
--- a/components/UnitWidget.vue
+++ b/components/UnitWidget.vue
@@ -48,8 +48,7 @@ export default {
           space = '&#8239;'
           break
         case 'dd':
-          symbol =
-            this.units == 'metric' ? '&deg;C&sdot;days' : '&deg;F&sdot;days'
+          symbol = '&deg;F&sdot;days'
           break
       }
       return {

--- a/components/UnitWidget.vue
+++ b/components/UnitWidget.vue
@@ -1,43 +1,9 @@
 <template>
-  <span
-    ><span class="units" v-if="unitType == 'temp'"
-      ><span v-if="units == 'imperial' && type == 'heavy'">(&deg;F)</span
-      ><span
-        v-if="units == 'imperial' && type == 'light'"
-        :class="{ light: type == 'light' }"
-        >&deg;F</span
-      ><span v-if="units == 'metric' && type == 'heavy'">(&deg;C)</span
-      ><span
-        v-if="units == 'metric' && type == 'light'"
-        :class="{ light: type == 'light' }"
-        >&deg;C</span
-      ></span
-    ><span class="units" v-if="unitType == 'mm_in'"
-      >&#8239;<span v-if="units == 'imperial' && type == 'heavy'">(in)</span
-      ><span
-        v-if="units == 'imperial' && type == 'light'"
-        :class="{ light: type == 'light' }"
-        >in</span
-      ><span v-if="units == 'metric' && type == 'heavy'">(&#x339C;)</span
-      ><span
-        v-if="units == 'metric' && type == 'light'"
-        :class="{ light: type == 'light' }"
-        >&#x339C;</span
-      ></span
-    ><span class="units" v-if="unitType == 'm_in'"
-      ><span v-if="units == 'imperial' && type == 'heavy'">(in)</span
-      ><span
-        v-if="units == 'imperial' && type == 'light'"
-        :class="{ light: type == 'light' }"
-        >in</span
-      ><span v-if="units == 'metric' && type == 'heavy'">(m)</span
-      ><span
-        v-if="units == 'metric' && type == 'light'"
-        :class="{ light: type == 'light' }"
-        >m</span
-      ></span
-    ></span
-  >
+  <span class="units">
+    <span v-html="symbol.space"></span
+    ><span v-if="type == 'heavy'" v-html="'(' + symbol.symbol + ')'"></span
+    ><span v-if="type == 'light'" class="light" v-html="symbol.symbol"></span>
+  </span>
 </template>
 <style lang="scss" scoped>
 .light {
@@ -49,9 +15,14 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'UnitWidget',
   props: {
+    // Can be...
+    // temp = ºF / ºC
+    // mm_in (millimeters/inches)
+    // m_in (meters/inches)
+    // dd (degree days, ºF•days / ºC•days)
     unitType: {
       type: String,
-      default: 'temp', // or mm_in (millimeters/inches), or m_in (meters/inches)
+      default: 'temp',
     },
     // Type can be "light" (no parentheses) or "heavy" (parens).
     type: {
@@ -60,6 +31,32 @@ export default {
     },
   },
   computed: {
+    symbol() {
+      let symbol = ''
+      let space = ''
+
+      switch (this.unitType) {
+        case 'temp':
+          symbol = this.units == 'metric' ? '&deg;F' : '&deg;C'
+          break
+        case 'mm_in':
+          symbol = this.units == 'metric' ? '&#x339C;' : 'in'
+          space = '&#8239;'
+          break
+        case 'm_in':
+          symbol = this.units == 'metric' ? 'm' : 'in'
+          space = '&#8239;'
+          break
+        case 'dd':
+          symbol =
+            this.units == 'metric' ? '&deg;F&sdot;days' : '&deg;C&sdot;days'
+          break
+      }
+      return {
+        symbol: symbol,
+        space: space,
+      }
+    },
     ...mapGetters({
       units: 'report/units',
     }),

--- a/components/UnitWidget.vue
+++ b/components/UnitWidget.vue
@@ -37,7 +37,7 @@ export default {
 
       switch (this.unitType) {
         case 'temp':
-          symbol = this.units == 'metric' ? '&deg;F' : '&deg;C'
+          symbol = this.units == 'metric' ? '&deg;C' : '&deg;F'
           break
         case 'mm_in':
           symbol = this.units == 'metric' ? '&#x339C;' : 'in'

--- a/components/UnitWidget.vue
+++ b/components/UnitWidget.vue
@@ -49,7 +49,7 @@ export default {
           break
         case 'dd':
           symbol =
-            this.units == 'metric' ? '&deg;F&sdot;days' : '&deg;C&sdot;days'
+            this.units == 'metric' ? '&deg;C&sdot;days' : '&deg;F&sdot;days'
           break
       }
       return {

--- a/components/plates/design_freezing_index/Report.vue
+++ b/components/plates/design_freezing_index/Report.vue
@@ -33,15 +33,15 @@
           <tbody>
             <tr>
               <th scope="row">Historical (1980-2009)</th>
-              <td>{{ results['historical']['di'] }}<UnitWidget /></td>
+              <td>{{ results['historical']['di'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results['2040-2069']['di'] }}<UnitWidget /></td>
+              <td>{{ results['2040-2069']['di'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results['2070-2099']['di'] }}<UnitWidget /></td>
+              <td>{{ results['2070-2099']['di'] }}<UnitWidget unitType="dd" /></td>
             </tr>
           </tbody>
         </table>

--- a/components/plates/design_thawing_index/Report.vue
+++ b/components/plates/design_thawing_index/Report.vue
@@ -32,15 +32,15 @@
           <tbody>
             <tr>
               <th scope="row">Historical (1980-2009)</th>
-              <td>{{ results['historical']['di'] }}<UnitWidget /></td>
+              <td>{{ results['historical']['di'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results['2040-2069']['di'] }}<UnitWidget /></td>
+              <td>{{ results['2040-2069']['di'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results['2070-2099']['di'] }}<UnitWidget /></td>
+              <td>{{ results['2070-2099']['di'] }}<UnitWidget unitType="dd" /></td>
             </tr>
           </tbody>
         </table>

--- a/components/plates/freezing_index/Report.vue
+++ b/components/plates/freezing_index/Report.vue
@@ -33,27 +33,27 @@
           <tbody>
             <tr>
               <th scope="row">Historical (1979-2015)</th>
-              <td>{{ results['historical']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['historical']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['historical']['ddmax'] }}<UnitWidget /></td>
+              <td>{{ results['historical']['ddmin'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['historical']['ddmean'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['historical']['ddmax'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Early Century (2010-2039)</th>
-              <td>{{ results['2010-2039']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['2010-2039']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['2010-2039']['ddmax'] }}<UnitWidget /></td>
+              <td>{{ results['2010-2039']['ddmin'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2010-2039']['ddmean'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2010-2039']['ddmax'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results['2040-2069']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['2040-2069']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['2040-2069']['ddmax'] }}<UnitWidget /></td>
+              <td>{{ results['2040-2069']['ddmin'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2040-2069']['ddmean'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2040-2069']['ddmax'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results['2070-2099']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['2070-2099']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['2070-2099']['ddmax'] }}<UnitWidget /></td>
+              <td>{{ results['2070-2099']['ddmin'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2070-2099']['ddmean'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2070-2099']['ddmax'] }}<UnitWidget unitType="dd" /></td>
             </tr>
           </tbody>
         </table>

--- a/components/plates/heating_degree_days/Report.vue
+++ b/components/plates/heating_degree_days/Report.vue
@@ -35,27 +35,27 @@
           <tbody>
             <tr>
               <th scope="row">Historical (1979-2015)</th>
-              <td>{{ results['historical']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['historical']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['historical']['ddmax'] }}<UnitWidget /></td>
+              <td>{{ results['historical']['ddmin'] }}<UnitWidget unitType="dd"/></td>
+              <td>{{ results['historical']['ddmean'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['historical']['ddmax'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Early Century (2010-2039)</th>
-              <td>{{ results['2010-2039']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['2010-2039']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['2010-2039']['ddmax'] }}<UnitWidget /></td>
+              <td>{{ results['2010-2039']['ddmin'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2010-2039']['ddmean'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2010-2039']['ddmax'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results['2040-2069']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['2040-2069']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['2040-2069']['ddmax'] }}<UnitWidget /></td>
+              <td>{{ results['2040-2069']['ddmin'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2040-2069']['ddmean'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2040-2069']['ddmax'] }}<UnitWidget unitType="dd" /></td>
             </tr>
             <tr>
               <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results['2070-2099']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['2070-2099']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['2070-2099']['ddmax'] }}<UnitWidget /></td>
+              <td>{{ results['2070-2099']['ddmin'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2070-2099']['ddmean'] }}<UnitWidget unitType="dd" /></td>
+              <td>{{ results['2070-2099']['ddmax'] }}<UnitWidget unitType="dd" /></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
A few things to spot here,

 • Incorporates the new degree day unit signifiers,
 • Refactors the `UnitWidget` component to simplify the template.

It doesn't do some things,

 - Does not remove the `heavy` type (even though that's unused, see #201) 
 - Does not add unit conversion to the degree day types.  (Stuck in F for now).

To test this, it's best to open one tab with this branch and one with the production version.  Then, check the production vs. local for temperature, precipitation, and heating degree days.  They should be identical except that this branch should correctly show `ºF•days`.  Also, use the unit conversion widget and make sure things look OK!

Degree days (ºf•days):
 - https://arcticeds.org/engineering/design-freezing-index/report/66.2726/-146.3229#report
 - http://localhost:3000/engineering/design-freezing-index/report/66.2726/-146.3229#report
 - Should see the proper degree day units locally (no conversion widget)

Temperature (c/f):
 - https://arcticeds.org/climate/temperature/report/63.4875/-150.3953#report
 - http://localhost:3000/climate/temperature/report/63.4875/-150.3953#report

Precipitation (mm/in):
 - https://arcticeds.org/climate/precipitation/report/66.1164/-148.9562#report
 - http://localhost:3000/climate/precipitation/report/66.1164/-148.9562#report

Closes #182