### PR TITLE
Hide header banner, unit switcher, and buttons from print mode of report page

### DIFF
--- a/components/CloseReportButton.vue
+++ b/components/CloseReportButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="back">
+  <div class="back no-print">
     <b-button
       v-on:click="close"
       class="default"

--- a/components/HeaderBanner.vue
+++ b/components/HeaderBanner.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="headerbanner">
+  <div class="headerbanner no-print">
     University of Alaska
     Fairbanks&nbsp;&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;&nbsp;Scenarios Network
     for Alaska + Arctic Planning

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="nav-wrapper">
+  <div class="nav-wrapper no-print">
     <b-navbar>
       <template #start>
         <b-navbar-item href="/"> Home </b-navbar-item>

--- a/components/UnitRadio.vue
+++ b/components/UnitRadio.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="radio-units">
+  <div class="radio-units no-print">
     <p>You can display these results in Imperial or Metric units.</p>
     <div>
       <b-field label="Units">


### PR DESCRIPTION
Closes #250.
Closes #251.
Closes #252.

This PR uses the new global `no-print` class to hide the UAF/SNAP header banner (not the logo header below it), unit switcher, and back button from the report page in print mode.