### PR TITLE
Add more padding around map maxBounds

### DIFF
--- a/store/map.js
+++ b/store/map.js
@@ -40,8 +40,8 @@ function getBaseMapAndLayers() {
   )
 
   // Set maximum bounds of main map
-  let southWest = L.latLng('51.2', '155')
-  let northEast = L.latLng('63.5', '-132.4')
+  let southWest = L.latLng('50.5', '155')
+  let northEast = L.latLng('64', '-131')
   let bounds = L.latLngBounds(southWest, northEast)
 
   // Map base configuration


### PR DESCRIPTION
Closes #225.

This PR simply adds some buffer room around map maxBounds lat/lon coordinates so that data overlays are not right up against the edge of the map's maxBounds. The intention is to make it more clear to users that they are seeing the entire data overlay. To test, load any map and trying dragging it around to the edges in any/all directions.