### PR TITLE
Improve formatting of logo & tagline header in print mode

### DIFF
--- a/layouts/home.vue
+++ b/layouts/home.vue
@@ -24,8 +24,11 @@
   justify-content: center;
   max-width: 98vw;
   margin: 2.5rem auto;
-  @media (min-width: 769px) {
+  @media (min-width: 769px), print {
     display: flex;
+  }
+  @media print {
+    margin-bottom: 0;
   }
   .brand--logo {
     max-width: 300px;
@@ -35,8 +38,11 @@
     @media (max-width: 768px) {
       margin: 0 auto;
     }
-    @media (min-width: 769px) {
+    @media (min-width: 769px), print {
       flex: 0 0 15em;
+    }
+    @media print {
+      max-width: 25%;
     }
     @media (min-width: 769px) and (max-width: 1425px) {
       margin-left: 2rem;


### PR DESCRIPTION
Closes #235.

This PR adds a few CSS media queries to use flex boxes for the logo & taglines in the header in print mode, and also removes the excessive vertical whitespace below the logo & taglines in print mode. Without these changes, the logo & taglines consumed about half of the first printed page. This makes the logo & taglines more compact. I've tested these changes in Chrome, Firefox, and Safari.