### PR TITLE
Hide download links from print view

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -19,5 +19,5 @@
 }
 
 .no-print {
-  display: none;
+  display: none !important;
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -18,6 +18,8 @@
   max-width: 50rem;
 }
 
-.no-print {
-  display: none !important;
+@media print {
+  .no-print {
+    display: none !important;
+  }
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -17,3 +17,7 @@
 .content-clamp {
   max-width: 50rem;
 }
+
+.no-print {
+  display: none;
+}

--- a/components/plates/design_freezing_index/Report.vue
+++ b/components/plates/design_freezing_index/Report.vue
@@ -53,8 +53,8 @@
           </tr>
         </tbody>
       </table>
-      <h4 class="title is-6">Access to Data</h4>
-      <div class="content">
+      <h4 class="title is-6 no-print">Access to Data</h4>
+      <div class="content no-print">
         <p>Freezing index data was calculated from the following:</p>
         <ul>
           <li>

--- a/components/plates/design_thawing_index/Report.vue
+++ b/components/plates/design_thawing_index/Report.vue
@@ -51,8 +51,8 @@
           </tr>
         </tbody>
       </table>
-      <h4 class="title is-6">Access to Data</h4>
-      <div class="content">
+      <h4 class="title is-6 no-print">Access to Data</h4>
+      <div class="content no-print">
         <p>Thawing index data was calculated from the following:</p>
         <ul>
           <li>

--- a/components/plates/freezing_index/Report.vue
+++ b/components/plates/freezing_index/Report.vue
@@ -82,8 +82,8 @@
           </tr>
         </tbody>
       </table>
-      <h4 class="title is-6">Access to Data</h4>
-      <div class="content">
+      <h4 class="title is-6 no-print">Access to Data</h4>
+      <div class="content no-print">
         <p>Freezing index data was calculated from the following:</p>
         <ul>
           <li>

--- a/components/plates/heating_degree_days/Report.vue
+++ b/components/plates/heating_degree_days/Report.vue
@@ -82,8 +82,8 @@
           </tr>
         </tbody>
       </table>
-      <h4 class="title is-6">Access to Data</h4>
-      <div class="content">
+      <h4 class="title is-6 no-print">Access to Data</h4>
+      <div class="content no-print">
         <p>Heating degrees days data was calculated from the following:</p>
         <ul>
           <li>

--- a/components/plates/precipitation/Report.vue
+++ b/components/plates/precipitation/Report.vue
@@ -82,8 +82,8 @@
           </tr>
         </tbody>
       </table>
-      <h4 class="title is-6">Access to Data</h4>
-      <div class="content">
+      <h4 class="title is-6 no-print">Access to Data</h4>
+      <div class="content no-print">
         <ul>
           <li>
             <a

--- a/components/plates/snowfall/Report.vue
+++ b/components/plates/snowfall/Report.vue
@@ -49,8 +49,8 @@
         </tbody>
       </table>
 
-      <h4 class="title is-6">Access to Data</h4>
-      <div class="content">
+      <h4 class="title is-6 no-print">Access to Data</h4>
+      <div class="content no-print">
         <ul>
           <li>
             <a

--- a/components/plates/temperature/Report.vue
+++ b/components/plates/temperature/Report.vue
@@ -82,8 +82,8 @@
           </tr>
         </tbody>
       </table>
-      <h4 class="title is-6">Access to Data</h4>
-      <div class="content">
+      <h4 class="title is-6 no-print">Access to Data</h4>
+      <div class="content no-print">
         <ul>
           <li>
             <a

--- a/components/plates/thawing_index/Report.vue
+++ b/components/plates/thawing_index/Report.vue
@@ -69,8 +69,8 @@
           </tr>
         </tbody>
       </table>
-      <h4 class="title is-6">Access to Data</h4>
-      <div class="content">
+      <h4 class="title is-6 no-print">Access to Data</h4>
+      <div class="content no-print">
         <p>Thawing index data was calculated from the following:</p>
         <ul>
           <li>


### PR DESCRIPTION
Closes #254.

This PR uses a `no-print` utility class to hide the data download section from each section of the report.