### PR TITLE
Prevents the maps from being viewed by devices with small screen real estate such as smart phones

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -23,9 +23,3 @@
     display: none !important;
   }
 }
-
-@media screen and (max-width: 860px) {
-  .large-screen {
-    display: none;
-  }
-}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -23,3 +23,14 @@
     display: none !important;
   }
 }
+
+@media screen and (max-width: 860px) {
+  .large-screen {
+    display: none;
+  }
+}
+@media screen and (min-width: 861px) {
+  .small-screen {
+    display: none;
+  }
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -29,8 +29,3 @@
     display: none;
   }
 }
-@media screen and (min-width: 861px) {
-  .small-screen {
-    display: none;
-  }
-}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,7 +24,7 @@
         </div>
 
         <SearchControls />
-        <div class="px-5 pb-6 large-screen">
+        <div class="px-5 pb-6 is-hidden-mobile">
           <div class="columns is-multiline">
             <div class="column is-half">
               <h3 class="is-size-4">Precipitation</h3>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,7 +24,7 @@
         </div>
 
         <SearchControls />
-        <div class="px-5 pb-6">
+        <div class="px-5 pb-6 large-screen">
           <div class="columns is-multiline">
             <div class="column is-half">
               <h3 class="is-size-4">Precipitation</h3>


### PR DESCRIPTION
This PR hides the maps on the home page when viewed on smart phones and smaller tablets. It uses the same CSS as in the NCR for this purpose.

Fixes #164 