### PR TITLE
Override map layer sidebar content for Temperature and Temperature Indices modals

### DIFF
--- a/components/LayerList.vue
+++ b/components/LayerList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="layer-list-wrapper">
+  <div>
     <ul>
       <li v-for="layer in layers">
         <MapLayer v-bind:key="layer.id" v-bind:layer="layer" />
@@ -19,15 +19,6 @@
   // 32px for the map blurb
   // 30px for the top (15px) + bottom (15px) margin around modal
   height: calc(100vh - 42px - 32px - 30px);
-}
-
-ul {
-  margin: 0 1rem 1rem;
-
-  li {
-    margin-bottom: 0.5rem;
-    font-size: 1.1rem;
-  }
 }
 </style>
 

--- a/components/MapLayer.vue
+++ b/components/MapLayer.vue
@@ -11,7 +11,7 @@
 .map--layer {
   display: inline-block;
   line-height: 1;
-  padding: 0.5rem 0.5rem 0.25rem 0.5rem;
+  padding: 0.5rem;
   cursor: pointer;
   border-radius: 0.25rem;
 

--- a/components/MapModal.vue
+++ b/components/MapModal.vue
@@ -6,7 +6,11 @@
       </h4>
       <p class="pl-4 map-blurb">{{ mapBlurb }}</p>
       <div class="is-flex">
-        <LayerList class="layers" :layers="this.layers()" />
+        <slot name="layers" :layers="layers">
+          <div class="layer-list-wrapper">
+            <LayerList class="layers mx-3" :layers="layers" />
+          </div>
+        </slot>
         <Map class="map" />
       </div>
     </div>
@@ -23,8 +27,22 @@
     height: calc(100vh - 30px);
     margin: 15px;
   }
+  .layer-list-wrapper {
+    border-top: 1px solid #ddd;
+    padding-top: 15px;
+    overflow-wrap: normal;
+    overflow-y: auto;
+
+    width: 25%;
+
+    // Offset height by:
+    // 42px for the map title
+    // 32px for the map blurb
+    // 30px for the top (15px) + bottom (15px) margin around modal
+    height: calc(100vh - 42px - 32px - 30px);
+  }
   .map {
-    width: 100%;
+    width: 75%;
 
     // Offset height by:
     // 42px for the map title
@@ -48,7 +66,20 @@
     height: 32px;
   }
   .layers {
-    width: 300px;
+    h6 {
+      margin-bottom: 0;
+      color: #666;
+      font-size: 110%;
+      margin-top: 0;
+    }
+    ul {
+      list-style-type: none;
+      margin: 0;
+      li {
+        margin: 0.1rem 0;
+        padding: 0.1rem;
+      }
+    }
   }
   @media (min-width: 1408px) {
     .layers {
@@ -89,6 +120,9 @@ export default {
         this.$store.commit('map/selectMap', undefined)
       },
     },
+    layers() {
+      return mapContent.layers[this.selectedMap]
+    },
   },
   methods: {
     selectDefaultLayer() {
@@ -99,9 +133,6 @@ export default {
         }
       )[0]
       this.$store.commit('map/selectLayer', defaultLayer)
-    },
-    layers(mapId) {
-      return mapContent.layers[this.selectedMap]
     },
   },
 }

--- a/components/MapModal.vue
+++ b/components/MapModal.vue
@@ -81,11 +81,6 @@
       }
     }
   }
-  @media (min-width: 1408px) {
-    .layers {
-      width: 33%;
-    }
-  }
 }
 </style>
 

--- a/components/MapModal.vue
+++ b/components/MapModal.vue
@@ -6,7 +6,7 @@
       </h4>
       <p class="pl-4 map-blurb">{{ mapBlurb }}</p>
       <div class="is-flex">
-        <slot name="layers" :layers="layers">
+        <slot name="layers">
           <div class="layer-list-wrapper">
             <LayerList class="layers mx-3" :layers="layers" />
           </div>

--- a/components/TemperatureIndicesMap.vue
+++ b/components/TemperatureIndicesMap.vue
@@ -1,0 +1,81 @@
+<template>
+  <MapModal>
+    <template v-slot:layers :layers="layers">
+      <div class="layer-list-wrapper">
+        <div class="layers content mx-5">
+          <p>
+            Historical layers show <strong>modeled</strong> data from the ERA
+            Interim model, averaged over 1980&ndash;2009.
+          </p>
+          <p>
+            Projected layers show data from the NCAR CCSM4 model under the RCP
+            8.5 scenario, averaged over 2040&ndash;2069.
+            <NuxtLink to="/climate-modeling">Read more</NuxtLink>
+          </p>
+          <h5 class="mb-2">Heating Degree Days</h5>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[0].id" v-bind:layer="layers[0]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[1].id" v-bind:layer="layers[1]" />
+            </li>
+          </ul>
+          <h5 class="mb-2">Freezing Index</h5>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[2].id" v-bind:layer="layers[2]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[3].id" v-bind:layer="layers[3]" />
+            </li>
+          </ul>
+          <h5 class="mb-2">Thawing Index</h5>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[4].id" v-bind:layer="layers[4]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[5].id" v-bind:layer="layers[5]" />
+            </li>
+          </ul>
+          <h5 class="mb-2">Design Freezing Index</h5>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[6].id" v-bind:layer="layers[6]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[7].id" v-bind:layer="layers[7]" />
+            </li>
+          </ul>
+          <h5 class="mb-2">Design Thawing Index</h5>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[8].id" v-bind:layer="layers[8]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[9].id" v-bind:layer="layers[9]" />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </template>
+  </MapModal>
+</template>
+
+<script>
+import MapModal from '~/components/MapModal'
+import mapContent from '~/components/map_content'
+
+export default {
+  name: 'TemperatureIndicesMap',
+  components: {
+    MapModal,
+  },
+  computed: {
+    layers() {
+      return mapContent.layers['temperature_indices']
+    },
+  },
+}
+</script>

--- a/components/TemperatureIndicesMap.vue
+++ b/components/TemperatureIndicesMap.vue
@@ -1,6 +1,6 @@
 <template>
   <MapModal>
-    <template v-slot:layers :layers="layers">
+    <template v-slot:layers>
       <div class="layer-list-wrapper">
         <div class="layers content mx-5">
           <p>

--- a/components/TemperatureMap.vue
+++ b/components/TemperatureMap.vue
@@ -1,6 +1,6 @@
 <template>
   <MapModal>
-    <template v-slot:layers :layers="layers">
+    <template v-slot:layers>
       <div class="layer-list-wrapper">
         <div class="layers content mx-5">
           <p>

--- a/components/TemperatureMap.vue
+++ b/components/TemperatureMap.vue
@@ -1,0 +1,83 @@
+<template>
+  <MapModal>
+    <template v-slot:layers :layers="layers">
+      <div class="layer-list-wrapper">
+        <div class="layers content mx-5">
+          <p>
+            Historical layers show <strong>modeled</strong> data from the CRU TS
+            model, averaged over 1980&ndash;2009.
+          </p>
+          <p>
+            Projected layers show data from the NCAR CCSM4 model under the RCP
+            8.5 scenario, averaged over 2040&ndash;2069.
+            <NuxtLink to="/climate-modeling">Read more</NuxtLink>
+          </p>
+          <h5 class="mb-2">Annual Mean Temperature</h5>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[0].id" v-bind:layer="layers[0]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[1].id" v-bind:layer="layers[1]" />
+            </li>
+          </ul>
+          <h5 class="layer-section">January Temperatures</h5>
+          <h6>Minimum</h6>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[2].id" v-bind:layer="layers[2]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[3].id" v-bind:layer="layers[3]" />
+            </li>
+          </ul>
+          <h6>Maximum</h6>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[4].id" v-bind:layer="layers[4]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[5].id" v-bind:layer="layers[5]" />
+            </li>
+          </ul>
+          <h5 class="layer-section">July Temperatures</h5>
+          <h6>Minimum</h6>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[6].id" v-bind:layer="layers[6]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[7].id" v-bind:layer="layers[7]" />
+            </li>
+          </ul>
+          <h6>Maximum</h6>
+          <ul>
+            <li>
+              <MapLayer v-bind:key="layers[8].id" v-bind:layer="layers[8]" />
+            </li>
+            <li class="mb-3">
+              <MapLayer v-bind:key="layers[9].id" v-bind:layer="layers[9]" />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </template>
+  </MapModal>
+</template>
+
+<script>
+import MapModal from '~/components/MapModal'
+import mapContent from '~/components/map_content'
+
+export default {
+  name: 'Temperature',
+  components: {
+    MapModal,
+  },
+  computed: {
+    layers() {
+      return mapContent.layers['temperature']
+    },
+  },
+}
+</script>

--- a/components/map_content.js
+++ b/components/map_content.js
@@ -49,7 +49,7 @@ export default {
     temperature: [
       {
         id: 'historical_era_annual_mean_temp',
-        title: 'Historical Annual Mean (1980–2009)',
+        title: 'Historical',
         source: 'rasdaman',
         wmsLayerName: 'annual_mean_temp',
         style: 'temp_historical_era',
@@ -58,7 +58,7 @@ export default {
       },
       {
         id: 'midcentury_era_annual_mean_temp',
-        title: 'Projected Annual Mean (2040–2069)',
+        title: 'Projected',
         source: 'rasdaman',
         wmsLayerName: 'annual_mean_temp',
         style: 'temp_midcentury_era',
@@ -67,7 +67,7 @@ export default {
 
       {
         id: 'historical_era_january_min',
-        title: 'Historical January Minimum (1980–2009)',
+        title: 'Historical',
         source: 'rasdaman',
         wmsLayerName: 'jan_min_max_mean_temp',
         style: 'temp_historical_january_min',
@@ -75,7 +75,7 @@ export default {
       },
       {
         id: 'midcentury_era_january_min',
-        title: 'Projected January Minumum (2040–2069)',
+        title: 'Projected',
         source: 'rasdaman',
         wmsLayerName: 'jan_min_max_mean_temp',
         style: 'temp_midcentury_january_min',
@@ -83,7 +83,7 @@ export default {
       },
       {
         id: 'historical_era_january_max',
-        title: 'Historical January Maximum (1980–2009)',
+        title: 'Historical',
         source: 'rasdaman',
         wmsLayerName: 'jan_min_max_mean_temp',
         style: 'temp_historical_january_max',
@@ -91,7 +91,7 @@ export default {
       },
       {
         id: 'midcentury_era_january_max',
-        title: 'Projected January Maximum (2040–2069)',
+        title: 'Projected',
         source: 'rasdaman',
         wmsLayerName: 'jan_min_max_mean_temp',
         style: 'temp_midcentury_january_max',
@@ -100,7 +100,7 @@ export default {
 
       {
         id: 'historical_era_july_min',
-        title: 'Historical July Minimum (1980–2009)',
+        title: 'Historical',
         source: 'rasdaman',
         wmsLayerName: 'july_min_max_mean_temp',
         style: 'temp_historical_july_min',
@@ -108,7 +108,7 @@ export default {
       },
       {
         id: 'midcentury_era_july_min',
-        title: 'Projected July Minumum (2040–2069)',
+        title: 'Projected',
         source: 'rasdaman',
         wmsLayerName: 'july_min_max_mean_temp',
         style: 'temp_midcentury_july_min',
@@ -116,7 +116,7 @@ export default {
       },
       {
         id: 'historical_era_july_max',
-        title: 'Historical July Maximum (1980–2009)',
+        title: 'Historical',
         source: 'rasdaman',
         wmsLayerName: 'july_min_max_mean_temp',
         style: 'temp_historical_july_max',
@@ -124,7 +124,7 @@ export default {
       },
       {
         id: 'midcentury_era_july_max',
-        title: 'Projected July Maximum (2040–2069)',
+        title: 'Projected',
         source: 'rasdaman',
         wmsLayerName: 'july_min_max_mean_temp',
         style: 'temp_midcentury_july_max',
@@ -133,8 +133,57 @@ export default {
     ],
     temperature_indices: [
       {
+        id: 'heating_degree_days_index_condensed_historical',
+        title: 'Historical',
+        source: 'rasdaman',
+        wmsLayerName: 'heating_degree_days',
+        style: 'arctic_eds_heating_degree_days_historical_condensed_compressed',
+        legend: 'heating_degree_days',
+        default: true,
+      },
+      {
+        id: 'ncarccsm4_heating_degree_days_midcentury',
+        title: 'Projected',
+        source: 'rasdaman',
+        wmsLayerName: 'heating_degree_days',
+        style: 'arctic_eds_heating_degree_days_future_condensed_compressed',
+        legend: 'heating_degree_days',
+      },
+      {
+        id: 'freezing_index_condensed_historical',
+        title: 'Historical',
+        source: 'rasdaman',
+        wmsLayerName: 'freezing_index',
+        style: 'arctic_eds_freezing_index_historical_condensed',
+        legend: 'freezing_index',
+      },
+      {
+        id: 'ncarccsm4_freezing_index_midcentury',
+        title: 'Projected',
+        source: 'rasdaman',
+        wmsLayerName: 'freezing_index',
+        style: 'arctic_eds_freezing_index_future_condensed',
+        legend: 'freezing_index',
+      },
+      {
+        id: 'thawing_index_condensed_historical',
+        title: 'Historical',
+        source: 'rasdaman',
+        wmsLayerName: 'thawing_index',
+        style: 'arctic_eds_thawing_index_historical_condensed_compressed',
+        legend: 'thawing_index',
+      },
+      {
+        id: 'ncarccsm4_thawing_index_midcentury',
+        title: 'Projected',
+        source: 'rasdaman',
+        wmsLayerName: 'thawing_index',
+        style: 'arctic_eds_thawing_index_future_condensed_compressed',
+        legend: 'thawing_index',
+      },
+      {
         id: 'historical_design_freezing_index',
-        title: 'Historical Design Freezing Index (1980-2009)',
+        title: 'Historical',
         source: 'rasdaman',
         wmsLayerName: 'design_freezing_index',
         rasdamanConfiguration: {
@@ -143,12 +192,10 @@ export default {
         },
         style: 'arctic_eds',
         legend: 'design_freezing_index',
-        default: true,
       },
       {
         id: 'ncarccsm4_design_freezing_index',
-        title:
-          'Projected Design Freezing Index (2070-2099, NCAR CCSM4, RCP 8.5)',
+        title: 'Projected',
         source: 'rasdaman',
         wmsLayerName: 'design_freezing_index',
         rasdamanConfiguration: {
@@ -160,7 +207,7 @@ export default {
       },
       {
         id: 'historical_design_thawing_index',
-        title: 'Historical Design Thawing Index (1980-2009)',
+        title: 'Historical',
         source: 'rasdaman',
         wmsLayerName: 'design_thawing_index',
         rasdamanConfiguration: {
@@ -169,12 +216,10 @@ export default {
         },
         style: 'arctic_eds',
         legend: 'design_thawing_index',
-        default: true,
       },
       {
         id: 'ncarccsm4_design_thawing_index',
-        title:
-          'Projected Design Thawing Index (2070-2099, NCAR CCSM4, RCP 8.5)',
+        title: 'Projected',
         source: 'rasdaman',
         wmsLayerName: 'design_thawing_index',
         rasdamanConfiguration: {
@@ -183,63 +228,6 @@ export default {
         },
         style: 'arctic_eds',
         legend: 'design_thawing_index',
-      },
-      {
-        id: 'freezing_index_condensed_historical',
-        title:
-          'Modeled Historical Freezing Index (1980&ndash;2009, ERA Interim)',
-        source: 'rasdaman',
-        wmsLayerName: 'freezing_index',
-        style: 'arctic_eds_freezing_index_historical_condensed',
-        legend: 'freezing_index',
-        default: true,
-      },
-      {
-        id: 'ncarccsm4_freezing_index_midcentury',
-        title:
-          'Projected Mid&ndash;Century Freezing Index (2040&ndash;2069, NCAR CCSM4, RCP 8.5)',
-        source: 'rasdaman',
-        wmsLayerName: 'freezing_index',
-        style: 'arctic_eds_freezing_index_future_condensed',
-        legend: 'freezing_index',
-      },
-      {
-        id: 'thawing_index_condensed_historical',
-        title:
-          'Modeled Historical Thawing Index (1980&ndash;2009, ERA Interim)',
-        source: 'rasdaman',
-        wmsLayerName: 'thawing_index',
-        style: 'arctic_eds_thawing_index_historical_condensed_compressed',
-        legend: 'thawing_index',
-        default: true,
-      },
-      {
-        id: 'ncarccsm4_thawing_index_midcentury',
-        title:
-          'Projected Mid&ndash;Century Thawing Index (2040&ndash;2069, NCAR CCSM4, RCP 8.5)',
-        source: 'rasdaman',
-        wmsLayerName: 'thawing_index',
-        style: 'arctic_eds_thawing_index_future_condensed_compressed',
-        legend: 'thawing_index',
-      },
-      {
-        id: 'heating_degree_days_index_condensed_historical',
-        title:
-          'Modeled Historical Heating Degree Days (1980&ndash;2009, ERA Interim)',
-        source: 'rasdaman',
-        wmsLayerName: 'heating_degree_days',
-        style: 'arctic_eds_heating_degree_days_historical_condensed_compressed',
-        legend: 'heating_degree_days',
-        default: true,
-      },
-      {
-        id: 'ncarccsm4_heating_degree_days_midcentury',
-        title:
-          'Projected Mid&ndash;Century Heating Degree Days (2040&ndash;2069, NCAR CCSM4, RCP 8.5)',
-        source: 'rasdaman',
-        wmsLayerName: 'heating_degree_days',
-        style: 'arctic_eds_heating_degree_days_future_condensed_compressed',
-        legend: 'heating_degree_days',
       },
     ],
     permafrost: [
@@ -432,13 +420,7 @@ export default {
     precipitation: 'Placeholder blurb for Precipitation map',
     snowfall: 'Placeholder blurb for Snowfall map',
     temperature: 'Placeholder blurb for Temperature map',
-    design_freezing_index: 'Placeholder blurb for Design Freezing Index map',
-    design_thawing_index: 'Placeholder blurb for Design Thawing Index map',
-    freezing_index: 'Placeholder blurb for Freezing Index map',
-    thawing_index: 'Placeholder blurb for Thawing Index map',
-    heating_degree_days: 'Placeholder blurb for Heating Degree Days map',
-    ecoregions: 'Placeholder blurb for Ecoregions map',
-    geology: 'Placeholder blurb for Geology map',
+    temperature_indices: 'Placeholder blurb for Temperature Indices map',
     permafrost: 'Placeholder blurb for Permafrost map',
   },
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -76,7 +76,17 @@
             </div>
           </div>
         </div>
-        <MapModal />
+        <TemperatureMap v-if="this.selectedMap == 'temperature'" />
+        <TemperatureIndicesMap
+          v-if="this.selectedMap == 'temperature_indices'"
+        />
+        <MapModal
+          v-if="
+            this.selectedMap != undefined &&
+            this.selectedMap != 'temperature' &&
+            this.selectedMap != 'temperature_indices'
+          "
+        />
       </div>
       <div v-if="reportIsVisible">
         <FullReport />
@@ -103,6 +113,8 @@
 <script>
 import { mapGetters } from 'vuex'
 import MapModal from '~/components/MapModal'
+import TemperatureMap from '~/components/TemperatureMap'
+import TemperatureIndicesMap from '~/components/TemperatureIndicesMap'
 import SearchControls from '~/components/SearchControls'
 import FullReport from '~/components/Report'
 
@@ -111,8 +123,15 @@ export default {
   layout: 'home',
   components: {
     MapModal,
+    TemperatureMap,
+    TemperatureIndicesMap,
     SearchControls,
     FullReport,
+  },
+  computed: {
+    ...mapGetters({
+      selectedMap: 'map/selectedMap',
+    }),
   },
   computed: {
     ...mapGetters({


### PR DESCRIPTION
Closes #224.

This PR restores the ability to override the map layers sidebar content via template slots. It also:

- Groups the Temperature map layers in the sidebar the same way they had been grouped before, and restores the historical/model/scenario intro text above the layer list, too
- Groups the Temperature Indices map layers in a similar way, by category, and adds layer intro text here too
- Switches to using computed properties instead of methods in a couple cases to make the code more concise
- Fixes the Temperature Indices subtitle/blurb bug

To test, load and look at each of the four maps and make sure the sidebar content looks good for each.