### PR TITLE
Prevent map panning so far that it shows projection weirdness

### DIFF
--- a/components/MapModal.vue
+++ b/components/MapModal.vue
@@ -50,6 +50,11 @@
   .layers {
     width: 300px;
   }
+  @media (min-width: 1408px) {
+    .layers {
+      width: 33%;
+    }
+  }
 }
 </style>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -138,9 +138,9 @@
           </div>
         </div>
         <MapModal />
-      </div>
-      <div v-if="reportIsVisible">
-        <FullReport />
+        <div v-if="reportIsVisible">
+          <FullReport />
+        </div>
       </div>
     </client-only>
   </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -138,9 +138,9 @@
           </div>
         </div>
         <MapModal />
-        <div v-if="reportIsVisible">
-          <FullReport />
-        </div>
+      </div>
+      <div v-if="reportIsVisible">
+        <FullReport />
       </div>
     </client-only>
   </div>

--- a/store/map.js
+++ b/store/map.js
@@ -40,14 +40,14 @@ function getBaseMapAndLayers() {
   )
 
   // Set maximum bounds of main map
-  let southWest = L.latLng('50', '-175')
-  let northEast = L.latLng('65', '-98')
+  let southWest = L.latLng('51.2', '155')
+  let northEast = L.latLng('63.5', '-132.4')
   let bounds = L.latLngBounds(southWest, northEast)
 
   // Map base configuration
   var config = {
     zoom: 1,
-    minZoom: 0,
+    minZoom: 1,
     maxZoom: 6,
     center: [64.7, -155],
     scrollWheelZoom: false,
@@ -110,7 +110,11 @@ export default {
 
   mutations: {
     create(state) {
-      map = L.map('map', getBaseMapAndLayers())
+      let mapConfig = getBaseMapAndLayers()
+      map = L.map('map', getBaseMapAndLayers(mapConfig))
+      map.on('drag', function () {
+        map.panInsideBounds(mapConfig.maxBounds, { animate: false })
+      })
       new L.Control.Zoom({ position: 'topright' }).addTo(map)
     },
     destroy(state) {


### PR DESCRIPTION
Closes #216.

This PR depends on PR #219, so I'm setting this PR as a draft until #219 is merged.

This PR does a few things:

- Reduces the map maxBounds to coordinates that more closely match the bounds of the data layers.
- Sets the minimum zoom level of maps to 1 instead of 0 to make sure the available map imagery fills the entire modal window by default at more resolutions and browser sizes.
- Uses Leaflet's `panInsideBounds` method to prevent the user from panning outside of our maxBounds, even temporarily. Before this change, there was nothing stopping the user from dragging the map so far north that they see the EPSG:3338 weirdness before the map snapped back to acceptable bounds.

To test, try viewing the map modals at various browser sizes and computer resolutions and make sure it looks good.

Occasionally you'll still see cases where you can drag the map past the bounds of available imagery. This appears to be unavoidable, unfortunately, because Leaflet's maxBounds feature does not do well with EPSG:3338. But you should never be able to pan the map so far north that you see the projection weirdness/distortions.