### PR TITLE
Combines all ArcticEDS plates into a single report

### DIFF
--- a/components/LatLngSelector.vue
+++ b/components/LatLngSelector.vue
@@ -69,7 +69,6 @@ export default {
             this.latLng.lat.toFixed(4) +
             '/' +
             this.latLng.lng.toFixed(4),
-          hash: '#report',
         })
       }
     },

--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -89,7 +89,6 @@ export default {
       if (selected) {
         this.$router.push({
           path: this.$route.path + '/report/community/' + selected.id,
-          hash: '#report',
         })
       }
     },

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -11,6 +11,7 @@
         "
       >
         <h3 class="title is-2">Full Report for {{ placeName }}</h3>
+        <UnitRadio />
         <TemperatureReport />
         <PrecipitationReport />
         <SnowfallReport />
@@ -29,6 +30,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import UnitRadio from '~/components/UnitRadio'
 import TemperatureReport from '~/components/plates/temperature/Report'
 import PrecipitationReport from '~/components/plates/precipitation/Report'
 import SnowfallReport from '~/components/plates/snowfall/Report'
@@ -43,6 +45,7 @@ import ThawingIndexReport from '~/components/plates/thawing_index/Report'
 export default {
   name: 'FullReport',
   components: {
+    UnitRadio,
     TemperatureReport,
     PrecipitationReport,
     SnowfallReport,

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <hr />
-
+    <LoadingStatus :state="state" />
     <div id="report">
       <div
         v-if="
@@ -49,6 +49,7 @@ export default {
   name: 'FullReport',
   components: {
     UnitRadio,
+    MiniMap,
     TemperatureReport,
     PrecipitationReport,
     SnowfallReport,

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -1,0 +1,92 @@
+<template>
+  <div>
+    <hr />
+
+    <div id="report">
+      <div
+        v-if="
+          !$fetchState.pending &&
+          !$fetchState.error &&
+          Object.keys(results).length > 0
+        "
+      >
+        <h3 class="title is-2">Full Report for {{ placeName }}</h3>
+        <TemperatureReport />
+        <PrecipitationReport />
+        <SnowfallReport />
+        <PermafrostReport />
+        <HeatingDegreeDaysReport />
+        <DesignFreezingIndexReport />
+        <DesignThawingIndexReport />
+        <EcoregionsReport />
+        <FreezingIndexReport />
+        <GeologyReport />
+        <ThawingIndexReport />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import TemperatureReport from '~/components/plates/temperature/Report'
+import PrecipitationReport from '~/components/plates/precipitation/Report'
+import SnowfallReport from '~/components/plates/snowfall/Report'
+import PermafrostReport from '~/components/plates/permafrost/Report'
+import HeatingDegreeDaysReport from '~/components/plates/heating_degree_days/Report'
+import DesignFreezingIndexReport from '~/components/plates/design_freezing_index/Report'
+import DesignThawingIndexReport from '~/components/plates/design_thawing_index/Report'
+import EcoregionsReport from '~/components/plates/ecoregions/Report'
+import FreezingIndexReport from '~/components/plates/freezing_index/Report'
+import GeologyReport from '~/components/plates/geology/Report'
+import ThawingIndexReport from '~/components/plates/thawing_index/Report'
+export default {
+  name: 'FullReport',
+  components: {
+    TemperatureReport,
+    PrecipitationReport,
+    SnowfallReport,
+    PermafrostReport,
+    HeatingDegreeDaysReport,
+    DesignFreezingIndexReport,
+    DesignThawingIndexReport,
+    EcoregionsReport,
+    FreezingIndexReport,
+    GeologyReport,
+    ThawingIndexReport,
+  },
+  computed: {
+    state: function () {
+      return this.$fetchState
+    },
+    ...mapGetters({
+      results: 'report/results',
+      placeName: 'report/placeName',
+      isPlaceDefined: 'report/isPlaceDefined',
+      latLng: 'report/latLng',
+    }),
+  },
+
+  watch: {
+    latLng: function () {
+      this.$fetch()
+    },
+  },
+  async fetch() {
+    await this.$store.dispatch('report/fetchPlaces')
+
+    if (this.isPlaceDefined) {
+      let url =
+        process.env.apiUrl +
+        '/eds/all/' +
+        this.latLng.lat +
+        '/' +
+        this.latLng.lng
+
+      await this.$store.dispatch('report/apiFetch', url)
+    }
+  },
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -11,7 +11,9 @@
         "
       >
         <h3 class="title is-2">Full Report for {{ placeName }}</h3>
+        <MiniMap />
         <UnitRadio />
+        <CloseReportButton />
         <TemperatureReport />
         <PrecipitationReport />
         <SnowfallReport />
@@ -31,6 +33,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import UnitRadio from '~/components/UnitRadio'
+import MiniMap from '~/components/MiniMap'
 import TemperatureReport from '~/components/plates/temperature/Report'
 import PrecipitationReport from '~/components/plates/precipitation/Report'
 import SnowfallReport from '~/components/plates/snowfall/Report'

--- a/components/UnitRadio.vue
+++ b/components/UnitRadio.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="radio-units">
     <p>You can display these results in Imperial or Metric units.</p>
     <div>
       <b-field label="Units">
@@ -46,3 +46,8 @@ export default {
   },
 }
 </script>
+<style scoped>
+.radio-units {
+  padding-bottom: 1rem;
+}
+</style>

--- a/components/UnitRadio.vue
+++ b/components/UnitRadio.vue
@@ -18,7 +18,7 @@ import { mapGetters } from 'vuex'
 
 export default {
   name: 'UnitRadio',
-  props: ['type', 'patterns'],
+  props: ['type', 'patterns', 'variable'],
   data() {
     return {
       radioUnits: this.storeRadioUnits,
@@ -40,6 +40,7 @@ export default {
           this.$store.commit('report/convertResults', {
             type: this.type,
             patterns: this.patterns,
+            variable: this.variable,
           })
         }
       } else {
@@ -47,6 +48,7 @@ export default {
         this.$store.commit('report/convertResults', {
           type: this.type,
           patterns: this.patterns,
+          variable: this.variable,
         })
       }
     },

--- a/components/UnitRadio.vue
+++ b/components/UnitRadio.vue
@@ -37,20 +37,11 @@ export default {
       if (this.radioUnits == 'metric') {
         if (this.storeRadioUnits != 'metric') {
           this.$store.commit('report/setMetric')
-          this.$store.commit('report/convertResults', {
-            type: this.type,
-            patterns: this.patterns,
-            variable: this.variable,
-          })
         }
       } else {
         this.$store.commit('report/setImperial')
-        this.$store.commit('report/convertResults', {
-          type: this.type,
-          patterns: this.patterns,
-          variable: this.variable,
-        })
       }
+      this.$store.commit('report/convertResults')
     },
   },
 }

--- a/components/plates/design_freezing_index/Report.vue
+++ b/components/plates/design_freezing_index/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/components/plates/design_freezing_index/Report.vue
+++ b/components/plates/design_freezing_index/Report.vue
@@ -4,9 +4,7 @@
     <hr />
 
     <div id="report">
-      <h3 class="title is-3">
-        Design freezing index data for {{ plateResults.place }}
-      </h3>
+      <h3 class="title is-3">Design freezing index data for {{ placeName }}</h3>
 
       <DesignFreezingIndexExplanation />
       <DataExplanation context="wrf" />
@@ -24,19 +22,22 @@
           <tr>
             <th scope="row">Historical (1980-2009)</th>
             <td>
-              {{ plateResults['historical']['di'] }}<UnitWidget unitType="dd" />
+              {{ results.design_freezing['historical']['di']
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040-2069)</th>
             <td>
-              {{ plateResults['2040-2069']['di'] }}<UnitWidget unitType="dd" />
+              {{ results.design_freezing['2040-2069']['di']
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070-2099)</th>
             <td>
-              {{ plateResults['2070-2099']['di'] }}<UnitWidget unitType="dd" />
+              {{ results.design_freezing['2070-2099']['di']
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
         </tbody>
@@ -82,27 +83,7 @@ export default {
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
-      isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
-  },
-  data() {
-    return {
-      plateResults: null,
-    }
-  },
-
-  watch: {
-    latLng: function () {
-      this.$fetch()
-    },
-  },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      this.plateResults = this.results['design_freezing']
-
-      this.plateResults.place = this.placeName
-    }
   },
 }
 </script>

--- a/components/plates/design_freezing_index/Report.vue
+++ b/components/plates/design_freezing_index/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.design_freezing).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/design_freezing_index/Report.vue
+++ b/components/plates/design_freezing_index/Report.vue
@@ -4,63 +4,61 @@
     <hr />
 
     <div id="report">
-      <div
-        v-if="
-          !$fetchState.pending &&
-          !$fetchState.error &&
-          Object.keys(results).length > 0
-        "
-      >
-        <h3 class="title is-3">
-          Design freezing index data for {{ results.place }}
-        </h3>
+      <h3 class="title is-3">
+        Design freezing index data for {{ plateResults.place }}
+      </h3>
 
-        <DesignFreezingIndexExplanation />
-        <DataExplanation context="wrf" />
+      <DesignFreezingIndexExplanation />
+      <DataExplanation context="wrf" />
 
-        <h4 class="title is-4">Design Freezing Index</h4>
+      <h4 class="title is-4">Design Freezing Index</h4>
 
-        <table class="table">
-          <thead>
-            <tr>
-              <th scope="col"></th>
-              <th scope="col">Mean</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Historical (1980-2009)</th>
-              <td>{{ results['historical']['di'] }}<UnitWidget unitType="dd" /></td>
-            </tr>
-            <tr>
-              <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results['2040-2069']['di'] }}<UnitWidget unitType="dd" /></td>
-            </tr>
-            <tr>
-              <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results['2070-2099']['di'] }}<UnitWidget unitType="dd" /></td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 class="title is-6">Access to Data</h4>
-        <div class="content">
-          <p>Freezing index data was calculated from the following:</p>
-          <ul>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
-                target="_blank"
-                >Historical and Projected Climate Products</a
-              >
-            </li>
-          </ul>
-        </div>
-        <DownloadCsvButton
-          text="Download design freezing index data as CSV"
-          endpoint="design_index/freezing/all/point"
-          class="mt-3 mb-5"
-        />
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Mean</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1980-2009)</th>
+            <td>
+              {{ plateResults['historical']['di'] }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040-2069)</th>
+            <td>
+              {{ plateResults['2040-2069']['di'] }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070-2099)</th>
+            <td>
+              {{ plateResults['2070-2099']['di'] }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h4 class="title is-6">Access to Data</h4>
+      <div class="content">
+        <p>Freezing index data was calculated from the following:</p>
+        <ul>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
+              target="_blank"
+              >Historical and Projected Climate Products</a
+            >
+          </li>
+        </ul>
       </div>
+      <DownloadCsvButton
+        text="Download design freezing index data as CSV"
+        endpoint="design_index/freezing/all/point"
+        class="mt-3 mb-5"
+      />
     </div>
   </div>
 </template>
@@ -80,21 +78,18 @@ export default {
     DataExplanation,
     UnitWidget,
   },
-  data() {
-    return {
-      results: {}, // Will have the results of the data fetch.
-    }
-  },
-
   computed: {
-    state: function () {
-      return this.$fetchState
-    },
     ...mapGetters({
+      results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       latLng: 'report/latLng',
     }),
+  },
+  data() {
+    return {
+      plateResults: null,
+    }
   },
 
   watch: {
@@ -104,15 +99,9 @@ export default {
   },
   async fetch() {
     if (this.isPlaceDefined) {
-      this.results = await this.$axios.$get(
-        process.env.apiUrl +
-          '/design_index/freezing/hp/point/' +
-          this.latLng.lat +
-          '/' +
-          this.latLng.lng
-      )
+      this.plateResults = this.results['design_freezing']
 
-      this.results.place = this.placeName
+      this.plateResults.place = this.placeName
     }
   },
 }

--- a/components/plates/design_thawing_index/Report.vue
+++ b/components/plates/design_thawing_index/Report.vue
@@ -3,69 +3,61 @@
     <CloseReportButton />
     <hr />
     <div id="report">
-      <div
-        v-if="
-          !$fetchState.pending &&
-            !$fetchState.error &&
-            Object.keys(results).length > 0
-        "
-      >
-        <h3 class="title is-3">
-          Design thawing index data for {{ results.place }}
-        </h3>
+      <h3 class="title is-3">
+        Design thawing index data for {{ plateResults.place }}
+      </h3>
 
-        <DesignThawingIndexExplanation />
-        <DataExplanation context="wrf" />
+      <DesignThawingIndexExplanation />
+      <DataExplanation context="wrf" />
 
-        <h4 class="title is-4">Design Thawing Index</h4>
+      <h4 class="title is-4">Design Thawing Index</h4>
 
-        <table class="table">
-          <thead>
-            <tr>
-              <th scope="col"></th>
-              <th scope="col">Mean</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Historical (1980-2009)</th>
-              <td>
-                {{ results['historical']['di'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Mid Century (2040-2069)</th>
-              <td>
-                {{ results['2040-2069']['di'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Late Century (2070-2099)</th>
-              <td>
-                {{ results['2070-2099']['di'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 class="title is-6">Access to Data</h4>
-        <div class="content">
-          <p>Thawing index data was calculated from the following:</p>
-          <ul>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
-                target="_blank"
-                >Historical and Projected Climate Products</a
-              >
-            </li>
-          </ul>
-        </div>
-        <DownloadCsvButton
-          text="Download design thawing index data as CSV"
-          endpoint="design_index/thawing/all/point"
-          class="mt-3 mb-5"
-        />
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Mean</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1980-2009)</th>
+            <td>
+              {{ plateResults['historical']['di'] }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040-2069)</th>
+            <td>
+              {{ plateResults['2040-2069']['di'] }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070-2099)</th>
+            <td>
+              {{ plateResults['2070-2099']['di'] }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h4 class="title is-6">Access to Data</h4>
+      <div class="content">
+        <p>Thawing index data was calculated from the following:</p>
+        <ul>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
+              target="_blank"
+              >Historical and Projected Climate Products</a
+            >
+          </li>
+        </ul>
       </div>
+      <DownloadCsvButton
+        text="Download design thawing index data as CSV"
+        endpoint="design_index/thawing/all/point"
+        class="mt-3 mb-5"
+      />
     </div>
   </div>
 </template>
@@ -88,15 +80,13 @@ export default {
   data() {
     return {
       // Will have the results of the data fetch.
-      results: {},
+      plateResults: null,
     }
   },
 
   computed: {
-    state: function() {
-      return this.$fetchState
-    },
     ...mapGetters({
+      results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       latLng: 'report/latLng',
@@ -104,21 +94,14 @@ export default {
   },
 
   watch: {
-    latLng: function() {
+    latLng: function () {
       this.$fetch()
     },
   },
   async fetch() {
     if (this.isPlaceDefined) {
-      this.results = await this.$axios.$get(
-        process.env.apiUrl +
-          '/design_index/thawing/hp/point/' +
-          this.latLng.lat +
-          '/' +
-          this.latLng.lng
-      )
-
-      this.results.place = this.placeName
+      this.plateResults = this.results['design_thawing']
+      this.plateResults.place = this.placeName
     }
   },
 }

--- a/components/plates/design_thawing_index/Report.vue
+++ b/components/plates/design_thawing_index/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
     <div id="report">
       <h3 class="title is-3">Design thawing index data for {{ placeName }}</h3>

--- a/components/plates/design_thawing_index/Report.vue
+++ b/components/plates/design_thawing_index/Report.vue
@@ -3,9 +3,7 @@
     <CloseReportButton />
     <hr />
     <div id="report">
-      <h3 class="title is-3">
-        Design thawing index data for {{ plateResults.place }}
-      </h3>
+      <h3 class="title is-3">Design thawing index data for {{ placeName }}</h3>
 
       <DesignThawingIndexExplanation />
       <DataExplanation context="wrf" />
@@ -23,19 +21,22 @@
           <tr>
             <th scope="row">Historical (1980-2009)</th>
             <td>
-              {{ plateResults['historical']['di'] }}<UnitWidget unitType="dd" />
+              {{ results.design_thawing['historical']['di']
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040-2069)</th>
             <td>
-              {{ plateResults['2040-2069']['di'] }}<UnitWidget unitType="dd" />
+              {{ results.design_thawing['2040-2069']['di']
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070-2099)</th>
             <td>
-              {{ plateResults['2070-2099']['di'] }}<UnitWidget unitType="dd" />
+              {{ results.design_thawing['2070-2099']['di']
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
         </tbody>
@@ -77,32 +78,12 @@ export default {
     DataExplanation,
     UnitWidget,
   },
-  data() {
-    return {
-      // Will have the results of the data fetch.
-      plateResults: null,
-    }
-  },
 
   computed: {
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
-      isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
-  },
-
-  watch: {
-    latLng: function () {
-      this.$fetch()
-    },
-  },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      this.plateResults = this.results['design_thawing']
-      this.plateResults.place = this.placeName
-    }
   },
 }
 </script>

--- a/components/plates/design_thawing_index/Report.vue
+++ b/components/plates/design_thawing_index/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.design_thawing).length != 0">
     <hr />
     <div id="report">
       <h3 class="title is-3">Design thawing index data for {{ placeName }}</h3>

--- a/components/plates/ecoregions/Report.vue
+++ b/components/plates/ecoregions/Report.vue
@@ -4,10 +4,8 @@
     <hr />
 
     <div id="report">
-      <div v-if="!$fetchState.pending & !$fetchState.error">
-        <h3 class="title is-3">Ecoregion for {{ plateResults.place }}</h3>
-        <h4 class="subtitle is-3">{{ plateResults.name }}</h4>
-      </div>
+      <h3 class="title is-3">Ecoregion for {{ placeName }}</h3>
+      <h4 class="subtitle is-3">{{ results.physiography.name }}</h4>
     </div>
   </div>
 </template>
@@ -17,36 +15,12 @@ import { mapGetters } from 'vuex'
 
 export default {
   name: 'EcoregionsReport',
-  data() {
-    return {
-      // Will have the results of the data fetch.
-      plateResults: null,
-    }
-  },
 
   computed: {
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
-      isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
-  },
-  data() {
-    return {
-      plateResults: null,
-    }
-  },
-  watch: {
-    latLng: function () {
-      this.$fetch()
-    },
-  },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      this.plateResults = this.results['physiography']
-      this.plateResults.place = this.placeName
-    }
   },
 }
 </script>

--- a/components/plates/ecoregions/Report.vue
+++ b/components/plates/ecoregions/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/components/plates/ecoregions/Report.vue
+++ b/components/plates/ecoregions/Report.vue
@@ -5,8 +5,8 @@
 
     <div id="report">
       <div v-if="!$fetchState.pending & !$fetchState.error">
-        <h3 class="title is-3">Ecoregion for {{ results.place }}</h3>
-        <h4 class="subtitle is-3">{{ results.name }}</h4>
+        <h3 class="title is-3">Ecoregion for {{ plateResults.place }}</h3>
+        <h4 class="subtitle is-3">{{ plateResults.name }}</h4>
       </div>
     </div>
   </div>
@@ -20,37 +20,32 @@ export default {
   data() {
     return {
       // Will have the results of the data fetch.
-      results: {},
+      plateResults: null,
     }
   },
 
   computed: {
-    state: function() {
-      return this.$fetchState
-    },
     ...mapGetters({
+      results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       latLng: 'report/latLng',
     }),
   },
-
+  data() {
+    return {
+      plateResults: null,
+    }
+  },
   watch: {
-    latLng: function() {
+    latLng: function () {
       this.$fetch()
     },
   },
   async fetch() {
     if (this.isPlaceDefined) {
-      this.results = await this.$axios.$get(
-        process.env.apiUrl +
-          '/physiography/point/' +
-          this.latLng.lat +
-          '/' +
-          this.latLng.lng
-      )
-
-      this.results.place = this.placeName
+      this.plateResults = this.results['physiography']
+      this.plateResults.place = this.placeName
     }
   },
 }

--- a/components/plates/ecoregions/Report.vue
+++ b/components/plates/ecoregions/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.physiography).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/freezing_index/Report.vue
+++ b/components/plates/freezing_index/Report.vue
@@ -4,100 +4,105 @@
     <hr />
 
     <div id="report">
-      <div
-        v-if="
-          !$fetchState.pending &&
-            !$fetchState.error &&
-            Object.keys(results).length > 0
-        "
-      >
-        <h3 class="title is-3">Freezing index data for {{ results.place }}</h3>
+      <h3 class="title is-3">
+        Freezing index data for {{ plateResults.place }}
+      </h3>
 
-        <FreezingIndexExplanation />
-        <DataExplanation context="wrf" />
+      <FreezingIndexExplanation />
+      <DataExplanation context="wrf" />
 
-        <h4 class="title is-4">Freezing Index</h4>
+      <h4 class="title is-4">Freezing Index</h4>
 
-        <table class="table">
-          <thead>
-            <tr>
-              <th scope="col"></th>
-              <th scope="col">Min</th>
-              <th scope="col">Mean</th>
-              <th scope="col">Max</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Historical (1979-2015)</th>
-              <td>
-                {{ results['historical']['ddmin'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['historical']['ddmean']
-                }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['historical']['ddmax'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Early Century (2010-2039)</th>
-              <td>
-                {{ results['2010-2039']['ddmin'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2010-2039']['ddmean'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2010-2039']['ddmax'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Mid Century (2040-2069)</th>
-              <td>
-                {{ results['2040-2069']['ddmin'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2040-2069']['ddmean'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2040-2069']['ddmax'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Late Century (2070-2099)</th>
-              <td>
-                {{ results['2070-2099']['ddmin'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2070-2099']['ddmean'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2070-2099']['ddmax'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 class="title is-6">Access to Data</h4>
-        <div class="content">
-          <p>Freezing index data was calculated from the following:</p>
-          <ul>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
-                target="_blank"
-                >Historical and Projected Climate Products</a
-              >
-            </li>
-          </ul>
-        </div>
-        <DownloadCsvButton
-          text="Download freezing index data as CSV"
-          endpoint="mmm/degree_days/freezing_index/all"
-          class="mt-3 mb-5"
-        />
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1979-2015)</th>
+            <td>
+              {{ plateResults['historical']['ddmin']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['historical']['ddmean']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['historical']['ddmax']
+              }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Early Century (2010-2039)</th>
+            <td>
+              {{ plateResults['2010-2039']['ddmin']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2010-2039']['ddmean']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2010-2039']['ddmax']
+              }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040-2069)</th>
+            <td>
+              {{ plateResults['2040-2069']['ddmin']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2040-2069']['ddmean']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2040-2069']['ddmax']
+              }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070-2099)</th>
+            <td>
+              {{ plateResults['2070-2099']['ddmin']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2070-2099']['ddmean']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2070-2099']['ddmax']
+              }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h4 class="title is-6">Access to Data</h4>
+      <div class="content">
+        <p>Freezing index data was calculated from the following:</p>
+        <ul>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
+              target="_blank"
+              >Historical and Projected Climate Products</a
+            >
+          </li>
+        </ul>
       </div>
+      <DownloadCsvButton
+        text="Download freezing index data as CSV"
+        endpoint="mmm/degree_days/freezing_index/all"
+        class="mt-3 mb-5"
+      />
     </div>
   </div>
 </template>
@@ -120,15 +125,13 @@ export default {
   data() {
     return {
       // Will have the results of the data fetch.
-      results: {},
+      plateResults: null,
     }
   },
 
   computed: {
-    state: function() {
-      return this.$fetchState
-    },
     ...mapGetters({
+      results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       latLng: 'report/latLng',
@@ -136,21 +139,15 @@ export default {
   },
 
   watch: {
-    latLng: function() {
+    latLng: function () {
       this.$fetch()
     },
   },
   async fetch() {
     if (this.isPlaceDefined) {
-      this.results = await this.$axios.$get(
-        process.env.apiUrl +
-          '/eds/degree_days/freezing_index/' +
-          this.latLng.lat +
-          '/' +
-          this.latLng.lng
-      )
+      this.plateResults = this.results['freezing_index']
 
-      this.results.place = this.placeName
+      this.plateResults.place = this.placeName
     }
   },
 }

--- a/components/plates/freezing_index/Report.vue
+++ b/components/plates/freezing_index/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/components/plates/freezing_index/Report.vue
+++ b/components/plates/freezing_index/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.freezing_index).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/freezing_index/Report.vue
+++ b/components/plates/freezing_index/Report.vue
@@ -4,9 +4,7 @@
     <hr />
 
     <div id="report">
-      <h3 class="title is-3">
-        Freezing index data for {{ plateResults.place }}
-      </h3>
+      <h3 class="title is-3">Freezing index data for {{ placeName }}</h3>
 
       <FreezingIndexExplanation />
       <DataExplanation context="wrf" />
@@ -26,60 +24,60 @@
           <tr>
             <th scope="row">Historical (1979-2015)</th>
             <td>
-              {{ plateResults['historical']['ddmin']
+              {{ results.freezing_index['historical']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['historical']['ddmean']
+              {{ results.freezing_index['historical']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['historical']['ddmax']
+              {{ results.freezing_index['historical']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Early Century (2010-2039)</th>
             <td>
-              {{ plateResults['2010-2039']['ddmin']
+              {{ results.freezing_index['2010-2039']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2010-2039']['ddmean']
+              {{ results.freezing_index['2010-2039']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2010-2039']['ddmax']
+              {{ results.freezing_index['2010-2039']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040-2069)</th>
             <td>
-              {{ plateResults['2040-2069']['ddmin']
+              {{ results.freezing_index['2040-2069']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2040-2069']['ddmean']
+              {{ results.freezing_index['2040-2069']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2040-2069']['ddmax']
+              {{ results.freezing_index['2040-2069']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070-2099)</th>
             <td>
-              {{ plateResults['2070-2099']['ddmin']
+              {{ results.freezing_index['2070-2099']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2070-2099']['ddmean']
+              {{ results.freezing_index['2070-2099']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2070-2099']['ddmax']
+              {{ results.freezing_index['2070-2099']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
@@ -122,33 +120,12 @@ export default {
     DataExplanation,
     UnitWidget,
   },
-  data() {
-    return {
-      // Will have the results of the data fetch.
-      plateResults: null,
-    }
-  },
 
   computed: {
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
-      isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
-  },
-
-  watch: {
-    latLng: function () {
-      this.$fetch()
-    },
-  },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      this.plateResults = this.results['freezing_index']
-
-      this.plateResults.place = this.placeName
-    }
   },
 }
 </script>

--- a/components/plates/geology/Report.vue
+++ b/components/plates/geology/Report.vue
@@ -5,17 +5,17 @@
 
     <div id="report">
       <div v-if="!$fetchState.pending && !$fetchState.error">
-        <h3 class="title is-3">Geological unit for {{ results.place }}</h3>
+        <h3 class="title is-3">Geological unit for {{ plateResults.place }}</h3>
 
         <table class="table">
           <tbody>
             <tr>
               <th scope="row">Age</th>
-              <td>{{ results.age }}</td>
+              <td>{{ plateResults.age }}</td>
             </tr>
             <tr>
               <th scope="row">Classification</th>
-              <td>{{ results.name }}</td>
+              <td>{{ plateResults.name }}</td>
             </tr>
           </tbody>
         </table>
@@ -32,14 +32,12 @@ export default {
   data() {
     return {
       // Will have the results of the data fetch.
-      results: {},
+      plateResults: {},
     }
   },
   computed: {
-    state: function() {
-      return this.$fetchState
-    },
     ...mapGetters({
+      results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       latLng: 'report/latLng',
@@ -47,21 +45,14 @@ export default {
   },
 
   watch: {
-    latLng: function() {
+    latLng: function () {
       this.$fetch()
     },
   },
   async fetch() {
     if (this.isPlaceDefined) {
-      this.results = await this.$axios.$get(
-        process.env.apiUrl +
-          '/geology/point/' +
-          this.latLng.lat +
-          '/' +
-          this.latLng.lng
-      )
-
-      this.results.place = this.placeName
+      this.plateResults = this.results['geology']
+      this.plateResults.place = this.placeName
     }
   },
 }

--- a/components/plates/geology/Report.vue
+++ b/components/plates/geology/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.geology).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/geology/Report.vue
+++ b/components/plates/geology/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/components/plates/geology/Report.vue
+++ b/components/plates/geology/Report.vue
@@ -4,22 +4,20 @@
     <hr />
 
     <div id="report">
-      <div v-if="!$fetchState.pending && !$fetchState.error">
-        <h3 class="title is-3">Geological unit for {{ plateResults.place }}</h3>
+      <h3 class="title is-3">Geological unit for {{ placeName }}</h3>
 
-        <table class="table">
-          <tbody>
-            <tr>
-              <th scope="row">Age</th>
-              <td>{{ plateResults.age }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Classification</th>
-              <td>{{ plateResults.name }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      <table class="table">
+        <tbody>
+          <tr>
+            <th scope="row">Age</th>
+            <td>{{ results.geology.age }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Classification</th>
+            <td>{{ results.geology.name }}</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>
@@ -29,31 +27,12 @@ import { mapGetters } from 'vuex'
 
 export default {
   name: 'GeologyReport',
-  data() {
-    return {
-      // Will have the results of the data fetch.
-      plateResults: {},
-    }
-  },
+
   computed: {
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
-      isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
-  },
-
-  watch: {
-    latLng: function () {
-      this.$fetch()
-    },
-  },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      this.plateResults = this.results['geology']
-      this.plateResults.place = this.placeName
-    }
   },
 }
 </script>

--- a/components/plates/heating_degree_days/Report.vue
+++ b/components/plates/heating_degree_days/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.heating_degree_days).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/heating_degree_days/Report.vue
+++ b/components/plates/heating_degree_days/Report.vue
@@ -4,102 +4,112 @@
     <hr />
 
     <div id="report">
-      <div
+      <!-- <div
         v-if="
           !$fetchState.pending &&
             !$fetchState.error &&
             Object.keys(results).length > 0
         "
-      >
-        <h3 class="title is-3">
-          Heating degree days data for {{ results.place }}
-        </h3>
+      > -->
+      <h3 class="title is-3">
+        Heating degree days data for {{ plateResults.place }}
+      </h3>
 
-        <HeatingDegreeDaysExplanation />
-        <DataExplanation context="wrf" />
+      <HeatingDegreeDaysExplanation />
+      <DataExplanation context="wrf" />
 
-        <h4 class="title is-4">Heating Degree Days</h4>
+      <h4 class="title is-4">Heating Degree Days</h4>
 
-        <table class="table">
-          <thead>
-            <tr>
-              <th scope="col"></th>
-              <th scope="col">Min</th>
-              <th scope="col">Mean</th>
-              <th scope="col">Max</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Historical (1979-2015)</th>
-              <td>
-                {{ results['historical']['ddmin'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['historical']['ddmean']
-                }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['historical']['ddmax'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Early Century (2010-2039)</th>
-              <td>
-                {{ results['2010-2039']['ddmin'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2010-2039']['ddmean'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2010-2039']['ddmax'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Mid Century (2040-2069)</th>
-              <td>
-                {{ results['2040-2069']['ddmin'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2040-2069']['ddmean'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2040-2069']['ddmax'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Late Century (2070-2099)</th>
-              <td>
-                {{ results['2070-2099']['ddmin'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2070-2099']['ddmean'] }}<UnitWidget unitType="dd" />
-              </td>
-              <td>
-                {{ results['2070-2099']['ddmax'] }}<UnitWidget unitType="dd" />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 class="title is-6">Access to Data</h4>
-        <div class="content">
-          <p>Heating degrees days data was calculated from the following:</p>
-          <ul>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
-                target="_blank"
-                >Historical and Projected Climate Products</a
-              >
-            </li>
-          </ul>
-        </div>
-        <DownloadCsvButton
-          text="Download heating degree days data as CSV"
-          endpoint="mmm/degree_days/heating/all"
-          class="mt-3 mb-5"
-        />
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1979-2015)</th>
+            <td>
+              {{ plateResults['historical']['ddmin']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['historical']['ddmean']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['historical']['ddmax']
+              }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Early Century (2010-2039)</th>
+            <td>
+              {{ plateResults['2010-2039']['ddmin']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2010-2039']['ddmean']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2010-2039']['ddmax']
+              }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040-2069)</th>
+            <td>
+              {{ plateResults['2040-2069']['ddmin']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2040-2069']['ddmean']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2040-2069']['ddmax']
+              }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070-2099)</th>
+            <td>
+              {{ plateResults['2070-2099']['ddmin']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2070-2099']['ddmean']
+              }}<UnitWidget unitType="dd" />
+            </td>
+            <td>
+              {{ plateResults['2070-2099']['ddmax']
+              }}<UnitWidget unitType="dd" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h4 class="title is-6">Access to Data</h4>
+      <div class="content">
+        <p>Heating degrees days data was calculated from the following:</p>
+        <ul>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
+              target="_blank"
+              >Historical and Projected Climate Products</a
+            >
+          </li>
+        </ul>
       </div>
+      <DownloadCsvButton
+        text="Download heating degree days data as CSV"
+        endpoint="mmm/degree_days/heating/all"
+        class="mt-3 mb-5"
+      />
     </div>
   </div>
 </template>
@@ -122,37 +132,32 @@ export default {
   data() {
     return {
       // Will have the results of the data fetch.
-      results: {},
+      placeResults: null,
     }
   },
 
   computed: {
-    state: function() {
-      return this.$fetchState
-    },
     ...mapGetters({
+      results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       latLng: 'report/latLng',
     }),
   },
-
+  data() {
+    return {
+      plateResults: null,
+    }
+  },
   watch: {
-    latLng: function() {
+    latLng: function () {
       this.$fetch()
     },
   },
   async fetch() {
     if (this.isPlaceDefined) {
-      this.results = await this.$axios.$get(
-        process.env.apiUrl +
-          '/eds/degree_days/heating/' +
-          this.latLng.lat +
-          '/' +
-          this.latLng.lng
-      )
-
-      this.results.place = this.placeName
+      this.plateResults = this.results['heating_degree_days']
+      this.plateResults.place = this.placeName
     }
   },
 }

--- a/components/plates/heating_degree_days/Report.vue
+++ b/components/plates/heating_degree_days/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/components/plates/heating_degree_days/Report.vue
+++ b/components/plates/heating_degree_days/Report.vue
@@ -4,16 +4,7 @@
     <hr />
 
     <div id="report">
-      <!-- <div
-        v-if="
-          !$fetchState.pending &&
-            !$fetchState.error &&
-            Object.keys(results).length > 0
-        "
-      > -->
-      <h3 class="title is-3">
-        Heating degree days data for {{ plateResults.place }}
-      </h3>
+      <h3 class="title is-3">Heating degree days data for {{ placeName }}</h3>
 
       <HeatingDegreeDaysExplanation />
       <DataExplanation context="wrf" />
@@ -33,60 +24,60 @@
           <tr>
             <th scope="row">Historical (1979-2015)</th>
             <td>
-              {{ plateResults['historical']['ddmin']
+              {{ results.heating_degree_days['historical']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['historical']['ddmean']
+              {{ results.heating_degree_days['historical']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['historical']['ddmax']
+              {{ results.heating_degree_days['historical']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Early Century (2010-2039)</th>
             <td>
-              {{ plateResults['2010-2039']['ddmin']
+              {{ results.heating_degree_days['2010-2039']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2010-2039']['ddmean']
+              {{ results.heating_degree_days['2010-2039']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2010-2039']['ddmax']
+              {{ results.heating_degree_days['2010-2039']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040-2069)</th>
             <td>
-              {{ plateResults['2040-2069']['ddmin']
+              {{ results.heating_degree_days['2040-2069']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2040-2069']['ddmean']
+              {{ results.heating_degree_days['2040-2069']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2040-2069']['ddmax']
+              {{ results.heating_degree_days['2040-2069']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070-2099)</th>
             <td>
-              {{ plateResults['2070-2099']['ddmin']
+              {{ results.heating_degree_days['2070-2099']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2070-2099']['ddmean']
+              {{ results.heating_degree_days['2070-2099']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ plateResults['2070-2099']['ddmax']
+              {{ results.heating_degree_days['2070-2099']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
@@ -129,36 +120,12 @@ export default {
     DataExplanation,
     UnitWidget,
   },
-  data() {
-    return {
-      // Will have the results of the data fetch.
-      placeResults: null,
-    }
-  },
 
   computed: {
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
-      isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
-  },
-  data() {
-    return {
-      plateResults: null,
-    }
-  },
-  watch: {
-    latLng: function () {
-      this.$fetch()
-    },
-  },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      this.plateResults = this.results['heating_degree_days']
-      this.plateResults.place = this.placeName
-    }
   },
 }
 </script>

--- a/components/plates/permafrost/Report.vue
+++ b/components/plates/permafrost/Report.vue
@@ -4,14 +4,7 @@
     <hr />
 
     <div id="report">
-      <h3 class="title is-3">Permafrost data for {{ plateResults.place }}</h3>
-
-      <UnitRadio
-        class="my-5"
-        :patterns="[
-          { type: 'temperature', substring: 'magt_', variable: 'permafrost' },
-        ]"
-      />
+      <h3 class="title is-3">Permafrost data for {{ placeName }}</h3>
 
       <h4 class="title is-4">GIPL Mean Annual Ground Temperature</h4>
 
@@ -27,20 +20,20 @@
           <tr>
             <th scope="row">Historical (1995)</th>
             <td>
-              {{ plateResults.gipl_magt_1995 }}<UnitWidget type="light" />
+              {{ results.permafrost.gipl_magt_1995 }}<UnitWidget type="light" />
             </td>
             <td></td>
           </tr>
           <tr>
             <th scope="row">2011 - 2040</th>
             <td>
-              {{ plateResults.gipl_magt_2025 }}<UnitWidget type="light" />
+              {{ results.permafrost.gipl_magt_2025 }}<UnitWidget type="light" />
             </td>
             <td>
               {{
                 signedDiff(
-                  plateResults.gipl_magt_1995,
-                  plateResults.gipl_magt_2025,
+                  results.permafrost.gipl_magt_1995,
+                  results.permafrost.gipl_magt_2025,
                   'magt'
                 )
               }}<UnitWidget type="light" />
@@ -49,13 +42,13 @@
           <tr>
             <th scope="row">2036 - 2065</th>
             <td>
-              {{ plateResults.gipl_magt_2050 }}<UnitWidget type="light" />
+              {{ results.permafrost.gipl_magt_2050 }}<UnitWidget type="light" />
             </td>
             <td>
               {{
                 signedDiff(
-                  plateResults.gipl_magt_1995,
-                  plateResults.gipl_magt_2050,
+                  results.permafrost.gipl_magt_1995,
+                  results.permafrost.gipl_magt_2050,
                   'magt'
                 )
               }}<UnitWidget type="light" />
@@ -64,13 +57,13 @@
           <tr>
             <th scope="row">2061 – 2090</th>
             <td>
-              {{ plateResults.gipl_magt_2075 }}<UnitWidget type="light" />
+              {{ results.permafrost.gipl_magt_2075 }}<UnitWidget type="light" />
             </td>
             <td>
               {{
                 signedDiff(
-                  plateResults.gipl_magt_1995,
-                  plateResults.gipl_magt_2075,
+                  results.permafrost.gipl_magt_1995,
+                  results.permafrost.gipl_magt_2075,
                   'magt'
                 )
               }}<UnitWidget type="light" />
@@ -79,13 +72,13 @@
           <tr>
             <th scope="row">2086 – 2100</th>
             <td>
-              {{ plateResults.gipl_magt_2095 }}<UnitWidget type="light" />
+              {{ results.permafrost.gipl_magt_2095 }}<UnitWidget type="light" />
             </td>
             <td>
               {{
                 signedDiff(
-                  plateResults.gipl_magt_1995,
-                  plateResults.gipl_magt_2095,
+                  results.permafrost.gipl_magt_1995,
+                  results.permafrost.gipl_magt_2095,
                   'magt'
                 )
               }}<UnitWidget type="light" />
@@ -97,25 +90,25 @@
       <h4 class="title is-6 mt-5">Additional data</h4>
       <div class="content">
         <ul>
-          <li v-if="plateResults.magt_2018">
+          <li v-if="results.permafrost.magt_2018">
             Obu et al. (2018) Mean Annual Ground Temperature at Top of
             Permafrost:
             <strong
-              >{{ plateResults.magt_2018
+              >{{ results.permafrost.magt_2018
               }}<UnitWidget unitType="temp" type="light"
             /></strong>
           </li>
-          <li v-if="plateResults.giv_2008">
+          <li v-if="results.permafrost.giv_2008">
             Jorgenson et al. (2008) Ground Ice Volume:
-            <strong>{{ plateResults.giv_2008 }}</strong>
+            <strong>{{ results.permafrost.giv_2008 }}</strong>
           </li>
-          <li v-if="plateResults.pe_2008">
+          <li v-if="results.permafrost.pe_2008">
             Jorgenson et al. (2008) Permafrost Extent:
-            <strong>{{ plateResults.pe_2008 }}</strong>
+            <strong>{{ results.permafrost.pe_2008 }}</strong>
           </li>
-          <li v-if="plateResults.pe_2018">
+          <li v-if="results.permafrost.pe_2018">
             Obu et al. (2018) Permafrost Extent:
-            <strong>{{ plateResults.pe_2018 }}</strong>
+            <strong>{{ results.permafrost.pe_2018 }}</strong>
           </li>
         </ul>
       </div>
@@ -144,8 +137,6 @@ export default {
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
-      units: 'report/units',
     }),
   },
   methods: {
@@ -163,62 +154,53 @@ export default {
     },
   },
   watch: {
-    latLng: function () {
+    isPlaceDefined: function () {
       this.$fetch()
     },
   },
-  data() {
-    return {
-      plateResults: null,
+  fetch() {
+    let plateResults = {
+      // "magt_" substrings are converted between °C and °F
+      gipl_magt_1995:
+        this.results['permafrost']['gipl']['1995']['cruts31']['historical'][
+          'magt'
+        ],
+      gipl_magt_2025:
+        this.results['permafrost']['gipl']['2025']['ncarccsm4']['rcp85'][
+          'magt'
+        ],
+      gipl_magt_2050:
+        this.results['permafrost']['gipl']['2050']['ncarccsm4']['rcp85'][
+          'magt'
+        ],
+      gipl_magt_2075:
+        this.results['permafrost']['gipl']['2075']['ncarccsm4']['rcp85'][
+          'magt'
+        ],
+      gipl_magt_2095:
+        this.results['permafrost']['gipl']['2095']['ncarccsm4']['rcp85'][
+          'magt'
+        ],
     }
-  },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      let place = this.placeName
 
-      this.plateResults = {
-        place: place,
-
-        // "magt_" substrings are converted between °C and °F
-        gipl_magt_1995:
-          this.results['permafrost']['gipl']['1995']['cruts31']['historical'][
-            'magt'
-          ],
-        gipl_magt_2025:
-          this.results['permafrost']['gipl']['2025']['ncarccsm4']['rcp85'][
-            'magt'
-          ],
-        gipl_magt_2050:
-          this.results['permafrost']['gipl']['2050']['ncarccsm4']['rcp85'][
-            'magt'
-          ],
-        gipl_magt_2075:
-          this.results['permafrost']['gipl']['2075']['ncarccsm4']['rcp85'][
-            'magt'
-          ],
-        gipl_magt_2095:
-          this.results['permafrost']['gipl']['2095']['ncarccsm4']['rcp85'][
-            'magt'
-          ],
-      }
-
-      if (this.results['permafrost']['jorg'] != null) {
-        this.plateResults['giv_2008'] =
-          this.results['permafrost']['jorg']['ice']
-        this.plateResults['pe_2008'] = this.results['permafrost']['jorg']['pfx']
-      }
-
-      if (this.results['permafrost']['obu_magt'] != null) {
-        // "magt_" substrings are converted between °C and °F
-        this.plateResults['magt_2018'] =
-          this.results['permafrost']['obu_magt']['temp']
-      }
-
-      if (this.results['permafrost']['obupfx'] != null) {
-        this.plateResults['pe_2018'] =
-          this.results['permafrost']['obupfx']['pfx']
-      }
+    if (this.results['permafrost']['jorg'] != null) {
+      plateResults['giv_2008'] = this.results['permafrost']['jorg']['ice']
+      plateResults['pe_2008'] = this.results['permafrost']['jorg']['pfx']
     }
+
+    if (this.results['permafrost']['obu_magt'] != null) {
+      // "magt_" substrings are converted between °C and °F
+      plateResults['magt_2018'] = this.results['permafrost']['obu_magt']['temp']
+    }
+
+    if (this.results['permafrost']['obupfx'] != null) {
+      plateResults['pe_2018'] = this.results['permafrost']['obupfx']['pfx']
+    }
+
+    this.$store.commit('report/setPlateResults', {
+      plateResults: plateResults,
+      variable: 'permafrost',
+    })
   },
 }
 </script>

--- a/components/plates/permafrost/Report.vue
+++ b/components/plates/permafrost/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.permafrost).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/permafrost/Report.vue
+++ b/components/plates/permafrost/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/components/plates/permafrost/Report.vue
+++ b/components/plates/permafrost/Report.vue
@@ -4,121 +4,126 @@
     <hr />
 
     <div id="report">
-      <div
-        v-if="
-          !$fetchState.pending &&
-            !$fetchState.error &&
-            Object.keys(results).length > 0
-        "
-      >
-        <h3 class="title is-3">Permafrost data for {{ results.place }}</h3>
+      <h3 class="title is-3">Permafrost data for {{ plateResults.place }}</h3>
 
-        <UnitRadio
-          class="my-5"
-          :patterns="[{ type: 'temperature', substring: 'magt_' }]"
-        />
+      <UnitRadio
+        class="my-5"
+        :patterns="[
+          { type: 'temperature', substring: 'magt_', variable: 'permafrost' },
+        ]"
+      />
 
-        <h4 class="title is-4">GIPL Mean Annual Ground Temperature</h4>
+      <h4 class="title is-4">GIPL Mean Annual Ground Temperature</h4>
 
-        <table class="table">
-          <thead>
-            <tr>
-              <th scope="col"></th>
-              <th scope="col">MAGT</th>
-              <th scope="col">Change from Historical</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Historical (1995)</th>
-              <td>{{ results.gipl_magt_1995 }}<UnitWidget type="light" /></td>
-              <td></td>
-            </tr>
-            <tr>
-              <th scope="row">2011 - 2040</th>
-              <td>{{ results.gipl_magt_2025 }}<UnitWidget type="light" /></td>
-              <td>
-                {{
-                  signedDiff(
-                    results.gipl_magt_1995,
-                    results.gipl_magt_2025,
-                    'magt'
-                  )
-                }}<UnitWidget type="light" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">2036 - 2065</th>
-              <td>{{ results.gipl_magt_2050 }}<UnitWidget type="light" /></td>
-              <td>
-                {{
-                  signedDiff(
-                    results.gipl_magt_1995,
-                    results.gipl_magt_2050,
-                    'magt'
-                  )
-                }}<UnitWidget type="light" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">2061 – 2090</th>
-              <td>{{ results.gipl_magt_2075 }}<UnitWidget type="light" /></td>
-              <td>
-                {{
-                  signedDiff(
-                    results.gipl_magt_1995,
-                    results.gipl_magt_2075,
-                    'magt'
-                  )
-                }}<UnitWidget type="light" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">2086 – 2100</th>
-              <td>{{ results.gipl_magt_2095 }}<UnitWidget type="light" /></td>
-              <td>
-                {{
-                  signedDiff(
-                    results.gipl_magt_1995,
-                    results.gipl_magt_2095,
-                    'magt'
-                  )
-                }}<UnitWidget type="light" />
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">MAGT</th>
+            <th scope="col">Change from Historical</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1995)</th>
+            <td>
+              {{ plateResults.gipl_magt_1995 }}<UnitWidget type="light" />
+            </td>
+            <td></td>
+          </tr>
+          <tr>
+            <th scope="row">2011 - 2040</th>
+            <td>
+              {{ plateResults.gipl_magt_2025 }}<UnitWidget type="light" />
+            </td>
+            <td>
+              {{
+                signedDiff(
+                  plateResults.gipl_magt_1995,
+                  plateResults.gipl_magt_2025,
+                  'magt'
+                )
+              }}<UnitWidget type="light" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">2036 - 2065</th>
+            <td>
+              {{ plateResults.gipl_magt_2050 }}<UnitWidget type="light" />
+            </td>
+            <td>
+              {{
+                signedDiff(
+                  plateResults.gipl_magt_1995,
+                  plateResults.gipl_magt_2050,
+                  'magt'
+                )
+              }}<UnitWidget type="light" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">2061 – 2090</th>
+            <td>
+              {{ plateResults.gipl_magt_2075 }}<UnitWidget type="light" />
+            </td>
+            <td>
+              {{
+                signedDiff(
+                  plateResults.gipl_magt_1995,
+                  plateResults.gipl_magt_2075,
+                  'magt'
+                )
+              }}<UnitWidget type="light" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">2086 – 2100</th>
+            <td>
+              {{ plateResults.gipl_magt_2095 }}<UnitWidget type="light" />
+            </td>
+            <td>
+              {{
+                signedDiff(
+                  plateResults.gipl_magt_1995,
+                  plateResults.gipl_magt_2095,
+                  'magt'
+                )
+              }}<UnitWidget type="light" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-        <h4 class="title is-6 mt-5">Additional data</h4>
-        <div class="content">
-          <ul>
-            <li v-if="results.magt_2018">
-              Obu et al. (2018) Mean Annual Ground Temperature at Top of
-              Permafrost:
-              <strong
-                >{{ results.magt_2018 }}<UnitWidget unitType="temp" type="light"
-              /></strong>
-            </li>
-            <li v-if="results.giv_2008">
-              Jorgenson et al. (2008) Ground Ice Volume:
-              <strong>{{ results.giv_2008 }}</strong>
-            </li>
-            <li v-if="results.pe_2008">
-              Jorgenson et al. (2008) Permafrost Extent:
-              <strong>{{ results.pe_2008 }}</strong>
-            </li>
-            <li v-if="results.pe_2018">
-              Obu et al. (2018) Permafrost Extent:
-              <strong>{{ results.pe_2018 }}</strong>
-            </li>
-          </ul>
-        </div>
-        <DownloadCsvButton
-          text="Download permafrost data as CSV"
-          endpoint="permafrost/point"
-          class="mt-3 mb-5"
-        />
+      <h4 class="title is-6 mt-5">Additional data</h4>
+      <div class="content">
+        <ul>
+          <li v-if="plateResults.magt_2018">
+            Obu et al. (2018) Mean Annual Ground Temperature at Top of
+            Permafrost:
+            <strong
+              >{{ plateResults.magt_2018
+              }}<UnitWidget unitType="temp" type="light"
+            /></strong>
+          </li>
+          <li v-if="plateResults.giv_2008">
+            Jorgenson et al. (2008) Ground Ice Volume:
+            <strong>{{ plateResults.giv_2008 }}</strong>
+          </li>
+          <li v-if="plateResults.pe_2008">
+            Jorgenson et al. (2008) Permafrost Extent:
+            <strong>{{ plateResults.pe_2008 }}</strong>
+          </li>
+          <li v-if="plateResults.pe_2018">
+            Obu et al. (2018) Permafrost Extent:
+            <strong>{{ plateResults.pe_2018 }}</strong>
+          </li>
+        </ul>
       </div>
+      <DownloadCsvButton
+        text="Download permafrost data as CSV"
+        endpoint="permafrost/point"
+        class="mt-3 mb-5"
+      />
     </div>
   </div>
 </template>
@@ -135,9 +140,6 @@ export default {
     UnitWidget,
   },
   computed: {
-    state: function() {
-      return this.$fetchState
-    },
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
@@ -161,59 +163,61 @@ export default {
     },
   },
   watch: {
-    latLng: function() {
+    latLng: function () {
       this.$fetch()
     },
   },
+  data() {
+    return {
+      plateResults: null,
+    }
+  },
   async fetch() {
     if (this.isPlaceDefined) {
-      let url =
-        process.env.apiUrl +
-        '/permafrost/point/' +
-        this.latLng.lat +
-        '/' +
-        this.latLng.lng
-
-      await this.$store.dispatch('report/apiFetch', url)
-
       let place = this.placeName
 
-      let plateResults = {
+      this.plateResults = {
         place: place,
 
         // "magt_" substrings are converted between °C and °F
-        gipl_magt_1995: this.results['gipl']['1995']['cruts31']['historical'][
-          'magt'
-        ],
-        gipl_magt_2025: this.results['gipl']['2025']['ncarccsm4']['rcp85'][
-          'magt'
-        ],
-        gipl_magt_2050: this.results['gipl']['2050']['ncarccsm4']['rcp85'][
-          'magt'
-        ],
-        gipl_magt_2075: this.results['gipl']['2075']['ncarccsm4']['rcp85'][
-          'magt'
-        ],
-        gipl_magt_2095: this.results['gipl']['2095']['ncarccsm4']['rcp85'][
-          'magt'
-        ],
+        gipl_magt_1995:
+          this.results['permafrost']['gipl']['1995']['cruts31']['historical'][
+            'magt'
+          ],
+        gipl_magt_2025:
+          this.results['permafrost']['gipl']['2025']['ncarccsm4']['rcp85'][
+            'magt'
+          ],
+        gipl_magt_2050:
+          this.results['permafrost']['gipl']['2050']['ncarccsm4']['rcp85'][
+            'magt'
+          ],
+        gipl_magt_2075:
+          this.results['permafrost']['gipl']['2075']['ncarccsm4']['rcp85'][
+            'magt'
+          ],
+        gipl_magt_2095:
+          this.results['permafrost']['gipl']['2095']['ncarccsm4']['rcp85'][
+            'magt'
+          ],
       }
 
-      if (this.results['jorg'] != null) {
-        plateResults['giv_2008'] = this.results['jorg']['ice']
-        plateResults['pe_2008'] = this.results['jorg']['pfx']
+      if (this.results['permafrost']['jorg'] != null) {
+        this.plateResults['giv_2008'] =
+          this.results['permafrost']['jorg']['ice']
+        this.plateResults['pe_2008'] = this.results['permafrost']['jorg']['pfx']
       }
 
-      if (this.results['obu_magt'] != null) {
+      if (this.results['permafrost']['obu_magt'] != null) {
         // "magt_" substrings are converted between °C and °F
-        plateResults['magt_2018'] = this.results['obu_magt']['temp']
+        this.plateResults['magt_2018'] =
+          this.results['permafrost']['obu_magt']['temp']
       }
 
-      if (this.results['obupfx'] != null) {
-        plateResults['pe_2018'] = this.results['obupfx']['pfx']
+      if (this.results['permafrost']['obupfx'] != null) {
+        this.plateResults['pe_2018'] =
+          this.results['permafrost']['obupfx']['pfx']
       }
-
-      this.$store.commit('report/setResults', plateResults)
     }
   },
 }

--- a/components/plates/precipitation/Report.vue
+++ b/components/plates/precipitation/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.precipitation).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/precipitation/Report.vue
+++ b/components/plates/precipitation/Report.vue
@@ -4,119 +4,113 @@
     <hr />
 
     <div id="report">
-      <div
-        v-if="
-          !$fetchState.pending &&
-          !$fetchState.error &&
-          Object.keys(results).length > 0
-        "
-      >
-        <h3 class="title is-3">Precipitation data for {{ results.place }}</h3>
+      <h3 class="title is-3">
+        Precipitation data for {{ plateResults.place }}
+      </h3>
 
-        <PrecipitationExplanation />
-        <DataExplanation context="snap" />
+      <PrecipitationExplanation />
+      <DataExplanation context="snap" />
 
-        <h4 class="title is-4">Annual Precipitation Totals</h4>
+      <h4 class="title is-4">Annual Precipitation Totals</h4>
 
-        <UnitRadio type="mm_in" />
+      <UnitRadio type="mm_in" variable="precipitation" />
 
-        <table class="table">
-          <thead>
-            <tr>
-              <th scope="col"></th>
-              <th scope="col">Min</th>
-              <th scope="col">Mean</th>
-              <th scope="col">Max</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Historical (1901-2015)</th>
-              <td>
-                {{ results.pr_hist_min
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-              <td>
-                {{ results.pr_hist_mean
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-              <td>
-                {{ results.pr_hist_max
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Early Century (2010-2039)</th>
-              <td>
-                {{ results.pr_2040_min
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-              <td>
-                {{ results.pr_2040_mean
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-              <td>
-                {{ results.pr_2040_max
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Mid Century (2040-2069)</th>
-              <td>
-                {{ results.pr_2070_min
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-              <td>
-                {{ results.pr_2070_mean
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-              <td>
-                {{ results.pr_2070_max
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Late Century (2070-2099)</th>
-              <td>
-                {{ results.pr_2100_min
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-              <td>
-                {{ results.pr_2100_mean
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-              <td>
-                {{ results.pr_2100_max
-                }}<UnitWidget unitType="mm_in" type="light" />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 class="title is-6">Access to Data</h4>
-        <div class="content">
-          <ul>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/historical-monthly-and-derived-precipitation-products-downscaled-from-cru-ts-data-via-the-delta"
-                target="_blank"
-                >Historical Monthly and Derived Precipitation Products</a
-              >
-            </li>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/projected-monthly-and-derived-precipitation-products-2km-cmip5-ar5"
-                target="_blank"
-                >Projected Monthly and Derived Precipitation Products</a
-              >
-            </li>
-          </ul>
-        </div>
-        <DownloadCsvButton
-          text="Download precipitation data as CSV"
-          endpoint="mmm/precipitation/all"
-          class="mt-3 mb-5"
-        />
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1901-2015)</th>
+            <td>
+              {{ plateResults.pr_hist_min
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+            <td>
+              {{ plateResults.pr_hist_mean
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+            <td>
+              {{ plateResults.pr_hist_max
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Early Century (2010-2039)</th>
+            <td>
+              {{ plateResults.pr_2040_min
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+            <td>
+              {{ plateResults.pr_2040_mean
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+            <td>
+              {{ plateResults.pr_2040_max
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040-2069)</th>
+            <td>
+              {{ plateResults.pr_2070_min
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+            <td>
+              {{ plateResults.pr_2070_mean
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+            <td>
+              {{ plateResults.pr_2070_max
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070-2099)</th>
+            <td>
+              {{ plateResults.pr_2100_min
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+            <td>
+              {{ plateResults.pr_2100_mean
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+            <td>
+              {{ plateResults.pr_2100_max
+              }}<UnitWidget unitType="mm_in" type="light" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h4 class="title is-6">Access to Data</h4>
+      <div class="content">
+        <ul>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/historical-monthly-and-derived-precipitation-products-downscaled-from-cru-ts-data-via-the-delta"
+              target="_blank"
+              >Historical Monthly and Derived Precipitation Products</a
+            >
+          </li>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/projected-monthly-and-derived-precipitation-products-2km-cmip5-ar5"
+              target="_blank"
+              >Projected Monthly and Derived Precipitation Products</a
+            >
+          </li>
+        </ul>
       </div>
+      <DownloadCsvButton
+        text="Download precipitation data as CSV"
+        endpoint="mmm/precipitation/all"
+        class="mt-3 mb-5"
+      />
     </div>
   </div>
 </template>
@@ -139,15 +133,17 @@ export default {
     DataExplanation,
   },
   computed: {
-    state: function () {
-      return this.$fetchState
-    },
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       latLng: 'report/latLng',
     }),
+  },
+  data() {
+    return {
+      plateResults: null,
+    }
   },
   watch: {
     latLng: function () {
@@ -156,34 +152,21 @@ export default {
   },
   async fetch() {
     if (this.isPlaceDefined) {
-      let url =
-        process.env.apiUrl +
-        '/eds/precipitation/' +
-        this.latLng.lat +
-        '/' +
-        this.latLng.lng
-
-      await this.$store.dispatch('report/apiFetch', url)
-
-      let place = this.placeName
-
-      let plateResults = {
-        place: place,
-        pr_hist_min: this.results['historical']['prmin'],
-        pr_hist_mean: this.results['historical']['prmean'],
-        pr_hist_max: this.results['historical']['prmax'],
-        pr_2040_min: this.results['2010-2039']['prmin'],
-        pr_2040_mean: this.results['2010-2039']['prmean'],
-        pr_2040_max: this.results['2010-2039']['prmax'],
-        pr_2070_min: this.results['2040-2069']['prmin'],
-        pr_2070_mean: this.results['2040-2069']['prmean'],
-        pr_2070_max: this.results['2040-2069']['prmax'],
-        pr_2100_min: this.results['2070-2099']['prmin'],
-        pr_2100_mean: this.results['2070-2099']['prmean'],
-        pr_2100_max: this.results['2070-2099']['prmax'],
+      this.plateResults = {
+        place: this.placeName,
+        pr_hist_min: this.results['precipitation']['historical']['prmin'],
+        pr_hist_mean: this.results['precipitation']['historical']['prmean'],
+        pr_hist_max: this.results['precipitation']['historical']['prmax'],
+        pr_2040_min: this.results['precipitation']['2010-2039']['prmin'],
+        pr_2040_mean: this.results['precipitation']['2010-2039']['prmean'],
+        pr_2040_max: this.results['precipitation']['2010-2039']['prmax'],
+        pr_2070_min: this.results['precipitation']['2040-2069']['prmin'],
+        pr_2070_mean: this.results['precipitation']['2040-2069']['prmean'],
+        pr_2070_max: this.results['precipitation']['2040-2069']['prmax'],
+        pr_2100_min: this.results['precipitation']['2070-2099']['prmin'],
+        pr_2100_mean: this.results['precipitation']['2070-2099']['prmean'],
+        pr_2100_max: this.results['precipitation']['2070-2099']['prmax'],
       }
-
-      this.$store.commit('report/setResults', plateResults)
     }
   },
 }

--- a/components/plates/precipitation/Report.vue
+++ b/components/plates/precipitation/Report.vue
@@ -4,16 +4,12 @@
     <hr />
 
     <div id="report">
-      <h3 class="title is-3">
-        Precipitation data for {{ plateResults.place }}
-      </h3>
+      <h3 class="title is-3">Precipitation data for {{ placeName }}</h3>
 
       <PrecipitationExplanation />
       <DataExplanation context="snap" />
 
       <h4 class="title is-4">Annual Precipitation Totals</h4>
-
-      <UnitRadio type="mm_in" variable="precipitation" />
 
       <table class="table">
         <thead>
@@ -28,60 +24,60 @@
           <tr>
             <th scope="row">Historical (1901-2015)</th>
             <td>
-              {{ plateResults.pr_hist_min
+              {{ results.precipitation.pr_hist_min
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
             <td>
-              {{ plateResults.pr_hist_mean
+              {{ results.precipitation.pr_hist_mean
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
             <td>
-              {{ plateResults.pr_hist_max
+              {{ results.precipitation.pr_hist_max
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
           </tr>
           <tr>
             <th scope="row">Early Century (2010-2039)</th>
             <td>
-              {{ plateResults.pr_2040_min
+              {{ results.precipitation.pr_2040_min
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
             <td>
-              {{ plateResults.pr_2040_mean
+              {{ results.precipitation.pr_2040_mean
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
             <td>
-              {{ plateResults.pr_2040_max
+              {{ results.precipitation.pr_2040_max
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040-2069)</th>
             <td>
-              {{ plateResults.pr_2070_min
+              {{ results.precipitation.pr_2070_min
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
             <td>
-              {{ plateResults.pr_2070_mean
+              {{ results.precipitation.pr_2070_mean
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
             <td>
-              {{ plateResults.pr_2070_max
+              {{ results.precipitation.pr_2070_max
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070-2099)</th>
             <td>
-              {{ plateResults.pr_2100_min
+              {{ results.precipitation.pr_2100_min
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
             <td>
-              {{ plateResults.pr_2100_mean
+              {{ results.precipitation.pr_2100_mean
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
             <td>
-              {{ plateResults.pr_2100_max
+              {{ results.precipitation.pr_2100_max
               }}<UnitWidget unitType="mm_in" type="light" />
             </td>
           </tr>
@@ -137,37 +133,32 @@ export default {
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
   },
-  data() {
-    return {
-      plateResults: null,
-    }
-  },
   watch: {
-    latLng: function () {
+    isPlaceDefined: function () {
       this.$fetch()
     },
   },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      this.plateResults = {
-        place: this.placeName,
-        pr_hist_min: this.results['precipitation']['historical']['prmin'],
-        pr_hist_mean: this.results['precipitation']['historical']['prmean'],
-        pr_hist_max: this.results['precipitation']['historical']['prmax'],
-        pr_2040_min: this.results['precipitation']['2010-2039']['prmin'],
-        pr_2040_mean: this.results['precipitation']['2010-2039']['prmean'],
-        pr_2040_max: this.results['precipitation']['2010-2039']['prmax'],
-        pr_2070_min: this.results['precipitation']['2040-2069']['prmin'],
-        pr_2070_mean: this.results['precipitation']['2040-2069']['prmean'],
-        pr_2070_max: this.results['precipitation']['2040-2069']['prmax'],
-        pr_2100_min: this.results['precipitation']['2070-2099']['prmin'],
-        pr_2100_mean: this.results['precipitation']['2070-2099']['prmean'],
-        pr_2100_max: this.results['precipitation']['2070-2099']['prmax'],
-      }
+  fetch() {
+    let plateResults = {
+      pr_hist_min: this.results['precipitation']['historical']['prmin'],
+      pr_hist_mean: this.results['precipitation']['historical']['prmean'],
+      pr_hist_max: this.results['precipitation']['historical']['prmax'],
+      pr_2040_min: this.results['precipitation']['2010-2039']['prmin'],
+      pr_2040_mean: this.results['precipitation']['2010-2039']['prmean'],
+      pr_2040_max: this.results['precipitation']['2010-2039']['prmax'],
+      pr_2070_min: this.results['precipitation']['2040-2069']['prmin'],
+      pr_2070_mean: this.results['precipitation']['2040-2069']['prmean'],
+      pr_2070_max: this.results['precipitation']['2040-2069']['prmax'],
+      pr_2100_min: this.results['precipitation']['2070-2099']['prmin'],
+      pr_2100_mean: this.results['precipitation']['2070-2099']['prmean'],
+      pr_2100_max: this.results['precipitation']['2070-2099']['prmax'],
     }
+    this.$store.commit('report/setPlateResults', {
+      plateResults: plateResults,
+      variable: 'precipitation',
+    })
   },
 }
 </script>

--- a/components/plates/precipitation/Report.vue
+++ b/components/plates/precipitation/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/components/plates/snowfall/Report.vue
+++ b/components/plates/snowfall/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.snowfall).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/snowfall/Report.vue
+++ b/components/plates/snowfall/Report.vue
@@ -4,79 +4,87 @@
     <hr />
 
     <div id="report">
-      <div
+      <!-- <div
         v-if="
           !$fetchState.pending &&
             !$fetchState.error &&
             Object.keys(results).length > 0
         "
-      >
-        <h3 class="title is-3">
-          Snowfall Equivalent data for {{ results.place }}
-        </h3>
+      > -->
+      <h3 class="title is-3">
+        Snowfall Equivalent data for {{ plateResults.place }}
+      </h3>
 
-        <SnowfallExplanation />
-        <DataExplanation context="snap" />
+      <SnowfallExplanation />
+      <DataExplanation context="snap" />
 
-        <h4 class="title is-4">Annual Snowfall Equivalent Totals</h4>
+      <h4 class="title is-4">Annual Snowfall Equivalent Totals</h4>
 
-        <UnitRadio type="mm_in" />
+      <UnitRadio type="mm_in" variable="snowfall" />
 
-        <table class="table">
-          <thead>
-            <tr>
-              <th scope="col"></th>
-              <th scope="col">Min</th>
-              <th scope="col">Mean</th>
-              <th scope="col">Max</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Historical (1910-2009)</th>
-              <td>{{ results.sfe_hist_min }}<UnitWidget unitType="mm_in" /></td>
-              <td>
-                {{ results.sfe_hist_mean }}<UnitWidget unitType="mm_in" />
-              </td>
-              <td>{{ results.sfe_hist_max }}<UnitWidget unitType="mm_in" /></td>
-            </tr>
-            <tr>
-              <th scope="row">Future Projections (2010-2099)</th>
-              <td>{{ results.sfe_proj_min }}<UnitWidget unitType="mm_in" /></td>
-              <td>
-                {{ results.sfe_proj_mean }}<UnitWidget unitType="mm_in" />
-              </td>
-              <td>{{ results.sfe_proj_max }}<UnitWidget unitType="mm_in" /></td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 class="title is-6">Access to Data</h4>
-        <div class="content">
-          <ul>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/historical-decadal-averages-of-monthly-snowfall-equivalent-771m-cru-ts3-0-ts3-1"
-                target="_blank"
-                >Historical Decadal Averages of Monthly Snowfall Equivalent 771m
-                CRU TS3.0/TS3.1</a
-              >
-            </li>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/projected-decadal-averages-of-monthly-snowfall-equivalent-771m-cmip5-ar5"
-                target="_blank"
-                >Projected Decadal Averages of Monthly Snowfall Equivalent 771m
-                CMIP5/AR5</a
-              >
-            </li>
-          </ul>
-        </div>
-        <DownloadCsvButton
-          text="Download snowfall equivalent data as CSV"
-          endpoint="mmm/snow/snowfallequivalent/all"
-          class="mt-3 mb-5"
-        />
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1910-2009)</th>
+            <td>
+              {{ plateResults.sfe_hist_min }}<UnitWidget unitType="mm_in" />
+            </td>
+            <td>
+              {{ plateResults.sfe_hist_mean }}<UnitWidget unitType="mm_in" />
+            </td>
+            <td>
+              {{ plateResults.sfe_hist_max }}<UnitWidget unitType="mm_in" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Future Projections (2010-2099)</th>
+            <td>
+              {{ plateResults.sfe_proj_min }}<UnitWidget unitType="mm_in" />
+            </td>
+            <td>
+              {{ plateResults.sfe_proj_mean }}<UnitWidget unitType="mm_in" />
+            </td>
+            <td>
+              {{ plateResults.sfe_proj_max }}<UnitWidget unitType="mm_in" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h4 class="title is-6">Access to Data</h4>
+      <div class="content">
+        <ul>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/historical-decadal-averages-of-monthly-snowfall-equivalent-771m-cru-ts3-0-ts3-1"
+              target="_blank"
+              >Historical Decadal Averages of Monthly Snowfall Equivalent 771m
+              CRU TS3.0/TS3.1</a
+            >
+          </li>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/projected-decadal-averages-of-monthly-snowfall-equivalent-771m-cmip5-ar5"
+              target="_blank"
+              >Projected Decadal Averages of Monthly Snowfall Equivalent 771m
+              CMIP5/AR5</a
+            >
+          </li>
+        </ul>
       </div>
+      <DownloadCsvButton
+        text="Download snowfall equivalent data as CSV"
+        endpoint="mmm/snow/snowfallequivalent/all"
+        class="mt-3 mb-5"
+      />
+      <!-- </div> -->
     </div>
   </div>
 </template>
@@ -99,9 +107,9 @@ export default {
     DataExplanation,
   },
   computed: {
-    state: function() {
-      return this.$fetchState
-    },
+    // state: function() {
+    //   return this.$fetchState
+    // },
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
@@ -111,33 +119,38 @@ export default {
   },
 
   watch: {
-    latLng: function() {
+    latLng: function () {
       this.$fetch()
     },
   },
+  data() {
+    return {
+      plateResults: null,
+    }
+  },
   async fetch() {
     if (this.isPlaceDefined) {
-      let url =
-        process.env.apiUrl +
-        '/mmm/snow/snowfallequivalent/hp/' +
-        this.latLng.lat +
-        '/' +
-        this.latLng.lng
+      // let url =
+      //   process.env.apiUrl +
+      //   '/mmm/snow/snowfallequivalent/hp/' +
+      //   this.latLng.lat +
+      //   '/' +
+      //   this.latLng.lng
 
-      await this.$store.dispatch('report/apiFetch', url)
+      // await this.$store.dispatch('report/apiFetch', url)
 
       let place = this.placeName
 
-      let plateResults = {
+      this.plateResults = {
         place: place,
-        sfe_hist_min: this.results['historical']['sfemin'],
-        sfe_hist_mean: this.results['historical']['sfemean'],
-        sfe_hist_max: this.results['historical']['sfemax'],
-        sfe_proj_min: this.results['projected']['sfemin'],
-        sfe_proj_mean: this.results['projected']['sfemean'],
-        sfe_proj_max: this.results['projected']['sfemax'],
+        sfe_hist_min: this.results['snowfall']['historical']['sfemin'],
+        sfe_hist_mean: this.results['snowfall']['historical']['sfemean'],
+        sfe_hist_max: this.results['snowfall']['historical']['sfemax'],
+        sfe_proj_min: this.results['snowfall']['projected']['sfemin'],
+        sfe_proj_mean: this.results['snowfall']['projected']['sfemean'],
+        sfe_proj_max: this.results['snowfall']['projected']['sfemax'],
       }
-      this.$store.commit('report/setResults', plateResults)
+      // this.$store.commit('report/setResults', plateResults)
     }
   },
 }

--- a/components/plates/snowfall/Report.vue
+++ b/components/plates/snowfall/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/components/plates/snowfall/Report.vue
+++ b/components/plates/snowfall/Report.vue
@@ -4,23 +4,12 @@
     <hr />
 
     <div id="report">
-      <!-- <div
-        v-if="
-          !$fetchState.pending &&
-            !$fetchState.error &&
-            Object.keys(results).length > 0
-        "
-      > -->
-      <h3 class="title is-3">
-        Snowfall Equivalent data for {{ plateResults.place }}
-      </h3>
+      <h3 class="title is-3">Snowfall Equivalent data for {{ placeName }}</h3>
 
       <SnowfallExplanation />
       <DataExplanation context="snap" />
 
       <h4 class="title is-4">Annual Snowfall Equivalent Totals</h4>
-
-      <UnitRadio type="mm_in" variable="snowfall" />
 
       <table class="table">
         <thead>
@@ -35,29 +24,32 @@
           <tr>
             <th scope="row">Historical (1910-2009)</th>
             <td>
-              {{ plateResults.sfe_hist_min }}<UnitWidget unitType="mm_in" />
+              {{ results.snowfall.sfe_hist_min }}<UnitWidget unitType="mm_in" />
             </td>
             <td>
-              {{ plateResults.sfe_hist_mean }}<UnitWidget unitType="mm_in" />
+              {{ results.snowfall.sfe_hist_mean
+              }}<UnitWidget unitType="mm_in" />
             </td>
             <td>
-              {{ plateResults.sfe_hist_max }}<UnitWidget unitType="mm_in" />
+              {{ results.snowfall.sfe_hist_max }}<UnitWidget unitType="mm_in" />
             </td>
           </tr>
           <tr>
             <th scope="row">Future Projections (2010-2099)</th>
             <td>
-              {{ plateResults.sfe_proj_min }}<UnitWidget unitType="mm_in" />
+              {{ results.snowfall.sfe_proj_min }}<UnitWidget unitType="mm_in" />
             </td>
             <td>
-              {{ plateResults.sfe_proj_mean }}<UnitWidget unitType="mm_in" />
+              {{ results.snowfall.sfe_proj_mean
+              }}<UnitWidget unitType="mm_in" />
             </td>
             <td>
-              {{ plateResults.sfe_proj_max }}<UnitWidget unitType="mm_in" />
+              {{ results.snowfall.sfe_proj_max }}<UnitWidget unitType="mm_in" />
             </td>
           </tr>
         </tbody>
       </table>
+
       <h4 class="title is-6">Access to Data</h4>
       <div class="content">
         <ul>
@@ -84,7 +76,6 @@
         endpoint="mmm/snow/snowfallequivalent/all"
         class="mt-3 mb-5"
       />
-      <!-- </div> -->
     </div>
   </div>
 </template>
@@ -107,51 +98,31 @@ export default {
     DataExplanation,
   },
   computed: {
-    // state: function() {
-    //   return this.$fetchState
-    // },
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
   },
 
   watch: {
-    latLng: function () {
+    isPlaceDefined: function () {
       this.$fetch()
     },
   },
-  data() {
-    return {
-      plateResults: null,
+  fetch() {
+    let plateResults = {
+      sfe_hist_min: this.results['snowfall']['historical']['sfemin'],
+      sfe_hist_mean: this.results['snowfall']['historical']['sfemean'],
+      sfe_hist_max: this.results['snowfall']['historical']['sfemax'],
+      sfe_proj_min: this.results['snowfall']['projected']['sfemin'],
+      sfe_proj_mean: this.results['snowfall']['projected']['sfemean'],
+      sfe_proj_max: this.results['snowfall']['projected']['sfemax'],
     }
-  },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      // let url =
-      //   process.env.apiUrl +
-      //   '/mmm/snow/snowfallequivalent/hp/' +
-      //   this.latLng.lat +
-      //   '/' +
-      //   this.latLng.lng
-
-      // await this.$store.dispatch('report/apiFetch', url)
-
-      let place = this.placeName
-
-      this.plateResults = {
-        place: place,
-        sfe_hist_min: this.results['snowfall']['historical']['sfemin'],
-        sfe_hist_mean: this.results['snowfall']['historical']['sfemean'],
-        sfe_hist_max: this.results['snowfall']['historical']['sfemax'],
-        sfe_proj_min: this.results['snowfall']['projected']['sfemin'],
-        sfe_proj_mean: this.results['snowfall']['projected']['sfemean'],
-        sfe_proj_max: this.results['snowfall']['projected']['sfemax'],
-      }
-      // this.$store.commit('report/setResults', plateResults)
-    }
+    this.$store.commit('report/setPlateResults', {
+      plateResults: plateResults,
+      variable: 'snowfall',
+    })
   },
 }
 </script>

--- a/components/plates/temperature/Explanation.vue
+++ b/components/plates/temperature/Explanation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="content content-clamp" :class="{ 'is-size-5': !legend }">
+  <div class="content content-clamp is-size-5">
     <p>
       Historically, Arctic regions had no months with mean monthly temperatures
       greater than 50&deg;F and had at least one month with a mean temperature

--- a/components/plates/temperature/Report.vue
+++ b/components/plates/temperature/Report.vue
@@ -4,14 +4,12 @@
     <hr />
 
     <div id="report">
-      <h3 class="title is-3">Temperature data for {{ plateResults.place }}</h3>
+      <h3 class="title is-3">Temperature data for {{ placeName }}</h3>
 
       <TemperatureExplanation context="report" />
       <DataExplanation context="snap" />
 
       <h4 class="title is-4">Temperature</h4>
-
-      <UnitRadio type="temperature" variable="temperature" />
 
       <table class="table">
         <thead>
@@ -37,51 +35,51 @@
         <tbody>
           <tr>
             <th scope="row">Historical (1901-2015)</th>
-            <td>{{ plateResults.hist_min }}<UnitWidget /></td>
-            <td>{{ plateResults.hist_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.hist_max }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_hist_min }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_hist_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_hist_max }}<UnitWidget /></td>
-            <td>{{ plateResults.july_hist_min }}<UnitWidget /></td>
-            <td>{{ plateResults.july_hist_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.july_hist_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.hist_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.hist_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.hist_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_hist_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_hist_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_hist_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_hist_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_hist_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_hist_max }}<UnitWidget /></td>
           </tr>
           <tr>
             <th scope="row">Early Century (2010-2039)</th>
-            <td>{{ plateResults.temp_2040_min }}<UnitWidget /></td>
-            <td>{{ plateResults.temp_2040_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.temp_2040_max }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_2040_min }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_2040_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_2040_max }}<UnitWidget /></td>
-            <td>{{ plateResults.july_2040_min }}<UnitWidget /></td>
-            <td>{{ plateResults.july_2040_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.july_2040_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.temp_2040_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.temp_2040_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.temp_2040_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_2040_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_2040_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_2040_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_2040_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_2040_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_2040_max }}<UnitWidget /></td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040-2069)</th>
-            <td>{{ plateResults.temp_2070_min }}<UnitWidget /></td>
-            <td>{{ plateResults.temp_2070_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.temp_2070_max }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_2070_min }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_2070_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_2070_max }}<UnitWidget /></td>
-            <td>{{ plateResults.july_2070_min }}<UnitWidget /></td>
-            <td>{{ plateResults.july_2070_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.july_2070_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.temp_2070_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.temp_2070_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.temp_2070_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_2070_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_2070_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_2070_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_2070_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_2070_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_2070_max }}<UnitWidget /></td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070-2099)</th>
-            <td>{{ plateResults.temp_2100_min }}<UnitWidget /></td>
-            <td>{{ plateResults.temp_2100_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.temp_2100_max }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_2100_min }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_2100_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.jan_2100_max }}<UnitWidget /></td>
-            <td>{{ plateResults.july_2100_min }}<UnitWidget /></td>
-            <td>{{ plateResults.july_2100_mean }}<UnitWidget /></td>
-            <td>{{ plateResults.july_2100_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.temp_2100_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.temp_2100_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.temp_2100_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_2100_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_2100_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.jan_2100_max }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_2100_min }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_2100_mean }}<UnitWidget /></td>
+            <td>{{ results.temperature.july_2100_max }}<UnitWidget /></td>
           </tr>
         </tbody>
       </table>
@@ -146,89 +144,67 @@ export default {
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
   },
-  data() {
-    return {
-      // Will have the results of the data fetch.
-      plateResults: null,
-    }
-  },
+
   watch: {
-    latLng: function () {
+    isPlaceDefined: function () {
       this.$fetch()
     },
   },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      this.plateResults = {
-        place: this.placeName,
-        hist_min: this.results['temperature']['historical']['all']['tasmin'],
-        hist_mean: this.results['temperature']['historical']['all']['tasmean'],
-        hist_max: this.results['temperature']['historical']['all']['tasmax'],
-        jan_hist_min:
-          this.results['temperature']['historical']['jan']['tasmin'],
-        jan_hist_mean:
-          this.results['temperature']['historical']['jan']['tasmean'],
-        jan_hist_max:
-          this.results['temperature']['historical']['jan']['tasmax'],
-        july_hist_min:
-          this.results['temperature']['historical']['july']['tasmin'],
-        july_hist_mean:
-          this.results['temperature']['historical']['july']['tasmean'],
-        july_hist_max:
-          this.results['temperature']['historical']['july']['tasmax'],
-        temp_2040_min:
-          this.results['temperature']['2010-2039']['all']['tasmin'],
-        temp_2040_mean:
-          this.results['temperature']['2010-2039']['all']['tasmean'],
-        temp_2040_max:
-          this.results['temperature']['2010-2039']['all']['tasmax'],
-        jan_2040_min: this.results['temperature']['2010-2039']['jan']['tasmin'],
-        jan_2040_mean:
-          this.results['temperature']['2010-2039']['jan']['tasmean'],
-        jan_2040_max: this.results['temperature']['2010-2039']['jan']['tasmax'],
-        july_2040_min:
-          this.results['temperature']['2010-2039']['july']['tasmin'],
-        july_2040_mean:
-          this.results['temperature']['2010-2039']['july']['tasmean'],
-        july_2040_max:
-          this.results['temperature']['2010-2039']['july']['tasmax'],
-        temp_2070_min:
-          this.results['temperature']['2040-2069']['all']['tasmin'],
-        temp_2070_mean:
-          this.results['temperature']['2040-2069']['all']['tasmean'],
-        temp_2070_max:
-          this.results['temperature']['2040-2069']['all']['tasmax'],
-        jan_2070_min: this.results['temperature']['2040-2069']['jan']['tasmin'],
-        jan_2070_mean:
-          this.results['temperature']['2040-2069']['jan']['tasmean'],
-        jan_2070_max: this.results['temperature']['2040-2069']['jan']['tasmax'],
-        july_2070_min:
-          this.results['temperature']['2040-2069']['july']['tasmin'],
-        july_2070_mean:
-          this.results['temperature']['2040-2069']['july']['tasmean'],
-        july_2070_max:
-          this.results['temperature']['2040-2069']['july']['tasmax'],
-        temp_2100_min:
-          this.results['temperature']['2070-2099']['all']['tasmin'],
-        temp_2100_mean:
-          this.results['temperature']['2070-2099']['all']['tasmean'],
-        temp_2100_max:
-          this.results['temperature']['2070-2099']['all']['tasmax'],
-        jan_2100_min: this.results['temperature']['2070-2099']['jan']['tasmin'],
-        jan_2100_mean:
-          this.results['temperature']['2070-2099']['jan']['tasmean'],
-        jan_2100_max: this.results['temperature']['2070-2099']['jan']['tasmax'],
-        july_2100_min:
-          this.results['temperature']['2070-2099']['july']['tasmin'],
-        july_2100_mean:
-          this.results['temperature']['2070-2099']['july']['tasmean'],
-        july_2100_max:
-          this.results['temperature']['2070-2099']['july']['tasmax'],
-      }
+  fetch() {
+    let plateResults = {
+      hist_min: this.results['temperature']['historical']['all']['tasmin'],
+      hist_mean: this.results['temperature']['historical']['all']['tasmean'],
+      hist_max: this.results['temperature']['historical']['all']['tasmax'],
+      jan_hist_min: this.results['temperature']['historical']['jan']['tasmin'],
+      jan_hist_mean:
+        this.results['temperature']['historical']['jan']['tasmean'],
+      jan_hist_max: this.results['temperature']['historical']['jan']['tasmax'],
+      july_hist_min:
+        this.results['temperature']['historical']['july']['tasmin'],
+      july_hist_mean:
+        this.results['temperature']['historical']['july']['tasmean'],
+      july_hist_max:
+        this.results['temperature']['historical']['july']['tasmax'],
+      temp_2040_min: this.results['temperature']['2010-2039']['all']['tasmin'],
+      temp_2040_mean:
+        this.results['temperature']['2010-2039']['all']['tasmean'],
+      temp_2040_max: this.results['temperature']['2010-2039']['all']['tasmax'],
+      jan_2040_min: this.results['temperature']['2010-2039']['jan']['tasmin'],
+      jan_2040_mean: this.results['temperature']['2010-2039']['jan']['tasmean'],
+      jan_2040_max: this.results['temperature']['2010-2039']['jan']['tasmax'],
+      july_2040_min: this.results['temperature']['2010-2039']['july']['tasmin'],
+      july_2040_mean:
+        this.results['temperature']['2010-2039']['july']['tasmean'],
+      july_2040_max: this.results['temperature']['2010-2039']['july']['tasmax'],
+      temp_2070_min: this.results['temperature']['2040-2069']['all']['tasmin'],
+      temp_2070_mean:
+        this.results['temperature']['2040-2069']['all']['tasmean'],
+      temp_2070_max: this.results['temperature']['2040-2069']['all']['tasmax'],
+      jan_2070_min: this.results['temperature']['2040-2069']['jan']['tasmin'],
+      jan_2070_mean: this.results['temperature']['2040-2069']['jan']['tasmean'],
+      jan_2070_max: this.results['temperature']['2040-2069']['jan']['tasmax'],
+      july_2070_min: this.results['temperature']['2040-2069']['july']['tasmin'],
+      july_2070_mean:
+        this.results['temperature']['2040-2069']['july']['tasmean'],
+      july_2070_max: this.results['temperature']['2040-2069']['july']['tasmax'],
+      temp_2100_min: this.results['temperature']['2070-2099']['all']['tasmin'],
+      temp_2100_mean:
+        this.results['temperature']['2070-2099']['all']['tasmean'],
+      temp_2100_max: this.results['temperature']['2070-2099']['all']['tasmax'],
+      jan_2100_min: this.results['temperature']['2070-2099']['jan']['tasmin'],
+      jan_2100_mean: this.results['temperature']['2070-2099']['jan']['tasmean'],
+      jan_2100_max: this.results['temperature']['2070-2099']['jan']['tasmax'],
+      july_2100_min: this.results['temperature']['2070-2099']['july']['tasmin'],
+      july_2100_mean:
+        this.results['temperature']['2070-2099']['july']['tasmean'],
+      july_2100_max: this.results['temperature']['2070-2099']['july']['tasmax'],
     }
+    this.$store.commit('report/setPlateResults', {
+      plateResults: plateResults,
+      variable: 'temperature',
+    })
   },
 }
 </script>

--- a/components/plates/temperature/Report.vue
+++ b/components/plates/temperature/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/components/plates/temperature/Report.vue
+++ b/components/plates/temperature/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.temperature).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/temperature/Report.vue
+++ b/components/plates/temperature/Report.vue
@@ -2,131 +2,124 @@
   <div>
     <CloseReportButton />
     <hr />
-    
+
     <div id="report">
-      <div
-        v-if="
-          !$fetchState.pending &&
-            !$fetchState.error &&
-            Object.keys(results).length > 0
-        "
-      >
-        <h3 class="title is-3">Temperature data for {{ results.place }}</h3>
+      <h3 class="title is-3">Temperature data for {{ plateResults.place }}</h3>
 
-        <TemperatureExplanation context="report" />
-        <DataExplanation context="snap" />
+      <TemperatureExplanation context="report" />
+      <DataExplanation context="snap" />
 
-        <h4 class="title is-4">Temperature</h4>
+      <h4 class="title is-4">Temperature</h4>
 
-        <UnitRadio type="temperature" />
+      <UnitRadio type="temperature" variable="temperature" />
 
-        <table class="table">
-          <thead>
-            <tr>
-              <th></th>
-              <th scope="col" colspan="3">Annual</th>
-              <th scope="col" colspan="3">January</th>
-              <th scope="col" colspan="3">July</th>
-            </tr>
-            <tr>
-              <th scope="col"></th>
-              <th scope="col">Min</th>
-              <th scope="col">Mean</th>
-              <th scope="col">Max</th>
-              <th scope="col">Min</th>
-              <th scope="col">Mean</th>
-              <th scope="col">Max</th>
-              <th scope="col">Min</th>
-              <th scope="col">Mean</th>
-              <th scope="col">Max</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Historical (1901-2015)</th>
-              <td>{{ results.hist_min }}<UnitWidget /></td>
-              <td>{{ results.hist_mean }}<UnitWidget /></td>
-              <td>{{ results.hist_max }}<UnitWidget /></td>
-              <td>{{ results.jan_hist_min }}<UnitWidget /></td>
-              <td>{{ results.jan_hist_mean }}<UnitWidget /></td>
-              <td>{{ results.jan_hist_max }}<UnitWidget /></td>
-              <td>{{ results.july_hist_min }}<UnitWidget /></td>
-              <td>{{ results.july_hist_mean }}<UnitWidget /></td>
-              <td>{{ results.july_hist_max }}<UnitWidget /></td>
-            </tr>
-            <tr>
-              <th scope="row">Early Century (2010-2039)</th>
-              <td>{{ results.temp_2040_min }}<UnitWidget /></td>
-              <td>{{ results.temp_2040_mean }}<UnitWidget /></td>
-              <td>{{ results.temp_2040_max }}<UnitWidget /></td>
-              <td>{{ results.jan_2040_min }}<UnitWidget /></td>
-              <td>{{ results.jan_2040_mean }}<UnitWidget /></td>
-              <td>{{ results.jan_2040_max }}<UnitWidget /></td>
-              <td>{{ results.july_2040_min }}<UnitWidget /></td>
-              <td>{{ results.july_2040_mean }}<UnitWidget /></td>
-              <td>{{ results.july_2040_max }}<UnitWidget /></td>
-            </tr>
-            <tr>
-              <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results.temp_2070_min }}<UnitWidget /></td>
-              <td>{{ results.temp_2070_mean }}<UnitWidget /></td>
-              <td>{{ results.temp_2070_max }}<UnitWidget /></td>
-              <td>{{ results.jan_2070_min }}<UnitWidget /></td>
-              <td>{{ results.jan_2070_mean }}<UnitWidget /></td>
-              <td>{{ results.jan_2070_max }}<UnitWidget /></td>
-              <td>{{ results.july_2070_min }}<UnitWidget /></td>
-              <td>{{ results.july_2070_mean }}<UnitWidget /></td>
-              <td>{{ results.july_2070_max }}<UnitWidget /></td>
-            </tr>
-            <tr>
-              <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results.temp_2100_min }}<UnitWidget /></td>
-              <td>{{ results.temp_2100_mean }}<UnitWidget /></td>
-              <td>{{ results.temp_2100_max }}<UnitWidget /></td>
-              <td>{{ results.jan_2100_min }}<UnitWidget /></td>
-              <td>{{ results.jan_2100_mean }}<UnitWidget /></td>
-              <td>{{ results.jan_2100_max }}<UnitWidget /></td>
-              <td>{{ results.july_2100_min }}<UnitWidget /></td>
-              <td>{{ results.july_2100_mean }}<UnitWidget /></td>
-              <td>{{ results.july_2100_max }}<UnitWidget /></td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 class="title is-6">Access to Data</h4>
-        <div class="content">
-          <ul>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/historical-monthly-and-derived-temperature-products-downscaled-from-cru-ts-data-via-the-delta-m"
-                target="_blank"
-                >Historical Monthly and Derived Temperature Products</a
-              >
-            </li>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/projected-monthly-and-derived-temperature-products-2km-cmip5-ar5"
-                target="_blank"
-                >Projected Monthly and Derived Temperature Products</a
-              >
-            </li>
-          </ul>
-        </div>
-        <DownloadCsvButton
-          text="Download annual temperature mean data as CSV"
-          endpoint="mmm/temperature/all"
-          class="mt-3 mb-5"
-        />
-        <DownloadCsvButton
-          text="Download annual January temperature min-mean-max as CSV"
-          endpoint="mmm/temperature/jan/all"
-          class="mt-3 mb-5"
-        />
-        <DownloadCsvButton
-          text="Download annual July temperature min-mean-max as CSV"
-          endpoint="mmm/temperature/july/all"
-          class="mt-3 mb-5"
-        />
+      <table class="table">
+        <thead>
+          <tr>
+            <th></th>
+            <th scope="col" colspan="3">Annual</th>
+            <th scope="col" colspan="3">January</th>
+            <th scope="col" colspan="3">July</th>
+          </tr>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1901-2015)</th>
+            <td>{{ plateResults.hist_min }}<UnitWidget /></td>
+            <td>{{ plateResults.hist_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.hist_max }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_hist_min }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_hist_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_hist_max }}<UnitWidget /></td>
+            <td>{{ plateResults.july_hist_min }}<UnitWidget /></td>
+            <td>{{ plateResults.july_hist_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.july_hist_max }}<UnitWidget /></td>
+          </tr>
+          <tr>
+            <th scope="row">Early Century (2010-2039)</th>
+            <td>{{ plateResults.temp_2040_min }}<UnitWidget /></td>
+            <td>{{ plateResults.temp_2040_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.temp_2040_max }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_2040_min }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_2040_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_2040_max }}<UnitWidget /></td>
+            <td>{{ plateResults.july_2040_min }}<UnitWidget /></td>
+            <td>{{ plateResults.july_2040_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.july_2040_max }}<UnitWidget /></td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040-2069)</th>
+            <td>{{ plateResults.temp_2070_min }}<UnitWidget /></td>
+            <td>{{ plateResults.temp_2070_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.temp_2070_max }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_2070_min }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_2070_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_2070_max }}<UnitWidget /></td>
+            <td>{{ plateResults.july_2070_min }}<UnitWidget /></td>
+            <td>{{ plateResults.july_2070_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.july_2070_max }}<UnitWidget /></td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070-2099)</th>
+            <td>{{ plateResults.temp_2100_min }}<UnitWidget /></td>
+            <td>{{ plateResults.temp_2100_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.temp_2100_max }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_2100_min }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_2100_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.jan_2100_max }}<UnitWidget /></td>
+            <td>{{ plateResults.july_2100_min }}<UnitWidget /></td>
+            <td>{{ plateResults.july_2100_mean }}<UnitWidget /></td>
+            <td>{{ plateResults.july_2100_max }}<UnitWidget /></td>
+          </tr>
+        </tbody>
+      </table>
+      <h4 class="title is-6">Access to Data</h4>
+      <div class="content">
+        <ul>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/historical-monthly-and-derived-temperature-products-downscaled-from-cru-ts-data-via-the-delta-m"
+              target="_blank"
+              >Historical Monthly and Derived Temperature Products</a
+            >
+          </li>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/projected-monthly-and-derived-temperature-products-2km-cmip5-ar5"
+              target="_blank"
+              >Projected Monthly and Derived Temperature Products</a
+            >
+          </li>
+        </ul>
       </div>
+      <DownloadCsvButton
+        text="Download annual temperature mean data as CSV"
+        endpoint="mmm/temperature/all"
+        class="mt-3 mb-5"
+      />
+      <DownloadCsvButton
+        text="Download annual January temperature min-mean-max as CSV"
+        endpoint="mmm/temperature/jan/all"
+        class="mt-3 mb-5"
+      />
+      <DownloadCsvButton
+        text="Download annual July temperature min-mean-max as CSV"
+        endpoint="mmm/temperature/july/all"
+        class="mt-3 mb-5"
+      />
+      <!-- </div> -->
     </div>
   </div>
 </template>
@@ -149,9 +142,6 @@ export default {
     DataExplanation,
   },
   computed: {
-    state: function() {
-      return this.$fetchState
-    },
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
@@ -159,66 +149,85 @@ export default {
       latLng: 'report/latLng',
     }),
   },
-
+  data() {
+    return {
+      // Will have the results of the data fetch.
+      plateResults: null,
+    }
+  },
   watch: {
-    latLng: function() {
+    latLng: function () {
       this.$fetch()
     },
   },
   async fetch() {
     if (this.isPlaceDefined) {
-      let url =
-        process.env.apiUrl +
-        '/eds/temperature/' +
-        this.latLng.lat +
-        '/' +
-        this.latLng.lng
-
-      await this.$store.dispatch('report/apiFetch', url)
-
-      let place = this.placeName
-
-      let plateResults = {
-        place: place,
-        hist_min: this.results['historical']['all']['tasmin'],
-        hist_mean: this.results['historical']['all']['tasmean'],
-        hist_max: this.results['historical']['all']['tasmax'],
-        jan_hist_min: this.results['historical']['jan']['tasmin'],
-        jan_hist_mean: this.results['historical']['jan']['tasmean'],
-        jan_hist_max: this.results['historical']['jan']['tasmax'],
-        july_hist_min: this.results['historical']['july']['tasmin'],
-        july_hist_mean: this.results['historical']['july']['tasmean'],
-        july_hist_max: this.results['historical']['july']['tasmax'],
-        temp_2040_min: this.results['2010-2039']['all']['tasmin'],
-        temp_2040_mean: this.results['2010-2039']['all']['tasmean'],
-        temp_2040_max: this.results['2010-2039']['all']['tasmax'],
-        jan_2040_min: this.results['2010-2039']['jan']['tasmin'],
-        jan_2040_mean: this.results['2010-2039']['jan']['tasmean'],
-        jan_2040_max: this.results['2010-2039']['jan']['tasmax'],
-        july_2040_min: this.results['2010-2039']['july']['tasmin'],
-        july_2040_mean: this.results['2010-2039']['july']['tasmean'],
-        july_2040_max: this.results['2010-2039']['july']['tasmax'],
-        temp_2070_min: this.results['2040-2069']['all']['tasmin'],
-        temp_2070_mean: this.results['2040-2069']['all']['tasmean'],
-        temp_2070_max: this.results['2040-2069']['all']['tasmax'],
-        jan_2070_min: this.results['2040-2069']['jan']['tasmin'],
-        jan_2070_mean: this.results['2040-2069']['jan']['tasmean'],
-        jan_2070_max: this.results['2040-2069']['jan']['tasmax'],
-        july_2070_min: this.results['2040-2069']['july']['tasmin'],
-        july_2070_mean: this.results['2040-2069']['july']['tasmean'],
-        july_2070_max: this.results['2040-2069']['july']['tasmax'],
-        temp_2100_min: this.results['2070-2099']['all']['tasmin'],
-        temp_2100_mean: this.results['2070-2099']['all']['tasmean'],
-        temp_2100_max: this.results['2070-2099']['all']['tasmax'],
-        jan_2100_min: this.results['2070-2099']['jan']['tasmin'],
-        jan_2100_mean: this.results['2070-2099']['jan']['tasmean'],
-        jan_2100_max: this.results['2070-2099']['jan']['tasmax'],
-        july_2100_min: this.results['2070-2099']['july']['tasmin'],
-        july_2100_mean: this.results['2070-2099']['july']['tasmean'],
-        july_2100_max: this.results['2070-2099']['july']['tasmax'],
+      this.plateResults = {
+        place: this.placeName,
+        hist_min: this.results['temperature']['historical']['all']['tasmin'],
+        hist_mean: this.results['temperature']['historical']['all']['tasmean'],
+        hist_max: this.results['temperature']['historical']['all']['tasmax'],
+        jan_hist_min:
+          this.results['temperature']['historical']['jan']['tasmin'],
+        jan_hist_mean:
+          this.results['temperature']['historical']['jan']['tasmean'],
+        jan_hist_max:
+          this.results['temperature']['historical']['jan']['tasmax'],
+        july_hist_min:
+          this.results['temperature']['historical']['july']['tasmin'],
+        july_hist_mean:
+          this.results['temperature']['historical']['july']['tasmean'],
+        july_hist_max:
+          this.results['temperature']['historical']['july']['tasmax'],
+        temp_2040_min:
+          this.results['temperature']['2010-2039']['all']['tasmin'],
+        temp_2040_mean:
+          this.results['temperature']['2010-2039']['all']['tasmean'],
+        temp_2040_max:
+          this.results['temperature']['2010-2039']['all']['tasmax'],
+        jan_2040_min: this.results['temperature']['2010-2039']['jan']['tasmin'],
+        jan_2040_mean:
+          this.results['temperature']['2010-2039']['jan']['tasmean'],
+        jan_2040_max: this.results['temperature']['2010-2039']['jan']['tasmax'],
+        july_2040_min:
+          this.results['temperature']['2010-2039']['july']['tasmin'],
+        july_2040_mean:
+          this.results['temperature']['2010-2039']['july']['tasmean'],
+        july_2040_max:
+          this.results['temperature']['2010-2039']['july']['tasmax'],
+        temp_2070_min:
+          this.results['temperature']['2040-2069']['all']['tasmin'],
+        temp_2070_mean:
+          this.results['temperature']['2040-2069']['all']['tasmean'],
+        temp_2070_max:
+          this.results['temperature']['2040-2069']['all']['tasmax'],
+        jan_2070_min: this.results['temperature']['2040-2069']['jan']['tasmin'],
+        jan_2070_mean:
+          this.results['temperature']['2040-2069']['jan']['tasmean'],
+        jan_2070_max: this.results['temperature']['2040-2069']['jan']['tasmax'],
+        july_2070_min:
+          this.results['temperature']['2040-2069']['july']['tasmin'],
+        july_2070_mean:
+          this.results['temperature']['2040-2069']['july']['tasmean'],
+        july_2070_max:
+          this.results['temperature']['2040-2069']['july']['tasmax'],
+        temp_2100_min:
+          this.results['temperature']['2070-2099']['all']['tasmin'],
+        temp_2100_mean:
+          this.results['temperature']['2070-2099']['all']['tasmean'],
+        temp_2100_max:
+          this.results['temperature']['2070-2099']['all']['tasmax'],
+        jan_2100_min: this.results['temperature']['2070-2099']['jan']['tasmin'],
+        jan_2100_mean:
+          this.results['temperature']['2070-2099']['jan']['tasmean'],
+        jan_2100_max: this.results['temperature']['2070-2099']['jan']['tasmax'],
+        july_2100_min:
+          this.results['temperature']['2070-2099']['july']['tasmin'],
+        july_2100_mean:
+          this.results['temperature']['2070-2099']['july']['tasmean'],
+        july_2100_max:
+          this.results['temperature']['2070-2099']['july']['tasmax'],
       }
-
-      this.$store.commit('report/setResults', plateResults)
     }
   },
 }

--- a/components/plates/thawing_index/Report.vue
+++ b/components/plates/thawing_index/Report.vue
@@ -4,74 +4,68 @@
     <hr />
 
     <div id="report">
-      <div
-        v-if="
-          !$fetchState.pending &&
-            !$fetchState.error &&
-            Object.keys(results).length > 0
-        "
-      >
-        <h3 class="title is-3">Thawing index data for {{ results.place }}</h3>
+      <h3 class="title is-3">
+        Thawing index data for {{ plateResults.place }}
+      </h3>
 
-        <ThawingIndexExplanation :isFooter="false" />
+      <ThawingIndexExplanation :isFooter="false" />
 
-        <h4 class="title is-4">Thawing Index</h4>
+      <h4 class="title is-4">Thawing Index</h4>
 
-        <table class="table">
-          <thead>
-            <tr>
-              <th scope="col"></th>
-              <th scope="col">Min</th>
-              <th scope="col">Mean</th>
-              <th scope="col">Max</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Historical (1979-2015)</th>
-              <td>{{ results['historical']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['historical']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['historical']['ddmax'] }}<UnitWidget /></td>
-            </tr>
-            <tr>
-              <th scope="row">Early Century (2010-2039)</th>
-              <td>{{ results['2010-2039']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['2010-2039']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['2010-2039']['ddmax'] }}<UnitWidget /></td>
-            </tr>
-            <tr>
-              <th scope="row">Mid Century (2040-2069)</th>
-              <td>{{ results['2040-2069']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['2040-2069']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['2040-2069']['ddmax'] }}<UnitWidget /></td>
-            </tr>
-            <tr>
-              <th scope="row">Late Century (2070-2099)</th>
-              <td>{{ results['2070-2099']['ddmin'] }}<UnitWidget /></td>
-              <td>{{ results['2070-2099']['ddmean'] }}<UnitWidget /></td>
-              <td>{{ results['2070-2099']['ddmax'] }}<UnitWidget /></td>
-            </tr>
-          </tbody>
-        </table>
-        <h4 class="title is-6">Access to Data</h4>
-        <div class="content">
-          <p>Thawing index data was calculated from the following:</p>
-          <ul>
-            <li>
-              <a
-                href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
-                target="_blank"
-                >Historical and Projected Climate Products</a
-              >
-            </li>
-          </ul>
-        </div>
-        <DownloadCsvButton
-          text="Download thawing index data as CSV"
-          endpoint="mmm/degree_days/thawing_index/all"
-          class="mt-3 mb-5"
-        />
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1979-2015)</th>
+            <td>{{ plateResults['historical']['ddmin'] }}<UnitWidget /></td>
+            <td>{{ plateResults['historical']['ddmean'] }}<UnitWidget /></td>
+            <td>{{ plateResults['historical']['ddmax'] }}<UnitWidget /></td>
+          </tr>
+          <tr>
+            <th scope="row">Early Century (2010-2039)</th>
+            <td>{{ plateResults['2010-2039']['ddmin'] }}<UnitWidget /></td>
+            <td>{{ plateResults['2010-2039']['ddmean'] }}<UnitWidget /></td>
+            <td>{{ plateResults['2010-2039']['ddmax'] }}<UnitWidget /></td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040-2069)</th>
+            <td>{{ plateResults['2040-2069']['ddmin'] }}<UnitWidget /></td>
+            <td>{{ plateResults['2040-2069']['ddmean'] }}<UnitWidget /></td>
+            <td>{{ plateResults['2040-2069']['ddmax'] }}<UnitWidget /></td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070-2099)</th>
+            <td>{{ plateResults['2070-2099']['ddmin'] }}<UnitWidget /></td>
+            <td>{{ plateResults['2070-2099']['ddmean'] }}<UnitWidget /></td>
+            <td>{{ plateResults['2070-2099']['ddmax'] }}<UnitWidget /></td>
+          </tr>
+        </tbody>
+      </table>
+      <h4 class="title is-6">Access to Data</h4>
+      <div class="content">
+        <p>Thawing index data was calculated from the following:</p>
+        <ul>
+          <li>
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
+              target="_blank"
+              >Historical and Projected Climate Products</a
+            >
+          </li>
+        </ul>
       </div>
+      <DownloadCsvButton
+        text="Download thawing index data as CSV"
+        endpoint="mmm/degree_days/thawing_index/all"
+        class="mt-3 mb-5"
+      />
     </div>
   </div>
 </template>
@@ -92,37 +86,34 @@ export default {
   data() {
     return {
       // Will have the results of the data fetch.
-      results: {},
+      plateResults: null,
     }
   },
 
   computed: {
-    state: function() {
-      return this.$fetchState
-    },
     ...mapGetters({
+      results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       latLng: 'report/latLng',
     }),
   },
 
+  data() {
+    return {
+      plateResults: null,
+    }
+  },
   watch: {
-    latLng: function() {
+    latLng: function () {
       this.$fetch()
     },
   },
   async fetch() {
     if (this.isPlaceDefined) {
-      this.results = await this.$axios.$get(
-        process.env.apiUrl +
-          '/eds/degree_days/thawing_index/' +
-          this.latLng.lat +
-          '/' +
-          this.latLng.lng
-      )
+      this.plateResults = this.results['thawing_index']
 
-      this.results.place = this.placeName
+      this.plateResults.place = this.placeName
     }
   },
 }

--- a/components/plates/thawing_index/Report.vue
+++ b/components/plates/thawing_index/Report.vue
@@ -4,9 +4,7 @@
     <hr />
 
     <div id="report">
-      <h3 class="title is-3">
-        Thawing index data for {{ plateResults.place }}
-      </h3>
+      <h3 class="title is-3">Thawing index data for {{ placeName }}</h3>
 
       <ThawingIndexExplanation :isFooter="false" />
 
@@ -24,27 +22,51 @@
         <tbody>
           <tr>
             <th scope="row">Historical (1979-2015)</th>
-            <td>{{ plateResults['historical']['ddmin'] }}<UnitWidget /></td>
-            <td>{{ plateResults['historical']['ddmean'] }}<UnitWidget /></td>
-            <td>{{ plateResults['historical']['ddmax'] }}<UnitWidget /></td>
+            <td>
+              {{ results.thawing_index['historical']['ddmin'] }}<UnitWidget />
+            </td>
+            <td>
+              {{ results.thawing_index['historical']['ddmean'] }}<UnitWidget />
+            </td>
+            <td>
+              {{ results.thawing_index['historical']['ddmax'] }}<UnitWidget />
+            </td>
           </tr>
           <tr>
             <th scope="row">Early Century (2010-2039)</th>
-            <td>{{ plateResults['2010-2039']['ddmin'] }}<UnitWidget /></td>
-            <td>{{ plateResults['2010-2039']['ddmean'] }}<UnitWidget /></td>
-            <td>{{ plateResults['2010-2039']['ddmax'] }}<UnitWidget /></td>
+            <td>
+              {{ results.thawing_index['2010-2039']['ddmin'] }}<UnitWidget />
+            </td>
+            <td>
+              {{ results.thawing_index['2010-2039']['ddmean'] }}<UnitWidget />
+            </td>
+            <td>
+              {{ results.thawing_index['2010-2039']['ddmax'] }}<UnitWidget />
+            </td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040-2069)</th>
-            <td>{{ plateResults['2040-2069']['ddmin'] }}<UnitWidget /></td>
-            <td>{{ plateResults['2040-2069']['ddmean'] }}<UnitWidget /></td>
-            <td>{{ plateResults['2040-2069']['ddmax'] }}<UnitWidget /></td>
+            <td>
+              {{ results.thawing_index['2040-2069']['ddmin'] }}<UnitWidget />
+            </td>
+            <td>
+              {{ results.thawing_index['2040-2069']['ddmean'] }}<UnitWidget />
+            </td>
+            <td>
+              {{ results.thawing_index['2040-2069']['ddmax'] }}<UnitWidget />
+            </td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070-2099)</th>
-            <td>{{ plateResults['2070-2099']['ddmin'] }}<UnitWidget /></td>
-            <td>{{ plateResults['2070-2099']['ddmean'] }}<UnitWidget /></td>
-            <td>{{ plateResults['2070-2099']['ddmax'] }}<UnitWidget /></td>
+            <td>
+              {{ results.thawing_index['2070-2099']['ddmin'] }}<UnitWidget />
+            </td>
+            <td>
+              {{ results.thawing_index['2070-2099']['ddmean'] }}<UnitWidget />
+            </td>
+            <td>
+              {{ results.thawing_index['2070-2099']['ddmax'] }}<UnitWidget />
+            </td>
           </tr>
         </tbody>
       </table>
@@ -83,38 +105,12 @@ export default {
     ThawingIndexExplanation,
     UnitWidget,
   },
-  data() {
-    return {
-      // Will have the results of the data fetch.
-      plateResults: null,
-    }
-  },
 
   computed: {
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
-      isPlaceDefined: 'report/isPlaceDefined',
-      latLng: 'report/latLng',
     }),
-  },
-
-  data() {
-    return {
-      plateResults: null,
-    }
-  },
-  watch: {
-    latLng: function () {
-      this.$fetch()
-    },
-  },
-  async fetch() {
-    if (this.isPlaceDefined) {
-      this.plateResults = this.results['thawing_index']
-
-      this.plateResults.place = this.placeName
-    }
   },
 }
 </script>

--- a/components/plates/thawing_index/Report.vue
+++ b/components/plates/thawing_index/Report.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="Object.keys(results.thawing_index).length != 0">
     <hr />
 
     <div id="report">

--- a/components/plates/thawing_index/Report.vue
+++ b/components/plates/thawing_index/Report.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <CloseReportButton />
     <hr />
 
     <div id="report">

--- a/layouts/home.vue
+++ b/layouts/home.vue
@@ -59,6 +59,7 @@
 }
 </style>
 <script>
+import { mapGetters } from 'vuex'
 import HeaderBanner from '~/components/HeaderBanner'
 import Navbar from '~/components/Navbar'
 import BetaFeedback from '~/components/BetaFeedback'
@@ -66,5 +67,8 @@ import Footer from '~/components/Footer'
 
 export default {
   components: { HeaderBanner, Navbar, BetaFeedback, Footer },
+  ...mapGetters({
+    reportIsVisible: 'report/reportIsVisible',
+  }),
 }
 </script>

--- a/layouts/home.vue
+++ b/layouts/home.vue
@@ -59,7 +59,6 @@
 }
 </style>
 <script>
-import { mapGetters } from 'vuex'
 import HeaderBanner from '~/components/HeaderBanner'
 import Navbar from '~/components/Navbar'
 import BetaFeedback from '~/components/BetaFeedback'
@@ -67,8 +66,5 @@ import Footer from '~/components/Footer'
 
 export default {
   components: { HeaderBanner, Navbar, BetaFeedback, Footer },
-  ...mapGetters({
-    reportIsVisible: 'report/reportIsVisible',
-  }),
 }
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -80,11 +80,11 @@ export default {
     extendRoutes(routes, resolve) {
       routes.push({
         path: '/report/community/:communityId',
-        component: resolve(__dirname, 'pages/report'),
+        component: resolve(__dirname, 'pages/index'),
       })
       routes.push({
         path: '/report/:lat/:lng',
-        component: resolve(__dirname, 'pages/report'),
+        component: resolve(__dirname, 'pages/index'),
       })
     },
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -77,6 +77,15 @@ export default {
 
   // Router customizations
   router: {
-    extendRoutes(routes, resolve) {},
+    extendRoutes(routes, resolve) {
+      routes.push({
+        path: '/report/community/:communityId',
+        component: resolve(__dirname, 'pages/report'),
+      })
+      routes.push({
+        path: '/report/:lat/:lng',
+        component: resolve(__dirname, 'pages/report'),
+      })
+    },
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4834,7 +4834,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -10837,7 +10837,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "p-defer": {
       "version": "1.0.0",
@@ -13867,7 +13867,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "through2": {
       "version": "2.0.5",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="!this.reportIsVisible">
+    <div v-show="!reportIsVisible">
       <div class="mx-5 mb-5">
         <h2 class="title is-4 mt-3">
           Modern environmental data for science and engineering.
@@ -79,9 +79,9 @@
         </div>
       </div>
     </div>
-    <!-- <div v-if="reportIsVisible">
+    <div v-if="reportIsVisible">
       <FullReport />
-    </div> -->
+    </div>
   </div>
 </template>
 <style lang="scss" scoped>
@@ -109,9 +109,11 @@ export default {
     SearchControls,
     FullReport,
   },
-  ...mapGetters({
-    reportIsVisible: 'report/reportIsVisible',
-  }),
+  computed: {
+    ...mapGetters({
+      reportIsVisible: 'report/reportIsVisible',
+    }),
+  },
   created() {
     const path = (/#!(\/.*)$/.exec(this.$route.fullPath) || [])[1]
     if (path) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,82 +1,87 @@
 <template>
   <div>
-    <div class="mx-5 mb-5">
-      <h2 class="title is-4 mt-3">
-        Modern environmental data for science and engineering.
-      </h2>
-      <div class="content is-size-5">
-        <p>
-          Do you need readily available, high quality engineering and
-          environmental data for projects in Alaska and the Arctic?
-        </p>
-        <p>
-          The Arctic-EDS offers curated, vetted datasets through online maps,
-          processing modules and direct data access.
-        </p>
-        <p>
-          <b-button tag="nuxt-link" to="/about">
-            Learn more about the system
-          </b-button>
-        </p>
+    <div v-if="!this.reportIsVisible">
+      <div class="mx-5 mb-5">
+        <h2 class="title is-4 mt-3">
+          Modern environmental data for science and engineering.
+        </h2>
+        <div class="content is-size-5">
+          <p>
+            Do you need readily available, high quality engineering and
+            environmental data for projects in Alaska and the Arctic?
+          </p>
+          <p>
+            The Arctic-EDS offers curated, vetted datasets through online maps,
+            processing modules and direct data access.
+          </p>
+          <p>
+            <b-button tag="nuxt-link" to="/about">
+              Learn more about the system
+            </b-button>
+          </p>
+        </div>
+      </div>
+      <SearchControls />
+      <div class="columns mx-2 mb-5">
+        <div class="column is-half">
+          <h4 class="is-size-4">Precipitation</h4>
+          <Map mapId="precipitation" />
+        </div>
+        <div class="column is-half">
+          <h4 class="is-size-4">Snowfall</h4>
+          <Map mapId="snowfall" />
+        </div>
+      </div>
+      <div class="columns mx-2 mb-5">
+        <div class="column is-half">
+          <h4 class="is-size-4">Temperature</h4>
+          <Map mapId="temperature" />
+        </div>
+        <div class="column is-half">
+          <h4 class="is-size-4">Design Freezing Index</h4>
+          <Map mapId="design_freezing_index" />
+        </div>
+      </div>
+      <div class="columns mx-2 mb-5">
+        <div class="column is-half">
+          <h4 class="is-size-4">Design Thawing Index</h4>
+          <Map mapId="design_thawing_index" />
+        </div>
+        <div class="column is-half">
+          <h4 class="is-size-4">Freezing Index</h4>
+          <Map mapId="freezing_index" />
+        </div>
+      </div>
+      <div class="columns mx-2 mb-5">
+        <div class="column is-half">
+          <h4 class="is-size-4">Thawing Index</h4>
+          <Map mapId="thawing_index" />
+        </div>
+        <div class="column is-half">
+          <h4 class="is-size-4">Heating Degree Days</h4>
+          <Map mapId="heating_degree_days" />
+        </div>
+      </div>
+      <div class="columns mx-2 mb-5">
+        <div class="column is-half">
+          <h4 class="is-size-4">Ecoregions</h4>
+          <Map mapId="ecoregions" />
+        </div>
+        <div class="column is-half">
+          <h4 class="is-size-4">Geology</h4>
+          <Map mapId="geology" />
+        </div>
+      </div>
+      <div class="columns mx-2 mb-5">
+        <div class="column is-half">
+          <h4 class="is-size-4">Permafrost</h4>
+          <Map mapId="permafrost" />
+        </div>
       </div>
     </div>
-    <SearchControls />
-    <div class="columns mx-2 mb-5">
-      <div class="column is-half">
-        <h4 class="is-size-4">Precipitation</h4>
-        <Map mapId="precipitation" />
-      </div>
-      <div class="column is-half">
-        <h4 class="is-size-4">Snowfall</h4>
-        <Map mapId="snowfall" />
-      </div>
-    </div>
-    <div class="columns mx-2 mb-5">
-      <div class="column is-half">
-        <h4 class="is-size-4">Temperature</h4>
-        <Map mapId="temperature" />
-      </div>
-      <div class="column is-half">
-        <h4 class="is-size-4">Design Freezing Index</h4>
-        <Map mapId="design_freezing_index" />
-      </div>
-    </div>
-    <div class="columns mx-2 mb-5">
-      <div class="column is-half">
-        <h4 class="is-size-4">Design Thawing Index</h4>
-        <Map mapId="design_thawing_index" />
-      </div>
-      <div class="column is-half">
-        <h4 class="is-size-4">Freezing Index</h4>
-        <Map mapId="freezing_index" />
-      </div>
-    </div>
-    <div class="columns mx-2 mb-5">
-      <div class="column is-half">
-        <h4 class="is-size-4">Thawing Index</h4>
-        <Map mapId="thawing_index" />
-      </div>
-      <div class="column is-half">
-        <h4 class="is-size-4">Heating Degree Days</h4>
-        <Map mapId="heating_degree_days" />
-      </div>
-    </div>
-    <div class="columns mx-2 mb-5">
-      <div class="column is-half">
-        <h4 class="is-size-4">Ecoregions</h4>
-        <Map mapId="ecoregions" />
-      </div>
-      <div class="column is-half">
-        <h4 class="is-size-4">Geology</h4>
-        <Map mapId="geology" />
-      </div>
-    </div>
-    <div class="columns mx-2 mb-5">
-      <div class="column is-half">
-        <h4 class="is-size-4">Permafrost</h4>
-        <Map mapId="permafrost" />
-      </div>
-    </div>
+    <!-- <div v-if="reportIsVisible">
+      <FullReport />
+    </div> -->
   </div>
 </template>
 <style lang="scss" scoped>
@@ -90,9 +95,11 @@
 }
 </style>
 <script>
+import { mapGetters } from 'vuex'
 import Map from '~/components/Map'
 import layers from '~/components/layers'
 import SearchControls from '~/components/SearchControls'
+import FullReport from '~/components/Report'
 
 export default {
   name: 'HomePage',
@@ -100,7 +107,11 @@ export default {
   components: {
     Map,
     SearchControls,
+    FullReport,
   },
+  ...mapGetters({
+    reportIsVisible: 'report/reportIsVisible',
+  }),
   created() {
     const path = (/#!(\/.*)$/.exec(this.$route.fullPath) || [])[1]
     if (path) {

--- a/pages/report.vue
+++ b/pages/report.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <div class="container">
+      <section class="section">
+        <FullReport />
+      </section>
+    </div>
+  </div>
+</template>
+<script lang="scss" scoped></script>
+<script>
+import FullReport from '~/components/Report'
+export default {
+  name: 'Report',
+  layout: 'plate',
+  components: {
+    FullReport,
+  },
+}
+</script>

--- a/store/report.js
+++ b/store/report.js
@@ -1,44 +1,56 @@
 import _ from 'lodash'
 
-function convertUnits(state, type, substring = '') {
-  Object.keys(state.results).forEach(key => {
+function convertUnits(state, type, substring = '', variable) {
+  Object.keys(state.results[variable]).forEach(key => {
     if (key != 'place' && key.includes(substring)) {
       switch (type) {
         case 'temperature':
-          state.results[key] = convertTemperature(state, key)
+          state.results[variable][key] = convertTemperature(
+            state,
+            variable,
+            key
+          )
           break
         case 'm_in':
-          state.results[key] = convertMetersInches(state, key)
+          state.results[variable][key] = convertMetersInches(
+            state,
+            variable,
+            key
+          )
           break
         case 'mm_in':
-          state.results[key] = convertMillimetersInches(state, key)
+          state.results[variable][key] = convertMillimetersInches(
+            state,
+            variable,
+            key
+          )
           break
       }
     }
   })
 }
 
-function convertTemperature(state, key) {
+function convertTemperature(state, variable, key) {
   if (state.units == 'metric') {
-    return ((state.results[key] - 32) * (5 / 9)).toFixed(1)
+    return ((state.results[variable][key] - 32) * (5 / 9)).toFixed(1)
   } else {
-    return (state.results[key] * (9 / 5) + 32).toFixed(1)
+    return (state.results[variable][key] * (9 / 5) + 32).toFixed(1)
   }
 }
 
-function convertMillimetersInches(state, key) {
+function convertMillimetersInches(state, variable, key) {
   if (state.units == 'metric') {
-    return (state.results[key] * 25.4).toFixed(0)
+    return (state.results[variable][key] * 25.4).toFixed(0)
   } else {
-    return (state.results[key] / 25.4).toFixed(1)
+    return (state.results[variable][key] / 25.4).toFixed(1)
   }
 }
 
-function convertMetersInches(state, key) {
+function convertMetersInches(state, variable, key) {
   if (state.units == 'metric') {
-    return (state.results[key] * 0.0254).toFixed(2)
+    return (state.results[variable][key] * 0.0254).toFixed(2)
   } else {
-    return (state.results[key] / 0.0254).toFixed(1)
+    return (state.results[variable][key] / 0.0254).toFixed(1)
   }
 }
 
@@ -147,10 +159,15 @@ export default {
     convertResults(state, params) {
       if (params['patterns']) {
         params['patterns'].forEach(pattern => {
-          convertUnits(state, pattern['type'], pattern['substring'])
+          convertUnits(
+            state,
+            pattern['type'],
+            pattern['substring'],
+            pattern['variable']
+          )
         })
       } else {
-        convertUnits(state, params['type'])
+        convertUnits(state, params['type'], '', params['variable'])
       }
     },
     setResults(state, results) {

--- a/store/report.js
+++ b/store/report.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 
 function convertUnits(state, type, substring = '', variable) {
   Object.keys(state.results[variable]).forEach(key => {
-    if (key != 'place' && key.includes(substring)) {
+    if (key.includes(substring)) {
       switch (type) {
         case 'temperature':
           state.results[variable][key] = convertTemperature(
@@ -156,19 +156,25 @@ export default {
         lng: undefined,
       }
     },
-    convertResults(state, params) {
-      if (params['patterns']) {
-        params['patterns'].forEach(pattern => {
-          convertUnits(
-            state,
-            pattern['type'],
-            pattern['substring'],
-            pattern['variable']
-          )
-        })
-      } else {
-        convertUnits(state, params['type'], '', params['variable'])
-      }
+    convertResults(state) {
+      // Converts all convertible units at the same time for shared report
+      let conversions = [
+        { type: 'temperature', substring: 'magt_', variable: 'permafrost' },
+        { type: 'temperature', substring: '', variable: 'temperature' },
+        { type: 'mm_in', substring: '', variable: 'precipitation' },
+        { type: 'mm_in', substring: '', variable: 'snowfall' },
+      ]
+      conversions.forEach(conversion => {
+        convertUnits(
+          state,
+          conversion['type'],
+          conversion['substring'],
+          conversion['variable']
+        )
+      })
+    },
+    setPlateResults(state, payload) {
+      state.results[payload.variable] = payload.plateResults
     },
     setResults(state, results) {
       state.results = results

--- a/store/report.js
+++ b/store/report.js
@@ -117,7 +117,14 @@ export default {
       return undefined
     },
     reportIsVisible(state) {
-      return state.reportIsVisible
+      console.log('Getting here')
+      return false
+      // if (state.isPlaceDefined()) {
+      //   return true
+      // } else {
+      //   return false
+      // }
+      // return state.reportIsVisible
     },
     results(state) {
       return state.results

--- a/store/report.js
+++ b/store/report.js
@@ -116,15 +116,12 @@ export default {
       }
       return undefined
     },
-    reportIsVisible(state) {
-      console.log('Getting here')
-      return false
-      // if (state.isPlaceDefined()) {
-      //   return true
-      // } else {
-      //   return false
-      // }
-      // return state.reportIsVisible
+    reportIsVisible(state, getters) {
+      if (getters.isPlaceDefined) {
+        return true
+      } else {
+        return false
+      }
     },
     results(state) {
       return state.results
@@ -147,12 +144,9 @@ export default {
       // Ensure that report is in URL before attempting
       // to remove it.
       if (fullPath.includes('report')) {
-        let pathArray = fullPath.split('/report')
-
         // Router push to base URL of plate
         this.$router.push({
-          path: fullPath.split('/report')[0],
-          hash: 'map-search',
+          path: '',
         })
       }
       state.placeName = undefined


### PR DESCRIPTION
This PR generates a single report for all of the plates after the place selector or lat / lon selector is used on the home page. 

There is more work to be done on formatting and the proper router push to the report's page, but the functionality for generating the report and for converting the units between Imperial / Metric works.

To test this, try typing a lat / lon and a place. Currently, it requires you to reload the page after it fails, this will be something to fix when all of the code is merged together.

Fairbanks: http://localhost:3000/report/community/AK124
Point Location: http://localhost:3000/report/64/-152
