### PR TITLE
Set minimap to absolute size to fix print mode bug

### DIFF
--- a/components/MiniMap.vue
+++ b/components/MiniMap.vue
@@ -11,8 +11,8 @@
   margin: 2rem 0 3rem;
 }
 #report--minimmap--map {
-  height: 20vw;
-  width: 20vw;
+  height: 300px;
+  width: 300px;
 }
 </style>
 


### PR DESCRIPTION
Closes #262.

This PR solves the problem described in #262, but not by invalidating the Leaflet map. You can observe the problem by loading the report page while on the `report_remix` branch and then switching to print mode (i.e., print preview). Because the minimap is sized using relative units (`vw` and `vh`), switching to print mode changes the viewport width, and then truncates the minimap so that the map marker is no longer in the center (or sometimes cropped off entirely depending on your browser width or display resolution).

After a bit of experimenting, it does not appear to be possible to use Leaflet's `invalidateSize()` method while in print mode. So, this PR fixes the problem by simply setting the minimap to absolute units (`300px` x `300px`). To test, try loading a report and then loading a print preview for it. The minimap should look the same in print mode vs. the web page, and the map marker for the location should be in the center.