### PR TITLE
Add support for additional coordinate formats and enter key for lat/lon input

### DIFF
--- a/components/LatLngPicker.vue
+++ b/components/LatLngPicker.vue
@@ -61,15 +61,17 @@ export default {
   },
   methods: {
     process() {
-      this.$router.push({
-        path:
-          this.$route.path +
-          '/report/' +
-          this.latLng.lat.toFixed(4) +
-          '/' +
-          this.latLng.lng.toFixed(4),
-        hash: '#report',
-      })
+      if (this.isValid) {
+        this.$router.push({
+          path:
+            this.$route.path +
+            '/report/' +
+            this.latLng.lat.toFixed(4) +
+            '/' +
+            this.latLng.lng.toFixed(4),
+          hash: '#report',
+        })
+      }
     },
     invalidLatLng() {
       this.fieldMessage = "I can't figure out how to make that a point."

--- a/components/LatLngPicker.vue
+++ b/components/LatLngPicker.vue
@@ -1,91 +1,111 @@
 <template>
-  <div class="latlng-picker">
-    <div class="field-wrapper">
-      <b-field label="Latitude" horizontal>
-        <b-input v-model="lat" placeholder="64.8436"></b-input>
-      </b-field>
+  <div>
+    <div class="content">
+      <h4 class="title is-5">Find a place by latitude &amp; longitude</h4>
+      <p>
+        Enter a specific lat/lon combo below. Decimal degrees or DMS formats are
+        accepted, i.e. <code>65.24, -142.22</code> or
+        <code>58&deg; 18' 0" N, 134&deg; 24' 57.6" W</code>.
+      </p>
+
+      <div class="columns">
+        <div class="column is-two-thirds">
+          <b-field :type="getFieldStatus" :message="getFieldMessage">
+            <b-input
+              v-model="latlngInput"
+              placeholder="64.8436, -147.7230"
+              @keydown.native.enter="process"
+            ></b-input>
+          </b-field>
+        </div>
+        <div class="column">
+          <b-button :type="type" :disabled="!isValid" @click="process"
+            >Get point data</b-button
+          >
+        </div>
+      </div>
     </div>
-    <div class="field-wrapper">
-      <b-field label="Longtitude" horizontal>
-        <b-input v-model="lng" placeholder="-147.7230"></b-input>
-      </b-field>
-    </div>
-    <b-button v-on:click="processClick" :disabled="!isValid" :type="type"
-      >Get point data</b-button
-    >
   </div>
 </template>
-
-<style lang="scss" scoped>
-.field-wrapper {
-  display: inline-block;
-  ::v-deep input[type='text'] {
-    width: 6rem;
-  }
-  ::v-deep .field-label {
-    margin-right: 1rem;
-  }
-  &:not(:first-child) {
-    margin-left: 2rem;
-    margin-right: 2rem;
-  }
-}
-</style>
 <script>
+import parseDMS from 'parse-dms'
+
 export default {
   name: 'LatLngPicker',
   data() {
     return {
-      lat: undefined,
-      lng: undefined,
-      isValid: false,
       type: 'is-light',
       latLng: undefined,
+      latlngInput: '',
+      fieldMessage: '',
     }
   },
-  watch: {
-    lat() {
-      this.validate()
+  computed: {
+    isValid() {
+      return this.validate()
     },
-    lng() {
-      this.validate()
+    getFieldStatus() {
+      if (this.latlngInput.length < 8 || this.isValid) {
+        return '' // OK
+      } else {
+        return 'is-danger' // not OK
+      }
+    },
+    getFieldMessage() {
+      if (this.latlngInput.length < 8 || this.isValid) {
+        return ''
+      } else {
+        return this.fieldMessage
+      }
     },
   },
   methods: {
-    validate() {
-      let lat = parseFloat(this.lat)
-      let lng = parseFloat(this.lng)
-
-      if (
-        // Check for bbox; these tests will also fail
-        // if the user has entered a non-numeric string.
-        lat >= 51.229 &&
-        lat <= 71.3526 &&
-        lng >= -179.1506 &&
-        lng <= -129.9795
-      ) {
-        // Valid!
-        this.isValid = true
-        this.type = 'is-success'
-        this.latLng = { lat: lat, lng: lng }
-      } else {
-        this.isValid = false
-        this.type = 'is-light'
-        this.latLng = {}
-      }
+    process() {
+      this.$router.push({
+        path:
+          this.$route.path +
+          '/report/' +
+          this.latLng.lat.toFixed(4) +
+          '/' +
+          this.latLng.lng.toFixed(4),
+        hash: '#report',
+      })
     },
-    processClick() {
-      if (this.isValid) {
-        this.$router.push({
-          path:
-            this.$route.path +
-            '/report/' +
-            this.latLng.lat.toFixed(4) +
-            '/' +
-            this.latLng.lng.toFixed(4),
-          hash: '#report',
-        })
+    invalidLatLng() {
+      this.fieldMessage = "I can't figure out how to make that a point."
+      this.type = 'is-light'
+      this.latLng = {}
+      return false
+    },
+    validLatLng(lat, lng) {
+      this.fieldMessage = ''
+      this.type = 'is-success'
+      this.latLng = { lat: lat, lng: lng }
+      return true
+    },
+    validate() {
+      if (!this.latlngInput) {
+        return false // do nothing if it's empty
       }
+
+      try {
+        let parsedDms = parseDMS(this.latlngInput)
+        if (parsedDms && parsedDms.lat && parsedDms.lon) {
+          let lat = parsedDms.lat
+          let lon = parsedDms.lon
+          if (
+            lat >= 51.229 &&
+            lat <= 71.3526 &&
+            lon >= -179.1506 &&
+            lon <= -129.9795
+          ) {
+            return this.validLatLng(lat, lon)
+          }
+        }
+      } catch (e) {
+        return this.invalidLatLng()
+      }
+      return this.invalidLatLng()
     },
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10909,6 +10909,11 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "parse-dms": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parse-dms/-/parse-dms-0.0.5.tgz",
+      "integrity": "sha512-4mIie3rQi8ovjulOsAuVddenvZJev0E/fv7MLdwvmWITakbaoKNtbmCMff2i10I/nkV6BkW4PXe7ZwhuSHD90g=="
+    },
     "parse-git-config": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "nuxt-buefy": "^0.4.22",
     "nuxt-leaflet": "0.0.25",
     "nuxt-vuex-router-sync": "0.0.3",
+    "parse-dms": "0.0.5",
     "proj4": "^2.8.0",
     "proj4leaflet": "^1.0.2",
     "raw-loader": "^4.0.2",


### PR DESCRIPTION
Closes #8.
Closes #115.
Closes #161.
Xref #14.

This PR:

- Revamps the lat/lon input to borrow much of the functionality and styling of the Northern Climate Reports lat/lon input.
- Uses the parseDMS library to add support for more lat/lon coordinate formats.
- Adds enter key support for lat/lon input.

This PR does not resolve #14, but I think the changes to the lat/lon selector in this PR can be folded into the work for #14 when we're ready.

To test, try entering lat/lon values in a variety of coordinate formats. For example:

- 65.24, -142.22
- 58° 18' 0" N, 134° 24' 57.6" W
- 64.84° N, 147.72° W

Also verify that clicking the "Get point data" button and pressing the enter key both run the query when a valid lat/lon has been entered.