### PR TITLE
Adds DOT projected precipitation into ArcticEDS

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -34,16 +34,15 @@
             </p>
             <p>
               The elevation within 1&#8239;km of this point ranges between
-              {{ results.elevation.min }}&ndash;{{
-                results.elevation.max
-              }}
+              {{ results.elevation.min }}&ndash;{{ results.elevation.max }}
               meters, with an average elevation of
               {{ results.elevation.mean }} meters. This variation should be kept
               in mind when interpreting the variables below.
             </p>
             <p>
-              The geology type of this point is <em>{{ results.geology.name }}</em>, and
-              this place lies within the
+              The geology type of this point is
+              <em>{{ results.geology.name }}</em
+              >, and this place lies within the
               {{ results.physiography.name }} ecological unit within Alaska.
               Read more about
               <a
@@ -137,6 +136,11 @@
             </p>
           </div>
           <PrecipitationReport />
+
+          <h3 id="projected-precipitation" class="title is-3 mt-6">
+            Projected Precipitation
+          </h3>
+          <ProjectedPrecipitation />
 
           <h3 id="snowfall" class="title is-3 mt-6">Snowfall</h3>
           <div class="content">
@@ -270,6 +274,7 @@ import DesignFreezingIndexReport from '~/components/reports/DesignFreezingIndex'
 import DesignThawingIndexReport from '~/components/reports/DesignThawingIndex'
 import FreezingIndexReport from '~/components/reports/FreezingIndex'
 import ThawingIndexReport from '~/components/reports/ThawingIndex'
+import ProjectedPrecipitation from '~/components/reports/ProjectedPrecipitation'
 
 export default {
   name: 'FullReport',
@@ -285,6 +290,7 @@ export default {
     DesignThawingIndexReport,
     FreezingIndexReport,
     ThawingIndexReport,
+    ProjectedPrecipitation,
   },
   computed: {
     state: function () {

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -79,6 +79,11 @@
                     >
                   </li>
                   <li>
+                    <a href="#projected-precipitation"
+                      >Projected Precipitation</a
+                    >
+                  </li>
+                  <li>
                     <a href="#snowfall">Snowfall</a>
                   </li>
                 </ul>

--- a/components/reports/ProjectedPrecipitation.vue
+++ b/components/reports/ProjectedPrecipitation.vue
@@ -2,7 +2,7 @@
   <div v-if="Object.keys(results.dot_precip).length != 0">
     <div v-for="model in ['GFDL-CM3', 'NCAR-CCSM4']" class="pb-5">
       <h3 class="title is-5 has-text-centered">
-        Modeled cumulative rainfall, {{ model }}, 2020-2049 (inches)
+        Modeled cumulative rainfall, {{ model }}, 2020-2049 ({{ getUnits }})
       </h3>
       <table class="table">
         <thead>
@@ -88,7 +88,11 @@ export default {
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
+      units: 'report/units',
     }),
+    getUnits() {
+      return this.units === 'imperial' ? 'inches' : 'mm'
+    },
   },
   watch: {
     isPlaceDefined: function () {

--- a/components/reports/ProjectedPrecipitation.vue
+++ b/components/reports/ProjectedPrecipitation.vue
@@ -132,11 +132,19 @@ export default {
   watch: {
     isPlaceDefined: function () {
       this.$fetch()
+      console.log('Fetching...')
     },
   },
   fetch() {
     const plateResults = {}
     for (const return_interval in this.results.proj_precip) {
+      // If the results have already been converted, such as when
+      // clicking on an anchor link in the TOC, do not try to convert
+      // the results again.
+      if (return_interval.includes('pr')) {
+        plateResults = this.results.proj_precip
+        break
+      }
       const durations = this.results.proj_precip[return_interval]
       for (const duration in durations) {
         const models = durations[duration]

--- a/components/reports/ProjectedPrecipitation.vue
+++ b/components/reports/ProjectedPrecipitation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="Object.keys(results.dot_precip).length != 0">
+  <div v-if="Object.keys(results.proj_precip).length != 0">
     <div class="radio-units no-print">
       <p>You can choose the era to show in the tables below.</p>
       <div>
@@ -60,19 +60,19 @@
             <td>{{ duration }}</td>
             <td v-for="interval in [2, 5, 10, 25, 50, 100, 200, 500, 1000]">
               {{
-                results.dot_precip[
+                results.proj_precip[
                   `pr_${interval}_${duration}_${model}_${radioEra}_mean`
                 ]
               }}<UnitWidget unitType="mm_in" /><br />
               <span class="small-text">
                 ({{
-                  results.dot_precip[
+                  results.proj_precip[
                     `pr_${interval}_${duration}_${model}_${radioEra}_min`
                   ]
                 }}
                 &ndash;
                 {{
-                  results.dot_precip[
+                  results.proj_precip[
                     `pr_${interval}_${duration}_${model}_${radioEra}_max`
                   ]
                 }})
@@ -84,7 +84,7 @@
     </div>
     <DownloadCsvButton
       text="Download projected precipitation data as CSV"
-      endpoint="dot_precip/point"
+      endpoint="proj_precip/point"
       class="mt-3 mb-5"
     />
   </div>
@@ -124,23 +124,21 @@ export default {
   },
   fetch() {
     const plateResults = {}
-    for (const key1 in this.results.dot_precip) {
-      const data1 = this.results.dot_precip[key1]
+    for (const key1 in this.results.proj_precip) {
+      const data1 = this.results.proj_precip[key1]
       for (const key2 in data1) {
         const data2 = data1[key2]
         for (const key3 in data2) {
           const data3 = data2[key3]
           for (const key4 in data3) {
             const data4 = data3[key4]
-            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_min`] = (
-              data4.pf_lower * 25.4
-            ).toFixed(0)
-            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_mean`] = (
-              data4.pf * 25.4
-            ).toFixed(0)
-            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_max`] = (
-              data4.pf_upper * 25.4
-            ).toFixed(0)
+            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_min`] =
+              data4.pf_lower
+
+            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_mean`] = data4.pf
+
+            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_max`] =
+              data4.pf_upper
           }
         }
       }
@@ -148,7 +146,7 @@ export default {
 
     this.$store.commit('report/setPlateResults', {
       plateResults: plateResults,
-      variable: 'dot_precip',
+      variable: 'proj_precip',
     })
   },
 }

--- a/components/reports/ProjectedPrecipitation.vue
+++ b/components/reports/ProjectedPrecipitation.vue
@@ -132,7 +132,6 @@ export default {
   watch: {
     isPlaceDefined: function () {
       this.$fetch()
-      console.log('Fetching...')
     },
   },
   fetch() {

--- a/components/reports/ProjectedPrecipitation.vue
+++ b/components/reports/ProjectedPrecipitation.vue
@@ -1,8 +1,26 @@
 <template>
   <div v-if="Object.keys(results.dot_precip).length != 0">
+    <div class="radio-units no-print">
+      <p>You can choose the era to show in the tables below.</p>
+      <div>
+        <b-field label="Era">
+          <b-radio v-model="radioEra" name="radioEra" native-value="2020-2049">
+            2020-2049
+          </b-radio>
+          <b-radio v-model="radioEra" name="radioEra" native-value="2050-2079">
+            2050-2079
+          </b-radio>
+          <b-radio v-model="radioEra" name="radioEra" native-value="2080-2099">
+            2080-2099
+          </b-radio>
+        </b-field>
+      </div>
+    </div>
     <div v-for="model in ['GFDL-CM3', 'NCAR-CCSM4']" class="pb-5">
-      <h3 class="title is-5 has-text-centered">
-        Modeled cumulative rainfall, {{ model }}, 2020-2049 ({{ getUnits }})
+      <h3 class="title is-5 pt-5">
+        Modeled cumulative rainfall, {{ model }}, {{ radioEra }} ({{
+          getUnits
+        }})
       </h3>
       <table class="table">
         <thead>
@@ -43,19 +61,19 @@
             <td v-for="interval in [2, 5, 10, 25, 50, 100, 200, 500, 1000]">
               {{
                 results.dot_precip[
-                  `pr_${interval}_${duration}_GFDL-CM3_2020-2049_mean`
+                  `pr_${interval}_${duration}_${model}_${radioEra}_mean`
                 ]
               }}<UnitWidget unitType="mm_in" /><br />
               <span class="small-text">
                 ({{
                   results.dot_precip[
-                    `pr_${interval}_${duration}_GFDL-CM3_2020-2049_min`
+                    `pr_${interval}_${duration}_${model}_${radioEra}_min`
                   ]
                 }}
                 &ndash;
                 {{
                   results.dot_precip[
-                    `pr_${interval}_${duration}_GFDL-CM3_2020-2049_max`
+                    `pr_${interval}_${duration}_${model}_${radioEra}_max`
                   ]
                 }})
               </span>
@@ -82,6 +100,11 @@ export default {
   components: {
     DownloadCsvButton,
     UnitWidget,
+  },
+  data() {
+    return {
+      radioEra: '2020-2049',
+    }
   },
   computed: {
     ...mapGetters({

--- a/components/reports/ProjectedPrecipitation.vue
+++ b/components/reports/ProjectedPrecipitation.vue
@@ -45,7 +45,7 @@
                 results.dot_precip[
                   `pr_${interval}_${duration}_GFDL-CM3_2020-2049_mean`
                 ]
-              }}<br />
+              }}<UnitWidget unitType="mm_in" /><br />
               <span class="small-text">
                 ({{
                   results.dot_precip[
@@ -109,16 +109,19 @@ export default {
           const data3 = data2[key3]
           for (const key4 in data3) {
             const data4 = data3[key4]
-            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_min`] =
-              data4.pf_lower
-            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_mean`] = data4.pf
-            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_max`] =
-              data4.pf_upper
+            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_min`] = (
+              data4.pf_lower * 25.4
+            ).toFixed(0)
+            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_mean`] = (
+              data4.pf * 25.4
+            ).toFixed(0)
+            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_max`] = (
+              data4.pf_upper * 25.4
+            ).toFixed(0)
           }
         }
       }
     }
-    console.log(plateResults)
 
     this.$store.commit('report/setPlateResults', {
       plateResults: plateResults,

--- a/components/reports/ProjectedPrecipitation.vue
+++ b/components/reports/ProjectedPrecipitation.vue
@@ -1,0 +1,135 @@
+<template>
+  <div v-if="Object.keys(results.dot_precip).length != 0">
+    <div v-for="model in ['GFDL-CM3', 'NCAR-CCSM4']" class="pb-5">
+      <h3 class="title is-5 has-text-centered">
+        Modeled cumulative rainfall, {{ model }}, 2020-2049 (inches)
+      </h3>
+      <table class="table">
+        <thead>
+          <tr>
+            <th class="no-border">Duration</th>
+            <th class="no-border" colspan="9">
+              Annual exceedance probability (1/years)
+            </th>
+          </tr>
+          <tr>
+            <th></th>
+            <th v-for="interval in [2, 5, 10, 25, 50, 100, 200, 500, 1000]">
+              1 / {{ interval }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="duration in [
+              '60m',
+              '2h',
+              '3h',
+              '6h',
+              '12h',
+              '24h',
+              '2d',
+              '3d',
+              '4d',
+              '7d',
+              '10d',
+              '20d',
+              '30d',
+              '45d',
+              '60d',
+            ]"
+          >
+            <td>{{ duration }}</td>
+            <td v-for="interval in [2, 5, 10, 25, 50, 100, 200, 500, 1000]">
+              {{
+                results.dot_precip[
+                  `pr_${interval}_${duration}_GFDL-CM3_2020-2049_mean`
+                ]
+              }}<br />
+              <span class="small-text">
+                ({{
+                  results.dot_precip[
+                    `pr_${interval}_${duration}_GFDL-CM3_2020-2049_min`
+                  ]
+                }}
+                &ndash;
+                {{
+                  results.dot_precip[
+                    `pr_${interval}_${duration}_GFDL-CM3_2020-2049_max`
+                  ]
+                }})
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <DownloadCsvButton
+      text="Download projected precipitation data as CSV"
+      endpoint="dot_precip/point"
+      class="mt-3 mb-5"
+    />
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import DownloadCsvButton from '~/components/DownloadCsvButton'
+import UnitWidget from '~/components/UnitWidget'
+
+export default {
+  name: 'ProjectedPrecipitationReport',
+  components: {
+    DownloadCsvButton,
+    UnitWidget,
+  },
+  computed: {
+    ...mapGetters({
+      results: 'report/results',
+      placeName: 'report/placeName',
+      isPlaceDefined: 'report/isPlaceDefined',
+    }),
+  },
+  watch: {
+    isPlaceDefined: function () {
+      this.$fetch()
+    },
+  },
+  fetch() {
+    const plateResults = {}
+    for (const key1 in this.results.dot_precip) {
+      const data1 = this.results.dot_precip[key1]
+      for (const key2 in data1) {
+        const data2 = data1[key2]
+        for (const key3 in data2) {
+          const data3 = data2[key3]
+          for (const key4 in data3) {
+            const data4 = data3[key4]
+            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_min`] =
+              data4.pf_lower
+            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_mean`] = data4.pf
+            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_max`] =
+              data4.pf_upper
+          }
+        }
+      }
+    }
+    console.log(plateResults)
+
+    this.$store.commit('report/setPlateResults', {
+      plateResults: plateResults,
+      variable: 'dot_precip',
+    })
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.small-text {
+  font-size: 10px;
+  font-style: italic;
+}
+.no-border {
+  border: none;
+}
+</style>

--- a/components/reports/ProjectedPrecipitation.vue
+++ b/components/reports/ProjectedPrecipitation.vue
@@ -82,6 +82,18 @@
         </tbody>
       </table>
     </div>
+    <h4 class="title is-6 no-print">Access to Data</h4>
+    <div class="content no-print">
+      <ul>
+        <li>
+          <a
+            href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/304b6d89-961e-417d-b6ba-4139c7fe5ff6"
+            target="_blank"
+            >Annual maximum precipitation projections for Alaska</a
+          >
+        </li>
+      </ul>
+    </div>
     <DownloadCsvButton
       text="Download projected precipitation data as CSV"
       endpoint="proj_precip/point"
@@ -124,21 +136,25 @@ export default {
   },
   fetch() {
     const plateResults = {}
-    for (const key1 in this.results.proj_precip) {
-      const data1 = this.results.proj_precip[key1]
-      for (const key2 in data1) {
-        const data2 = data1[key2]
-        for (const key3 in data2) {
-          const data3 = data2[key3]
-          for (const key4 in data3) {
-            const data4 = data3[key4]
-            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_min`] =
-              data4.pf_lower
+    for (const return_interval in this.results.proj_precip) {
+      const durations = this.results.proj_precip[return_interval]
+      for (const duration in durations) {
+        const models = durations[duration]
+        for (const model in models) {
+          const eras = models[model]
+          for (const era in eras) {
+            const precips = eras[era]
+            plateResults[
+              `pr_${return_interval}_${duration}_${model}_${era}_min`
+            ] = precips.pf_lower
 
-            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_mean`] = data4.pf
+            plateResults[
+              `pr_${return_interval}_${duration}_${model}_${era}_mean`
+            ] = precips.pf
 
-            plateResults[`pr_${key1}_${key2}_${key3}_${key4}_max`] =
-              data4.pf_upper
+            plateResults[
+              `pr_${return_interval}_${duration}_${model}_${era}_max`
+            ] = precips.pf_upper
           }
         }
       }

--- a/store/report.js
+++ b/store/report.js
@@ -140,7 +140,7 @@ export default {
         { type: 'temperature', substring: '', variable: 'temperature' },
         { type: 'mm_in', substring: '', variable: 'precipitation' },
         { type: 'mm_in', substring: '', variable: 'snowfall' },
-        { type: 'mm_in', substring: '', variable: 'dot_precip' },
+        { type: 'mm_in', substring: '', variable: 'proj_precip' },
       ]
       conversions.forEach(conversion => {
         convertUnits(

--- a/store/report.js
+++ b/store/report.js
@@ -29,10 +29,21 @@ function convertTemperature(state, variable, key) {
 }
 
 function convertMillimetersInches(state, variable, key) {
+  // If the variable is proj_precip, we want the metric and
+  // imperial units to be set to 2 decimal places to match
+  // the DOT Projected Precipitation application.
   if (state.units == 'metric') {
-    return (state.results[variable][key] * 25.4).toFixed(0)
+    if (variable == 'proj_precip') {
+      return (state.results[variable][key] * 25.4).toFixed(2)
+    } else {
+      return (state.results[variable][key] * 25.4).toFixed(0)
+    }
   } else {
-    return (state.results[variable][key] / 25.4).toFixed(1)
+    if (variable == 'proj_precip') {
+      return (state.results[variable][key] / 25.4).toFixed(2)
+    } else {
+      return (state.results[variable][key] / 25.4).toFixed(1)
+    }
   }
 }
 

--- a/store/report.js
+++ b/store/report.js
@@ -150,6 +150,7 @@ export default {
         { type: 'temperature', substring: '', variable: 'temperature' },
         { type: 'mm_in', substring: '', variable: 'precipitation' },
         { type: 'mm_in', substring: '', variable: 'snowfall' },
+        { type: 'mm_in', substring: '', variable: 'dot_precip' },
       ]
       conversions.forEach(conversion => {
         convertUnits(

--- a/store/report.js
+++ b/store/report.js
@@ -1,33 +1,23 @@
 import _ from 'lodash'
 
 function convertUnits(state, type, substring = '', variable) {
+  let variable_results = {}
   Object.keys(state.results[variable]).forEach(key => {
     if (key.includes(substring)) {
       switch (type) {
         case 'temperature':
-          state.results[variable][key] = convertTemperature(
-            state,
-            variable,
-            key
-          )
+          variable_results[key] = convertTemperature(state, variable, key)
           break
         case 'm_in':
-          state.results[variable][key] = convertMetersInches(
-            state,
-            variable,
-            key
-          )
+          variable_results[key] = convertMetersInches(state, variable, key)
           break
         case 'mm_in':
-          state.results[variable][key] = convertMillimetersInches(
-            state,
-            variable,
-            key
-          )
+          variable_results[key] = convertMillimetersInches(state, variable, key)
           break
       }
     }
   })
+  state.results[variable] = variable_results
 }
 
 function convertTemperature(state, variable, key) {


### PR DESCRIPTION
This PR adds the projected precipitation data that had been generated for the Department of Transportation into the precipitation section of the ArcticEDS report. This generates a table very similar to the table generated on the [original website](https://snap.uaf.edu/tools/future-alaska-precip) but at a much faster rate coming from Rasdaman and the data API. 

To use this branch, use these environment variables:

export RASDAMAN_URL=https://apollo.snap.uaf.edu/rasdaman/ows
export SNAP_API_URL=http://localhost:5000

Closes #289 