### PR TITLE
Make report page units darker for printing to fix Safari issue

### DIFF
--- a/components/UnitWidget.vue
+++ b/components/UnitWidget.vue
@@ -8,6 +8,9 @@
 <style lang="scss" scoped>
 .light {
   color: #888;
+  @media print {
+    color: #666;
+  }
 }
 </style>
 <script>


### PR DESCRIPTION
Closes #249.

This PR adds a media query to make unit labels slightly darker when printing. This fixes the issue in Safari where the units were too light in print mode. This has been tested in Chrome and Firefox, also. Each browser seems to deal with text lightness differently when in print view, but the units are now easy to read across all three browsers.