### PR TITLE
Removes minimap, loading indicator components from all reports.

### DIFF
--- a/components/plates/design_freezing_index/Report.vue
+++ b/components/plates/design_freezing_index/Report.vue
@@ -2,7 +2,6 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
 
     <div id="report">
       <div
@@ -15,8 +14,6 @@
         <h3 class="title is-3">
           Design freezing index data for {{ results.place }}
         </h3>
-
-        <MiniMap />
 
         <DesignFreezingIndexExplanation />
         <DataExplanation context="wrf" />
@@ -71,8 +68,6 @@
 <script>
 import { mapGetters } from 'vuex'
 import DownloadCsvButton from '~/components/DownloadCsvButton'
-import MiniMap from '~/components/MiniMap'
-import LoadingStatus from '~/components/LoadingStatus'
 import DesignFreezingIndexExplanation from '~/components/plates/design_freezing_index/Explanation'
 import DataExplanation from '~/components/DataExplanation'
 import UnitWidget from '~/components/UnitWidget'
@@ -81,8 +76,6 @@ export default {
   name: 'DesignFreezingIndexReport',
   components: {
     DownloadCsvButton,
-    MiniMap,
-    LoadingStatus,
     DesignFreezingIndexExplanation,
     DataExplanation,
     UnitWidget,

--- a/components/plates/design_thawing_index/Report.vue
+++ b/components/plates/design_thawing_index/Report.vue
@@ -2,20 +2,17 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
     <div id="report">
       <div
         v-if="
           !$fetchState.pending &&
-          !$fetchState.error &&
-          Object.keys(results).length > 0
+            !$fetchState.error &&
+            Object.keys(results).length > 0
         "
       >
         <h3 class="title is-3">
           Design thawing index data for {{ results.place }}
         </h3>
-
-        <MiniMap />
 
         <DesignThawingIndexExplanation />
         <DataExplanation context="wrf" />
@@ -32,15 +29,21 @@
           <tbody>
             <tr>
               <th scope="row">Historical (1980-2009)</th>
-              <td>{{ results['historical']['di'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['historical']['di'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
             <tr>
               <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results['2040-2069']['di'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['2040-2069']['di'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
             <tr>
               <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results['2070-2099']['di'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['2070-2099']['di'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
           </tbody>
         </table>
@@ -70,8 +73,6 @@
 <script>
 import { mapGetters } from 'vuex'
 import DownloadCsvButton from '~/components/DownloadCsvButton'
-import MiniMap from '~/components/MiniMap'
-import LoadingStatus from '~/components/LoadingStatus'
 import DesignThawingIndexExplanation from '~/components/plates/design_thawing_index/Explanation'
 import DataExplanation from '~/components/DataExplanation'
 import UnitWidget from '~/components/UnitWidget'
@@ -80,8 +81,6 @@ export default {
   name: 'DesignThawingIndexReport',
   components: {
     DownloadCsvButton,
-    MiniMap,
-    LoadingStatus,
     DesignThawingIndexExplanation,
     DataExplanation,
     UnitWidget,
@@ -94,7 +93,7 @@ export default {
   },
 
   computed: {
-    state: function () {
+    state: function() {
       return this.$fetchState
     },
     ...mapGetters({
@@ -105,7 +104,7 @@ export default {
   },
 
   watch: {
-    latLng: function () {
+    latLng: function() {
       this.$fetch()
     },
   },

--- a/components/plates/ecoregions/Report.vue
+++ b/components/plates/ecoregions/Report.vue
@@ -2,13 +2,11 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
 
     <div id="report">
       <div v-if="!$fetchState.pending & !$fetchState.error">
         <h3 class="title is-3">Ecoregion for {{ results.place }}</h3>
         <h4 class="subtitle is-3">{{ results.name }}</h4>
-        <MiniMap />
       </div>
     </div>
   </div>
@@ -16,15 +14,9 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import MiniMap from '~/components/MiniMap'
-import LoadingStatus from '~/components/LoadingStatus'
 
 export default {
   name: 'EcoregionsReport',
-  components: {
-    MiniMap,
-    LoadingStatus,
-  },
   data() {
     return {
       // Will have the results of the data fetch.
@@ -33,7 +25,7 @@ export default {
   },
 
   computed: {
-    state: function () {
+    state: function() {
       return this.$fetchState
     },
     ...mapGetters({
@@ -44,7 +36,7 @@ export default {
   },
 
   watch: {
-    latLng: function () {
+    latLng: function() {
       this.$fetch()
     },
   },

--- a/components/plates/freezing_index/Report.vue
+++ b/components/plates/freezing_index/Report.vue
@@ -2,19 +2,16 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
 
     <div id="report">
       <div
         v-if="
           !$fetchState.pending &&
-          !$fetchState.error &&
-          Object.keys(results).length > 0
+            !$fetchState.error &&
+            Object.keys(results).length > 0
         "
       >
         <h3 class="title is-3">Freezing index data for {{ results.place }}</h3>
-
-        <MiniMap />
 
         <FreezingIndexExplanation />
         <DataExplanation context="wrf" />
@@ -33,27 +30,52 @@
           <tbody>
             <tr>
               <th scope="row">Historical (1979-2015)</th>
-              <td>{{ results['historical']['ddmin'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['historical']['ddmean'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['historical']['ddmax'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['historical']['ddmin'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['historical']['ddmean']
+                }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['historical']['ddmax'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
             <tr>
               <th scope="row">Early Century (2010-2039)</th>
-              <td>{{ results['2010-2039']['ddmin'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2010-2039']['ddmean'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2010-2039']['ddmax'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['2010-2039']['ddmin'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2010-2039']['ddmean'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2010-2039']['ddmax'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
             <tr>
               <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results['2040-2069']['ddmin'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2040-2069']['ddmean'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2040-2069']['ddmax'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['2040-2069']['ddmin'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2040-2069']['ddmean'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2040-2069']['ddmax'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
             <tr>
               <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results['2070-2099']['ddmin'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2070-2099']['ddmean'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2070-2099']['ddmax'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['2070-2099']['ddmin'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2070-2099']['ddmean'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2070-2099']['ddmax'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
           </tbody>
         </table>
@@ -83,8 +105,6 @@
 <script>
 import { mapGetters } from 'vuex'
 import DownloadCsvButton from '~/components/DownloadCsvButton'
-import MiniMap from '~/components/MiniMap'
-import LoadingStatus from '~/components/LoadingStatus'
 import FreezingIndexExplanation from '~/components/plates/freezing_index/Explanation'
 import DataExplanation from '~/components/DataExplanation'
 import UnitWidget from '~/components/UnitWidget'
@@ -93,8 +113,6 @@ export default {
   name: 'FreezingIndexReport',
   components: {
     DownloadCsvButton,
-    MiniMap,
-    LoadingStatus,
     FreezingIndexExplanation,
     DataExplanation,
     UnitWidget,
@@ -107,7 +125,7 @@ export default {
   },
 
   computed: {
-    state: function () {
+    state: function() {
       return this.$fetchState
     },
     ...mapGetters({
@@ -118,7 +136,7 @@ export default {
   },
 
   watch: {
-    latLng: function () {
+    latLng: function() {
       this.$fetch()
     },
   },

--- a/components/plates/geology/Report.vue
+++ b/components/plates/geology/Report.vue
@@ -2,13 +2,10 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
 
     <div id="report">
       <div v-if="!$fetchState.pending && !$fetchState.error">
         <h3 class="title is-3">Geological unit for {{ results.place }}</h3>
-
-        <MiniMap />
 
         <table class="table">
           <tbody>
@@ -29,15 +26,9 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import MiniMap from '~/components/MiniMap'
-import LoadingStatus from '~/components/LoadingStatus'
 
 export default {
   name: 'GeologyReport',
-  components: {
-    MiniMap,
-    LoadingStatus,
-  },
   data() {
     return {
       // Will have the results of the data fetch.
@@ -45,7 +36,7 @@ export default {
     }
   },
   computed: {
-    state: function () {
+    state: function() {
       return this.$fetchState
     },
     ...mapGetters({
@@ -56,7 +47,7 @@ export default {
   },
 
   watch: {
-    latLng: function () {
+    latLng: function() {
       this.$fetch()
     },
   },

--- a/components/plates/heating_degree_days/Report.vue
+++ b/components/plates/heating_degree_days/Report.vue
@@ -2,21 +2,18 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
 
     <div id="report">
       <div
         v-if="
           !$fetchState.pending &&
-          !$fetchState.error &&
-          Object.keys(results).length > 0
+            !$fetchState.error &&
+            Object.keys(results).length > 0
         "
       >
         <h3 class="title is-3">
           Heating degree days data for {{ results.place }}
         </h3>
-
-        <MiniMap />
 
         <HeatingDegreeDaysExplanation />
         <DataExplanation context="wrf" />
@@ -35,27 +32,52 @@
           <tbody>
             <tr>
               <th scope="row">Historical (1979-2015)</th>
-              <td>{{ results['historical']['ddmin'] }}<UnitWidget unitType="dd"/></td>
-              <td>{{ results['historical']['ddmean'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['historical']['ddmax'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['historical']['ddmin'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['historical']['ddmean']
+                }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['historical']['ddmax'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
             <tr>
               <th scope="row">Early Century (2010-2039)</th>
-              <td>{{ results['2010-2039']['ddmin'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2010-2039']['ddmean'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2010-2039']['ddmax'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['2010-2039']['ddmin'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2010-2039']['ddmean'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2010-2039']['ddmax'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
             <tr>
               <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results['2040-2069']['ddmin'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2040-2069']['ddmean'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2040-2069']['ddmax'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['2040-2069']['ddmin'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2040-2069']['ddmean'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2040-2069']['ddmax'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
             <tr>
               <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results['2070-2099']['ddmin'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2070-2099']['ddmean'] }}<UnitWidget unitType="dd" /></td>
-              <td>{{ results['2070-2099']['ddmax'] }}<UnitWidget unitType="dd" /></td>
+              <td>
+                {{ results['2070-2099']['ddmin'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2070-2099']['ddmean'] }}<UnitWidget unitType="dd" />
+              </td>
+              <td>
+                {{ results['2070-2099']['ddmax'] }}<UnitWidget unitType="dd" />
+              </td>
             </tr>
           </tbody>
         </table>
@@ -85,8 +107,6 @@
 <script>
 import { mapGetters } from 'vuex'
 import DownloadCsvButton from '~/components/DownloadCsvButton'
-import MiniMap from '~/components/MiniMap'
-import LoadingStatus from '~/components/LoadingStatus'
 import HeatingDegreeDaysExplanation from '~/components/plates/heating_degree_days/Explanation'
 import DataExplanation from '~/components/DataExplanation'
 import UnitWidget from '~/components/UnitWidget'
@@ -95,8 +115,6 @@ export default {
   name: 'HeatingDegreeDaysReport',
   components: {
     DownloadCsvButton,
-    MiniMap,
-    LoadingStatus,
     HeatingDegreeDaysExplanation,
     DataExplanation,
     UnitWidget,
@@ -109,7 +127,7 @@ export default {
   },
 
   computed: {
-    state: function () {
+    state: function() {
       return this.$fetchState
     },
     ...mapGetters({
@@ -120,7 +138,7 @@ export default {
   },
 
   watch: {
-    latLng: function () {
+    latLng: function() {
       this.$fetch()
     },
   },

--- a/components/plates/permafrost/Report.vue
+++ b/components/plates/permafrost/Report.vue
@@ -2,19 +2,16 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
 
     <div id="report">
       <div
         v-if="
           !$fetchState.pending &&
-          !$fetchState.error &&
-          Object.keys(results).length > 0
+            !$fetchState.error &&
+            Object.keys(results).length > 0
         "
       >
         <h3 class="title is-3">Permafrost data for {{ results.place }}</h3>
-
-        <MiniMap />
 
         <UnitRadio
           class="my-5"
@@ -99,8 +96,7 @@
               Obu et al. (2018) Mean Annual Ground Temperature at Top of
               Permafrost:
               <strong
-                >{{ results.magt_2018
-                }}<UnitWidget unitType="temp" type="light"
+                >{{ results.magt_2018 }}<UnitWidget unitType="temp" type="light"
               /></strong>
             </li>
             <li v-if="results.giv_2008">
@@ -130,20 +126,16 @@
 <script>
 import { mapGetters } from 'vuex'
 import DownloadCsvButton from '~/components/DownloadCsvButton'
-import MiniMap from '~/components/MiniMap'
-import LoadingStatus from '~/components/LoadingStatus'
 import UnitWidget from '~/components/UnitWidget'
 
 export default {
   name: 'PermafrostReport',
   components: {
     DownloadCsvButton,
-    MiniMap,
-    LoadingStatus,
     UnitWidget,
   },
   computed: {
-    state: function () {
+    state: function() {
       return this.$fetchState
     },
     ...mapGetters({
@@ -169,7 +161,7 @@ export default {
     },
   },
   watch: {
-    latLng: function () {
+    latLng: function() {
       this.$fetch()
     },
   },
@@ -190,16 +182,21 @@ export default {
         place: place,
 
         // "magt_" substrings are converted between °C and °F
-        gipl_magt_1995:
-          this.results['gipl']['1995']['cruts31']['historical']['magt'],
-        gipl_magt_2025:
-          this.results['gipl']['2025']['ncarccsm4']['rcp85']['magt'],
-        gipl_magt_2050:
-          this.results['gipl']['2050']['ncarccsm4']['rcp85']['magt'],
-        gipl_magt_2075:
-          this.results['gipl']['2075']['ncarccsm4']['rcp85']['magt'],
-        gipl_magt_2095:
-          this.results['gipl']['2095']['ncarccsm4']['rcp85']['magt'],
+        gipl_magt_1995: this.results['gipl']['1995']['cruts31']['historical'][
+          'magt'
+        ],
+        gipl_magt_2025: this.results['gipl']['2025']['ncarccsm4']['rcp85'][
+          'magt'
+        ],
+        gipl_magt_2050: this.results['gipl']['2050']['ncarccsm4']['rcp85'][
+          'magt'
+        ],
+        gipl_magt_2075: this.results['gipl']['2075']['ncarccsm4']['rcp85'][
+          'magt'
+        ],
+        gipl_magt_2095: this.results['gipl']['2095']['ncarccsm4']['rcp85'][
+          'magt'
+        ],
       }
 
       if (this.results['jorg'] != null) {

--- a/components/plates/precipitation/Report.vue
+++ b/components/plates/precipitation/Report.vue
@@ -2,7 +2,6 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
 
     <div id="report">
       <div
@@ -13,8 +12,6 @@
         "
       >
         <h3 class="title is-3">Precipitation data for {{ results.place }}</h3>
-
-        <MiniMap />
 
         <PrecipitationExplanation />
         <DataExplanation context="snap" />
@@ -127,8 +124,6 @@
 <script>
 import { mapGetters } from 'vuex'
 import DownloadCsvButton from '~/components/DownloadCsvButton'
-import MiniMap from '~/components/MiniMap'
-import LoadingStatus from '~/components/LoadingStatus'
 import UnitWidget from '~/components/UnitWidget'
 import UnitRadio from '~/components/UnitRadio'
 import PrecipitationExplanation from '~/components/plates/precipitation/Explanation'
@@ -138,8 +133,6 @@ export default {
   name: 'PrecipitationReport',
   components: {
     DownloadCsvButton,
-    MiniMap,
-    LoadingStatus,
     UnitWidget,
     UnitRadio,
     PrecipitationExplanation,

--- a/components/plates/snowfall/Report.vue
+++ b/components/plates/snowfall/Report.vue
@@ -2,21 +2,18 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
 
     <div id="report">
       <div
         v-if="
           !$fetchState.pending &&
-          !$fetchState.error &&
-          Object.keys(results).length > 0
+            !$fetchState.error &&
+            Object.keys(results).length > 0
         "
       >
         <h3 class="title is-3">
           Snowfall Equivalent data for {{ results.place }}
         </h3>
-
-        <MiniMap />
 
         <SnowfallExplanation />
         <DataExplanation context="snap" />
@@ -98,15 +95,13 @@ export default {
   name: 'SnowfallReport',
   components: {
     DownloadCsvButton,
-    MiniMap,
-    LoadingStatus,
     UnitWidget,
     UnitRadio,
     SnowfallExplanation,
     DataExplanation,
   },
   computed: {
-    state: function () {
+    state: function() {
       return this.$fetchState
     },
     ...mapGetters({
@@ -118,7 +113,7 @@ export default {
   },
 
   watch: {
-    latLng: function () {
+    latLng: function() {
       this.$fetch()
     },
   },

--- a/components/plates/temperature/Report.vue
+++ b/components/plates/temperature/Report.vue
@@ -2,8 +2,7 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
-
+    
     <div id="report">
       <div
         v-if="
@@ -13,8 +12,6 @@
         "
       >
         <h3 class="title is-3">Temperature data for {{ results.place }}</h3>
-
-        <MiniMap />
 
         <TemperatureExplanation context="report" />
         <DataExplanation context="snap" />
@@ -136,9 +133,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import MiniMap from '~/components/MiniMap'
 import DownloadCsvButton from '~/components/DownloadCsvButton'
-import LoadingStatus from '~/components/LoadingStatus'
 import UnitWidget from '~/components/UnitWidget'
 import UnitRadio from '~/components/UnitRadio'
 import TemperatureExplanation from '~/components/plates/temperature/Explanation'
@@ -148,8 +143,6 @@ export default {
   name: 'TemperatureReport',
   components: {
     DownloadCsvButton,
-    MiniMap,
-    LoadingStatus,
     UnitWidget,
     UnitRadio,
     TemperatureExplanation,

--- a/components/plates/thawing_index/Report.vue
+++ b/components/plates/thawing_index/Report.vue
@@ -2,19 +2,16 @@
   <div>
     <CloseReportButton />
     <hr />
-    <LoadingStatus :state="state" />
 
     <div id="report">
       <div
         v-if="
           !$fetchState.pending &&
-          !$fetchState.error &&
-          Object.keys(results).length > 0
+            !$fetchState.error &&
+            Object.keys(results).length > 0
         "
       >
         <h3 class="title is-3">Thawing index data for {{ results.place }}</h3>
-
-        <MiniMap />
 
         <ThawingIndexExplanation :isFooter="false" />
 
@@ -91,8 +88,6 @@ export default {
   name: 'ThawingIndexReport',
   components: {
     DownloadCsvButton,
-    MiniMap,
-    LoadingStatus,
     ThawingIndexExplanation,
     UnitWidget,
   },
@@ -104,7 +99,7 @@ export default {
   },
 
   computed: {
-    state: function () {
+    state: function() {
       return this.$fetchState
     },
     ...mapGetters({
@@ -115,7 +110,7 @@ export default {
   },
 
   watch: {
-    latLng: function () {
+    latLng: function() {
       this.$fetch()
     },
   },


### PR DESCRIPTION
Just removes the MiniMap / LoadingIndicators from report components.

Check that all associated/dependent code is removed.  This is part of cleaning up the individual Reports so they are suitable for consolidating into a single larger report.