### PR TITLE
Hide CSV download buttons on print view

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -18,6 +18,8 @@
   max-width: 50rem;
 }
 
-.no-print {
-  display: none !important;
+@media print {
+  .no-print {
+    display: none !important;
+  }
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -17,3 +17,7 @@
 .content-clamp {
   max-width: 50rem;
 }
+
+.no-print {
+  display: none !important;
+}

--- a/components/DownloadCsvButton.vue
+++ b/components/DownloadCsvButton.vue
@@ -5,6 +5,9 @@
 .single {
   display: block;
   max-width: 30em;
+  @media print {
+    display: none;
+  }
 }
 </style>
 <script>

--- a/components/DownloadCsvButton.vue
+++ b/components/DownloadCsvButton.vue
@@ -1,13 +1,12 @@
 <template>
-  <a :href="downloadTarget" class="button is-info single">{{ text }}</a>
+  <a :href="downloadTarget" class="button is-info single no-print">{{
+    text
+  }}</a>
 </template>
 <style lang="scss" scoped>
 .single {
   display: block;
   max-width: 30em;
-  @media print {
-    display: none;
-  }
 }
 </style>
 <script>


### PR DESCRIPTION
Closes #255.

This PR adds a media query to hide the CSV download buttons when printing. This has been tested with Chrome, Firefox, and Safari.