### PR TITLE
Removes the SearchControls from individual variable Controllers

### DIFF
--- a/components/plates/design_freezing_index/Controller.vue
+++ b/components/plates/design_freezing_index/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -32,7 +30,6 @@ th {
 import Plate from '~/components/Plate'
 import DesignFreezingIndexLegend from '~/components/plates/design_freezing_index/Legend'
 import DesignFreezingIndexReport from '~/components/plates/design_freezing_index/Report'
-import SearchControls from '~/components/SearchControls'
 import layers from '~/components/plates/design_freezing_index/layers'
 import { mapGetters } from 'vuex'
 
@@ -42,7 +39,6 @@ export default {
     Plate,
     DesignFreezingIndexLegend,
     DesignFreezingIndexReport,
-    SearchControls,
   },
   data() {
     return {
@@ -68,7 +64,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -79,7 +75,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/design_thawing_index/Controller.vue
+++ b/components/plates/design_thawing_index/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -32,7 +30,6 @@ th {
 import Plate from '~/components/Plate'
 import DesignThawingIndexLegend from '~/components/plates/design_thawing_index/Legend'
 import DesignThawingIndexReport from '~/components/plates/design_thawing_index/Report'
-import SearchControls from '~/components/SearchControls'
 import layers from '~/components/plates/design_thawing_index/layers'
 import { mapGetters } from 'vuex'
 
@@ -42,7 +39,6 @@ export default {
     Plate,
     DesignThawingIndexLegend,
     DesignThawingIndexReport,
-    SearchControls,
   },
   data() {
     return {
@@ -67,7 +63,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -78,7 +74,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/ecoregions/Controller.vue
+++ b/components/plates/ecoregions/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -24,13 +22,12 @@
 import Plate from '~/components/Plate'
 import EcoregionsReport from '~/components/plates/ecoregions/Report'
 import EcoregionsLegend from '~/components/plates/ecoregions/Legend'
-import SearchControls from '~/components/SearchControls'
 import layers from '~/components/plates/ecoregions/layers'
 import { mapGetters } from 'vuex'
 
 export default {
   name: 'EcoregionsController',
-  components: { Plate, EcoregionsReport, EcoregionsLegend, SearchControls },
+  components: { Plate, EcoregionsReport, EcoregionsLegend },
   data() {
     return {
       legend: EcoregionsLegend,
@@ -54,7 +51,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -65,7 +62,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/freezing_index/Controller.vue
+++ b/components/plates/freezing_index/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -32,7 +30,6 @@ th {
 import Plate from '~/components/Plate'
 import FreezingIndexLegend from '~/components/plates/freezing_index/Legend'
 import FreezingIndexReport from '~/components/plates/freezing_index/Report'
-import SearchControls from '~/components/SearchControls'
 import layers from '~/components/plates/freezing_index/layers'
 import { mapGetters } from 'vuex'
 
@@ -42,7 +39,6 @@ export default {
     Plate,
     FreezingIndexLegend,
     FreezingIndexReport,
-    SearchControls,
   },
   data() {
     return {
@@ -67,7 +63,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -78,7 +74,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/geology/Controller.vue
+++ b/components/plates/geology/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -24,13 +22,12 @@
 import Plate from '~/components/Plate'
 import GeologyLegend from '~/components/plates/geology/Legend'
 import GeologyReport from '~/components/plates/geology/Report'
-import SearchControls from '~/components/SearchControls'
 import layers from '~/components/plates/geology/layers'
 import { mapGetters } from 'vuex'
 
 export default {
   name: 'GeologyController',
-  components: { Plate, GeologyLegend, GeologyReport, SearchControls },
+  components: { Plate, GeologyLegend, GeologyReport },
   data() {
     return {
       legend: GeologyLegend,
@@ -54,7 +51,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -65,7 +62,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/heating_degree_days/Controller.vue
+++ b/components/plates/heating_degree_days/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -32,7 +30,6 @@ th {
 import Plate from '~/components/Plate'
 import HeatingDegreeDaysLegend from '~/components/plates/heating_degree_days/Legend'
 import HeatingDegreeDaysReport from '~/components/plates/heating_degree_days/Report'
-import SearchControls from '~/components/SearchControls'
 import layers from '~/components/plates/heating_degree_days/layers'
 import { mapGetters } from 'vuex'
 
@@ -42,7 +39,6 @@ export default {
     Plate,
     HeatingDegreeDaysLegend,
     HeatingDegreeDaysReport,
-    SearchControls,
   },
   data() {
     return {
@@ -67,7 +63,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -78,7 +74,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/permafrost/Controller.vue
+++ b/components/plates/permafrost/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -24,13 +22,12 @@
 import Plate from '~/components/Plate'
 import PermafrostReport from '~/components/plates/permafrost/Report'
 import PermafrostLegend from '~/components/plates/permafrost/Legend'
-import SearchControls from '~/components/SearchControls.vue'
 import layers from '~/components/plates/permafrost/layers'
 import { mapGetters } from 'vuex'
 
 export default {
   name: 'PermafrostController',
-  components: { Plate, PermafrostReport, PermafrostLegend, SearchControls },
+  components: { Plate, PermafrostReport, PermafrostLegend },
   data() {
     return {
       legend: PermafrostLegend,
@@ -54,7 +51,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -65,7 +62,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/precipitation/Controller.vue
+++ b/components/plates/precipitation/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -33,7 +31,6 @@ import Plate from '~/components/Plate'
 import PrecipitationLegend from '~/components/plates/precipitation/Legend'
 import PrecipitationReport from '~/components/plates/precipitation/Report'
 import layers from '~/components/plates/precipitation/layers'
-import SearchControls from '~/components/SearchControls'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -42,7 +39,6 @@ export default {
     Plate,
     PrecipitationLegend,
     PrecipitationReport,
-    SearchControls,
   },
   data() {
     return {
@@ -67,7 +63,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -78,7 +74,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/snowfall/Controller.vue
+++ b/components/plates/snowfall/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -33,13 +31,12 @@ th {
 import Plate from '~/components/Plate'
 import SnowfallLegend from '~/components/plates/snowfall/Legend'
 import SnowfallReport from '~/components/plates/snowfall/Report'
-import SearchControls from '~/components/SearchControls'
 import layers from '~/components/plates/snowfall/layers'
 import { mapGetters } from 'vuex'
 
 export default {
   name: 'SnowfallController',
-  components: { Plate, SnowfallLegend, SnowfallReport, SearchControls },
+  components: { Plate, SnowfallLegend, SnowfallReport },
   data() {
     return {
       legend: SnowfallLegend,
@@ -63,7 +60,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -74,7 +71,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/temperature/Controller.vue
+++ b/components/plates/temperature/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:layers>
@@ -88,13 +86,12 @@
 import Plate from '~/components/Plate'
 import TemperatureLegend from '~/components/plates/temperature/Legend'
 import TemperatureReport from '~/components/plates/temperature/Report'
-import SearchControls from '~/components/SearchControls.vue'
 import layers from '~/components/plates/temperature/layers'
 import { mapGetters } from 'vuex'
 
 export default {
   name: 'TemperatureController',
-  components: { Plate, TemperatureLegend, TemperatureReport, SearchControls },
+  components: { Plate, TemperatureLegend, TemperatureReport },
   data() {
     return {
       legend: TemperatureLegend,
@@ -118,7 +115,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -129,7 +126,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },

--- a/components/plates/thawing_index/Controller.vue
+++ b/components/plates/thawing_index/Controller.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div id="map-search" v-show="!reportIsVisible" class="container">
-      <SearchControls />
-    </div>
+    <div id="map-search" v-show="!reportIsVisible" class="container"></div>
 
     <Plate :layers="layers" v-show="!reportIsVisible">
       <template v-slot:legend>
@@ -32,13 +30,12 @@ th {
 import Plate from '~/components/Plate'
 import ThawingIndexLegend from '~/components/plates/thawing_index/Legend'
 import ThawingIndexReport from '~/components/plates/thawing_index/Report'
-import SearchControls from '~/components/SearchControls'
 import layers from '~/components/plates/thawing_index/layers'
 import { mapGetters } from 'vuex'
 
 export default {
   name: 'ThawingIndexController',
-  components: { Plate, ThawingIndexLegend, ThawingIndexReport, SearchControls },
+  components: { Plate, ThawingIndexLegend, ThawingIndexReport },
   data() {
     return {
       legend: ThawingIndexLegend,
@@ -62,7 +59,7 @@ export default {
     }
   },
   methods: {
-    handleMapClick: function (event) {
+    handleMapClick: function(event) {
       this.$router.push({
         path:
           this.$route.path +
@@ -73,7 +70,7 @@ export default {
         hash: '#report',
       })
     },
-    activateReport: function () {
+    activateReport: function() {
       this.$store.commit('report/openReport')
     },
   },


### PR DESCRIPTION
Notes:

 - Has some minor linting, and I apologize but something may be off about my local config (I'm seeing some linting I don't expect here, ugh) -- may be OK and these files were out of date though, too.
 - This does NOT remove the `PlateInstructions/UserPrompt` from the Nuxt `pages/` for each variable, that can come later when we clean up / remove those.

Visit a plate.  You shouldn't see the location / latlng selectors anywhere anymore.  No JS code should remain for those in the Controllers.