### PR TITLE
Return to previous y-axis page position when map modal is closed

### DIFF
--- a/middleware/adjustScroll.js
+++ b/middleware/adjustScroll.js
@@ -1,0 +1,24 @@
+// Adapted from:
+// https://levelup.gitconnected.com/nuxt-js-how-to-retain-scroll-position-when-returning-to-page-without-navigation-history-7f0250886d27
+//
+// When loading map modals, save the previous y-axis scroll position so users
+// are placed back at the same y-axis position on the front page when they
+// close the modal. This also works if a user navigates to a different page
+// from a modal link, clicks back, then closes the modal.
+export default function ({ route, from }) {
+  const scrollPos = from?.meta[0].scrollPos
+  if (scrollPos && Object.keys(scrollPos).length > 0) {
+    const isFrontPage = route.fullPath == '/'
+    const isMapRoute = route.fullPath.substring(0, 2) == '/#'
+    if (isMapRoute) {
+      scrollPos.y = window.scrollY || 0
+      scrollPos.x = window.scrollX || 0
+    }
+    if (isFrontPage || isMapRoute) {
+      setTimeout(function () {
+        const previousY = scrollPos.y
+        window.scrollTo(0, previousY)
+      })
+    }
+  }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -87,5 +87,6 @@ export default {
         component: resolve(__dirname, 'pages/index'),
       })
     },
+    middleware: ['adjustScroll'],
   },
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -147,5 +147,11 @@ export default {
       })
     },
   },
+  meta: {
+    scrollPos: {
+      x: 0,
+      y: 0,
+    },
+  },
 }
 </script>


### PR DESCRIPTION
Closes #297.

This PR preserves the y-axis position on the front page when a user loads and then closes a map modal. Since map modals were implemented with permalink support (e.g., http://localhost:3000/#temperature), any time a map modal is loaded, it's actually reloading the entire front page from scratch by changing the route, which is what causes the app to lose track of the user's y-axis position on the page.

This has been fixed by implementing a route middleware that saves the front page's y-axis position to a meta property that persists between route transitions. The front page is still loaded from scratch whenever a map modal is loaded, but the y-axis scroll position is set back to its previous value when the modal is closed if the user arrived at the modal from the front page (i.e., not a permalink). Even better, if the user loads a map modal containing an embedded "Read more" link, if the user then clicks this link and lands on yet another page, the front page y-axis position persists between nested page transitions if the user goes back.

To test:

- Load the front page and click a map thumbnail to load a map modal
- Close the modal and verify that the front page is at the same y-axis scroll position as before
- Click the "Temperature" map modal, then click the "Read more" link inside of it to go to the "Climate Modeling" page
- Click your browser's back button to return to the map modal, then close the map modal and verify that you are still at the y-axis where your journey started