### PR TITLE
Integrate preview/summary pattern in reports

### DIFF
--- a/assets/scss/bulma-overrides.scss
+++ b/assets/scss/bulma-overrides.scss
@@ -12,14 +12,25 @@ a:focus {
   text-decoration: underline;
 }
 
-// General stuff for data summary/preview tables
+// General stuff for data summary/preview tables + report sections
+blockquote {
+  font-size: 1.15rem;
+}
+
 table {
   font-family: 'IBM Plex Mono', monospace;
   line-height: 1;
+
+  caption {
+    font-family: 'Overpass', sans-serif !important;
+    font-size: 1.15rem;
+    margin-bottom: 0.25rem;
+  }
 }
 
 table.preview {
-  td, th {
+  td,
+  th {
     padding: 0.5rem;
     border: 1px solid #888;
   }

--- a/assets/scss/bulma-overrides.scss
+++ b/assets/scss/bulma-overrides.scss
@@ -12,6 +12,32 @@ a:focus {
   text-decoration: underline;
 }
 
+// General stuff for data summary/preview tables
+table {
+  font-family: 'IBM Plex Mono', monospace;
+  line-height: 1;
+}
+
+table.preview {
+  td, th {
+    padding: 0.5rem;
+    border: 1px solid #888;
+  }
+  th {
+    font-weight: bold;
+  }
+  tfoot td {
+    border: none;
+  }
+}
+
+// vertical ellipsis
+.vellip {
+  font-size: 120%;
+  font-weight: bold;
+  text-align: center;
+}
+
 // Fix spacing on radio buttons / fields (beufy)
 label.b-radio.radio span.control-label {
   margin-right: 1.5rem;

--- a/components/PreviewTable.vue
+++ b/components/PreviewTable.vue
@@ -1,0 +1,62 @@
+<template>
+  <table class="preview">
+    <thead>
+      <tr>
+        <th scope="col" v-for="col in csvHeader">{{ col }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="row in csvHead">
+        <td v-for="value in row">{{ value }}</td>
+      </tr>
+      <tr>
+        <td :colspan="csvHeader.length" class="vellip">&#8942;</td>
+      </tr>
+      <tr v-for="row in csvTail">
+        <td v-for="value in row">{{ value }}</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td :colspan="csvHeader.length">{{ sizeBlurb }}</td>
+      </tr>
+    </tfoot>
+  </table>
+</template>
+
+<script>
+export default {
+  name: 'PreviewTable',
+  props: ['csvString', 'sizeBlurb'],
+  computed: {
+    csvParsed() {
+      if (this.csvString) {
+        let csvSplit = this.csvString.split('\r\n')
+        csvSplit = csvSplit.map(row => {
+          return row.split(',')
+        })
+        return csvSplit
+      } else {
+        return []
+      }
+    },
+    csvHeader() {
+      if (this.csvParsed) {
+        return this.csvParsed[0]
+      }
+    },
+    csvHead() {
+      if (this.csvParsed) {
+        return this.csvParsed.slice(1, 6)
+      }
+    },
+    csvTail() {
+      if (this.csvParsed) {
+        return this.csvParsed.slice(6, 11)
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -209,12 +209,34 @@
             <ThawingIndexReport />
           </div>
           <div class="block">
-            <div class="content is-size-5">
+            <div class="content is-size-5 data-outro content no-print">
               <h4 class="title is-5 no-print">
                 Data access &amp; additional information
               </h4>
+
               <ul>
-                <li></li>
+                <li>
+                  Source dataset and metadata:
+                  <a
+                    href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/3d4cc2e2-5cfb-4fed-b397-06854edb747f"
+                    >20km annual degree day totals at multiple thresholds for
+                    Alaska, 1980&ndash;2100</a
+                  >
+                </li>
+                <li>
+                  Academic reference:
+                  <blockquote>
+                    Bieniek, P. A., Bhatt, U. S., Walsh, J. E., Rupp, T. S.,
+                    Zhang, J., Krieger, J. R. &amp; Lader, R. (2016). Dynamical
+                    Downscaling of ERA-Interim Temperature and Precipitation for
+                    Alaska.
+                    <i>Journal of Applied Meteorology and Climatology, 55</i
+                    >(03), 635–654.
+                    <a href="https://doi.org/10.1175/JAMC-D-15-0153.1"
+                      >https://doi.org/10.1175/JAMC-D-15-0153.1</a
+                    >
+                  </blockquote>
+                </li>
               </ul>
             </div>
           </div>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -288,8 +288,6 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('report/fetchPlaces')
-
     if (this.isPlaceDefined) {
       let url =
         process.env.apiUrl +

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -222,7 +222,6 @@
       </section>
       <section class="section permafrost">
         <div class="container">
-          <h2 id="permafrost" class="title is-2">Permafrost</h2>
           <PermafrostReport />
         </div>
       </section>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -288,6 +288,11 @@ export default {
   },
 
   async fetch() {
+    // Needed here to ensure hydration works properly for
+    // direct links to specific places (mapping place names
+    // to lat/lngs).
+    await this.$store.dispatch('report/fetchPlaces')
+
     if (this.isPlaceDefined) {
       let url =
         process.env.apiUrl +

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -139,7 +139,7 @@
           <h3 id="precipitation-frequency" class="title is-3 mt-6">
             Precipitation Frequency
           </h3>
-          
+
           <PrecipitationFrequency />
 
           <h3 id="snowfall" class="title is-3 mt-6">Snowfall</h3>
@@ -181,10 +181,10 @@
           <h2 id="temperature-indices" class="title is-2">
             Temperature Indices
           </h2>
-          <div class="content is-size-5">
+          <div class="block content is-size-5">
             <p>
               The results in the sections below come from two types of data
-              sources: historical modeled data (ERA Interim) and projected
+              sources: historical modeled data (ERA-Interim) and projected
               climate conditions using two climate models (NCAR CCSM4 and GFDL
               CM3) and one emissions scenario (RCP 8.5).
             </p>
@@ -194,17 +194,30 @@
               resolution.
             </p>
           </div>
-
-          <h3 id="heating-degree-days" class="title is-3 mt-6">
-            Heating Degree Days
-          </h3>
-          <HeatingDegreeDaysReport />
-
-          <h3 id="freezing-index" class="title is-3 mt-6">Freezing Index</h3>
-          <FreezingIndexReport />
-
-          <h3 id="thawing-index" class="title is-3 mt-6">Thawing Index</h3>
-          <ThawingIndexReport />
+          <div class="block">
+            <h3 id="heating-degree-days" class="title is-4 mb-3">
+              Heating Degree Days
+            </h3>
+            <HeatingDegreeDaysReport />
+          </div>
+          <div class="block">
+            <h3 id="freezing-index" class="title is-4">Freezing Index</h3>
+            <FreezingIndexReport />
+          </div>
+          <div class="block">
+            <h3 id="thawing-index" class="title is-4">Thawing Index</h3>
+            <ThawingIndexReport />
+          </div>
+          <div class="block">
+            <div class="content is-size-5">
+              <h4 class="title is-5 no-print">
+                Data access &amp; additional information
+              </h4>
+              <ul>
+                <li></li>
+              </ul>
+            </div>
+          </div>
         </div>
       </section>
       <section class="section permafrost">
@@ -223,14 +236,7 @@
     </div>
   </div>
 </template>
-<style lang="scss" scoped>
-.content {
-  max-width: 50rem;
-}
-.together {
-  display: inline-flex;
-}
-</style>
+<style lang="scss" scoped></style>
 <script>
 import { mapGetters } from 'vuex'
 import UnitRadio from '~/components/UnitRadio'

--- a/components/reports/FreezingIndex.vue
+++ b/components/reports/FreezingIndex.vue
@@ -14,60 +14,60 @@
           <tr>
             <th scope="row">Historical (1979-2015)</th>
             <td>
-              {{ results.freezing_index['historical']['ddmin']
+              {{ results.freezing_index['summary']['historical']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ results.freezing_index['historical']['ddmean']
+              {{ results.freezing_index['summary']['historical']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ results.freezing_index['historical']['ddmax']
+              {{ results.freezing_index['summary']['historical']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Early Century (2010-2039)</th>
             <td>
-              {{ results.freezing_index['2010-2039']['ddmin']
+              {{ results.freezing_index['summary']['2010-2039']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ results.freezing_index['2010-2039']['ddmean']
+              {{ results.freezing_index['summary']['2010-2039']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ results.freezing_index['2010-2039']['ddmax']
+              {{ results.freezing_index['summary']['2010-2039']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040-2069)</th>
             <td>
-              {{ results.freezing_index['2040-2069']['ddmin']
+              {{ results.freezing_index['summary']['2040-2069']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ results.freezing_index['2040-2069']['ddmean']
+              {{ results.freezing_index['summary']['2040-2069']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ results.freezing_index['2040-2069']['ddmax']
+              {{ results.freezing_index['summary']['2040-2069']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070-2099)</th>
             <td>
-              {{ results.freezing_index['2070-2099']['ddmin']
+              {{ results.freezing_index['summary']['2070-2099']['ddmin']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ results.freezing_index['2070-2099']['ddmean']
+              {{ results.freezing_index['summary']['2070-2099']['ddmean']
               }}<UnitWidget unitType="dd" />
             </td>
             <td>
-              {{ results.freezing_index['2070-2099']['ddmax']
+              {{ results.freezing_index['summary']['2070-2099']['ddmax']
               }}<UnitWidget unitType="dd" />
             </td>
           </tr>

--- a/components/reports/HeatingDegreeDays.vue
+++ b/components/reports/HeatingDegreeDays.vue
@@ -82,7 +82,7 @@
       <h4 class="title is-5 mb-1">Data preview</h4>
 
       <p class="content is-size-5 mb-1">
-        Downloaded data includes annual values for both historical ERA-Interim
+        CSV download includes annual values for both historical ERA-Interim
         (1980&ndash;2009) and modeled projected (2006&ndash;2100) datasets.
       </p>
       <table class="preview">
@@ -156,7 +156,7 @@
     </div>
     <div class="content is-size-5 no-print">
       <DownloadCsvButton
-        text="Download heating degree days data as CSV"
+        :text="downloadCsvText"
         endpoint="mmm/degree_days/heating/all"
         class="mt-3 mb-5"
       />
@@ -173,11 +173,13 @@ export default {
   name: 'HeatingDegreeDaysReport',
   components: {
     DownloadCsvButton,
-
     UnitWidget,
   },
 
   computed: {
+    downloadCsvText() {
+      return "Download CSV of heading degree days for " + this.placeName
+    },
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',

--- a/components/reports/HeatingDegreeDays.vue
+++ b/components/reports/HeatingDegreeDays.vue
@@ -1,97 +1,167 @@
 <template>
   <div v-if="Object.keys(results.heating_degree_days).length != 0">
-    
-      <table class="table">
-        <thead>
-          <tr>
-            <th scope="col"></th>
-            <th scope="col">Min</th>
-            <th scope="col">Mean</th>
-            <th scope="col">Max</th>
-          </tr>
-        </thead>
+    <h4 class="title is-5 mb-1">Summary</h4>
+    <div class="content is-size-5">
+      The summary table below shows the minimum, mean and maximum values across
+      one scenario (RCP 8.5) and both models (NCAR CCSM4 and GFDL CM3) for the
+      specified era, which can be helpful to assess broad trends and variation.
+    </div>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col"></th>
+          <th scope="col">Min</th>
+          <th scope="col">Mean</th>
+          <th scope="col">Max</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Historical (1979&ndash;2015)</th>
+          <td>
+            {{ results.heating_degree_days['historical']['ddmin']
+            }}<UnitWidget unitType="dd" />
+          </td>
+          <td>
+            {{ results.heating_degree_days['historical']['ddmean']
+            }}<UnitWidget unitType="dd" />
+          </td>
+          <td>
+            {{ results.heating_degree_days['historical']['ddmax']
+            }}<UnitWidget unitType="dd" />
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Early Century (2010&ndash;2039)</th>
+          <td>
+            {{ results.heating_degree_days['2010-2039']['ddmin']
+            }}<UnitWidget unitType="dd" />
+          </td>
+          <td>
+            {{ results.heating_degree_days['2010-2039']['ddmean']
+            }}<UnitWidget unitType="dd" />
+          </td>
+          <td>
+            {{ results.heating_degree_days['2010-2039']['ddmax']
+            }}<UnitWidget unitType="dd" />
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Mid Century (2040&ndash;2069)</th>
+          <td>
+            {{ results.heating_degree_days['2040-2069']['ddmin']
+            }}<UnitWidget unitType="dd" />
+          </td>
+          <td>
+            {{ results.heating_degree_days['2040-2069']['ddmean']
+            }}<UnitWidget unitType="dd" />
+          </td>
+          <td>
+            {{ results.heating_degree_days['2040-2069']['ddmax']
+            }}<UnitWidget unitType="dd" />
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Late Century (2070&ndash;2099)</th>
+          <td>
+            {{ results.heating_degree_days['2070-2099']['ddmin']
+            }}<UnitWidget unitType="dd" />
+          </td>
+          <td>
+            {{ results.heating_degree_days['2070-2099']['ddmean']
+            }}<UnitWidget unitType="dd" />
+          </td>
+          <td>
+            {{ results.heating_degree_days['2070-2099']['ddmax']
+            }}<UnitWidget unitType="dd" />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="block">
+      <h4 class="title is-5 mb-1">Data preview</h4>
+
+      <p class="content is-size-5 mb-1">
+        Downloaded data includes annual values for both historical ERA-Interim
+        (1980&ndash;2009) and modeled projected (2006&ndash;2100) datasets.
+      </p>
+      <table class="preview">
         <tbody>
           <tr>
-            <th scope="row">Historical (1979-2015)</th>
-            <td>
-              {{ results.heating_degree_days['historical']['ddmin']
-              }}<UnitWidget unitType="dd" />
-            </td>
-            <td>
-              {{ results.heating_degree_days['historical']['ddmean']
-              }}<UnitWidget unitType="dd" />
-            </td>
-            <td>
-              {{ results.heating_degree_days['historical']['ddmax']
-              }}<UnitWidget unitType="dd" />
-            </td>
+            <th scope="col">model</th>
+            <th scope="col">year</th>
+            <th scope="col">dd</th>
+          </tr>
+
+          <tr>
+            <td>ERA-Interim</td>
+            <td>1980</td>
+            <td>13933</td>
           </tr>
           <tr>
-            <th scope="row">Early Century (2010-2039)</th>
-            <td>
-              {{ results.heating_degree_days['2010-2039']['ddmin']
-              }}<UnitWidget unitType="dd" />
-            </td>
-            <td>
-              {{ results.heating_degree_days['2010-2039']['ddmean']
-              }}<UnitWidget unitType="dd" />
-            </td>
-            <td>
-              {{ results.heating_degree_days['2010-2039']['ddmax']
-              }}<UnitWidget unitType="dd" />
-            </td>
+            <td>ERA-Interim</td>
+            <td>1981</td>
+            <td>12841</td>
           </tr>
           <tr>
-            <th scope="row">Mid Century (2040-2069)</th>
-            <td>
-              {{ results.heating_degree_days['2040-2069']['ddmin']
-              }}<UnitWidget unitType="dd" />
-            </td>
-            <td>
-              {{ results.heating_degree_days['2040-2069']['ddmean']
-              }}<UnitWidget unitType="dd" />
-            </td>
-            <td>
-              {{ results.heating_degree_days['2040-2069']['ddmax']
-              }}<UnitWidget unitType="dd" />
-            </td>
+            <td>ERA-Interim</td>
+            <td>1982</td>
+            <td>14840</td>
           </tr>
           <tr>
-            <th scope="row">Late Century (2070-2099)</th>
-            <td>
-              {{ results.heating_degree_days['2070-2099']['ddmin']
-              }}<UnitWidget unitType="dd" />
-            </td>
-            <td>
-              {{ results.heating_degree_days['2070-2099']['ddmean']
-              }}<UnitWidget unitType="dd" />
-            </td>
-            <td>
-              {{ results.heating_degree_days['2070-2099']['ddmax']
-              }}<UnitWidget unitType="dd" />
-            </td>
+            <td>ERA-Interim</td>
+            <td>1983</td>
+            <td>14235</td>
+          </tr>
+          <tr>
+            <td>ERA-Interim</td>
+            <td>1984</td>
+            <td>14389</td>
+          </tr>
+          <tr>
+            <td colspan="3" class="vellip">&#8942;</td>
+          </tr>
+          <tr>
+            <td>NCAR-CCSM4</td>
+            <td>2096</td>
+            <td>11481</td>
+          </tr>
+          <tr>
+            <td>NCAR-CCSM4</td>
+            <td>2097</td>
+            <td>10526</td>
+          </tr>
+          <tr>
+            <td>NCAR-CCSM4</td>
+            <td>2098</td>
+            <td>11773</td>
+          </tr>
+          <tr>
+            <td>NCAR-CCSM4</td>
+            <td>2099</td>
+            <td>10609</td>
+          </tr>
+          <tr>
+            <td>NCAR-CCSM4</td>
+            <td>2100</td>
+            <td>10472</td>
           </tr>
         </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="3">~219 rows, 3 columns, ~5kb</td>
+          </tr>
+        </tfoot>
       </table>
-      <h4 class="title is-6 no-print">Access to Data</h4>
-      <div class="content no-print">
-        <p>Heating degrees days data was calculated from the following:</p>
-        <ul>
-          <li>
-            <a
-              href="http://ckan.snap.uaf.edu/dataset/historical-and-projected-dynamically-downscaled-climate-data-for-the-state-of-alaska-and-surrou"
-              target="_blank"
-              >Historical and Projected Climate Products</a
-            >
-          </li>
-        </ul>
-      </div>
+    </div>
+    <div class="content is-size-5 no-print">
       <DownloadCsvButton
         text="Download heating degree days data as CSV"
         endpoint="mmm/degree_days/heating/all"
         class="mt-3 mb-5"
       />
     </div>
+  </div>
 </template>
 
 <script>

--- a/components/reports/HeatingDegreeDays.vue
+++ b/components/reports/HeatingDegreeDays.vue
@@ -85,81 +85,21 @@
         CSV download includes annual values for both historical ERA-Interim
         (1980&ndash;2009) and modeled projected (2006&ndash;2100) datasets.
       </p>
-      <table class="preview">
-        <tbody>
-          <tr>
-            <th scope="col">model</th>
-            <th scope="col">year</th>
-            <th scope="col">dd</th>
-          </tr>
-
-          <tr>
-            <td>ERA-Interim</td>
-            <td>1980</td>
-            <td>13933</td>
-          </tr>
-          <tr>
-            <td>ERA-Interim</td>
-            <td>1981</td>
-            <td>12841</td>
-          </tr>
-          <tr>
-            <td>ERA-Interim</td>
-            <td>1982</td>
-            <td>14840</td>
-          </tr>
-          <tr>
-            <td>ERA-Interim</td>
-            <td>1983</td>
-            <td>14235</td>
-          </tr>
-          <tr>
-            <td>ERA-Interim</td>
-            <td>1984</td>
-            <td>14389</td>
-          </tr>
-          <tr>
-            <td colspan="3" class="vellip">&#8942;</td>
-          </tr>
-          <tr>
-            <td>NCAR-CCSM4</td>
-            <td>2096</td>
-            <td>11481</td>
-          </tr>
-          <tr>
-            <td>NCAR-CCSM4</td>
-            <td>2097</td>
-            <td>10526</td>
-          </tr>
-          <tr>
-            <td>NCAR-CCSM4</td>
-            <td>2098</td>
-            <td>11773</td>
-          </tr>
-          <tr>
-            <td>NCAR-CCSM4</td>
-            <td>2099</td>
-            <td>10609</td>
-          </tr>
-          <tr>
-            <td>NCAR-CCSM4</td>
-            <td>2100</td>
-            <td>10472</td>
-          </tr>
-        </tbody>
-        <tfoot>
-          <tr>
-            <td colspan="3">~219 rows, 3 columns, ~5kb</td>
-          </tr>
-        </tfoot>
-      </table>
-    </div>
-    <div class="content is-size-5 no-print">
-      <DownloadCsvButton
-        :text="downloadCsvText"
-        endpoint="mmm/degree_days/heating/all"
-        class="mt-3 mb-5"
+      <PreviewTable
+        :csvString="results.heating_degree_days.preview"
+        sizeBlurb="~219 rows, 3 columns, ~5kb"
       />
+    </div>
+    <div class="block content is-size-5 no-print">
+      <h4 class="title is-5 mb-1">Data download</h4>
+      <ul>
+        <li>
+          <DownloadCsvButton
+            :text="downloadCsvText"
+            endpoint="mmm/degree_days/heating/all"
+          />
+        </li>
+      </ul>
     </div>
   </div>
 </template>
@@ -168,17 +108,18 @@
 import { mapGetters } from 'vuex'
 import DownloadCsvButton from '~/components/DownloadCsvButton'
 import UnitWidget from '~/components/UnitWidget'
+import PreviewTable from '~/components/PreviewTable'
 
 export default {
   name: 'HeatingDegreeDaysReport',
   components: {
     DownloadCsvButton,
     UnitWidget,
+    PreviewTable,
   },
-
   computed: {
     downloadCsvText() {
-      return "Download CSV of heading degree days for " + this.placeName
+      return 'Download CSV of heating degree days for ' + this.placeName
     },
     ...mapGetters({
       results: 'report/results',

--- a/components/reports/HeatingDegreeDays.vue
+++ b/components/reports/HeatingDegreeDays.vue
@@ -19,60 +19,60 @@
         <tr>
           <th scope="row">Historical (1979&ndash;2015)</th>
           <td>
-            {{ results.heating_degree_days['historical']['ddmin']
+            {{ results.heating_degree_days['summary']['historical']['ddmin']
             }}<UnitWidget unitType="dd" />
           </td>
           <td>
-            {{ results.heating_degree_days['historical']['ddmean']
+            {{ results.heating_degree_days['summary']['historical']['ddmean']
             }}<UnitWidget unitType="dd" />
           </td>
           <td>
-            {{ results.heating_degree_days['historical']['ddmax']
+            {{ results.heating_degree_days['summary']['historical']['ddmax']
             }}<UnitWidget unitType="dd" />
           </td>
         </tr>
         <tr>
           <th scope="row">Early Century (2010&ndash;2039)</th>
           <td>
-            {{ results.heating_degree_days['2010-2039']['ddmin']
+            {{ results.heating_degree_days['summary']['2010-2039']['ddmin']
             }}<UnitWidget unitType="dd" />
           </td>
           <td>
-            {{ results.heating_degree_days['2010-2039']['ddmean']
+            {{ results.heating_degree_days['summary']['2010-2039']['ddmean']
             }}<UnitWidget unitType="dd" />
           </td>
           <td>
-            {{ results.heating_degree_days['2010-2039']['ddmax']
+            {{ results.heating_degree_days['summary']['2010-2039']['ddmax']
             }}<UnitWidget unitType="dd" />
           </td>
         </tr>
         <tr>
           <th scope="row">Mid Century (2040&ndash;2069)</th>
           <td>
-            {{ results.heating_degree_days['2040-2069']['ddmin']
+            {{ results.heating_degree_days['summary']['2040-2069']['ddmin']
             }}<UnitWidget unitType="dd" />
           </td>
           <td>
-            {{ results.heating_degree_days['2040-2069']['ddmean']
+            {{ results.heating_degree_days['summary']['2040-2069']['ddmean']
             }}<UnitWidget unitType="dd" />
           </td>
           <td>
-            {{ results.heating_degree_days['2040-2069']['ddmax']
+            {{ results.heating_degree_days['summary']['2040-2069']['ddmax']
             }}<UnitWidget unitType="dd" />
           </td>
         </tr>
         <tr>
           <th scope="row">Late Century (2070&ndash;2099)</th>
           <td>
-            {{ results.heating_degree_days['2070-2099']['ddmin']
+            {{ results.heating_degree_days['summary']['2070-2099']['ddmin']
             }}<UnitWidget unitType="dd" />
           </td>
           <td>
-            {{ results.heating_degree_days['2070-2099']['ddmean']
+            {{ results.heating_degree_days['summary']['2070-2099']['ddmean']
             }}<UnitWidget unitType="dd" />
           </td>
           <td>
-            {{ results.heating_degree_days['2070-2099']['ddmax']
+            {{ results.heating_degree_days['summary']['2070-2099']['ddmax']
             }}<UnitWidget unitType="dd" />
           </td>
         </tr>

--- a/components/reports/Permafrost.vue
+++ b/components/reports/Permafrost.vue
@@ -1,45 +1,342 @@
 <template>
   <div v-if="isDataLoaded">
-    <h2 id="permafrost" class="title is-2">Permafrost</h2>
-    <div class="content is-size-5">
-      <p>
-        Annual projections of permafrost top and base depths, talik thickness,
-        and mean annual ground temperature at seven different depths are
-        provided by the GIPL 2.0 model at a resolution of 1km for years
-        2021&ndash;2120. These projections are provided for GFDL CM3 and NCAR
-        CCSM4 model outputs, as well as a 5-model average, under the RCP 4.5 and
-        RCP 8.5 emissions scenarios.
-      </p>
+    <div class="block">
+      <h2 id="permafrost" class="title is-2">Permafrost</h2>
+      <div class="content is-size-5">
+        <p>
+          Annual projections of permafrost top and base depths, talik thickness,
+          and mean annual ground temperature at seven different depths are
+          provided by the GIPL 2.0 model at a resolution of 1km for years
+          2021&ndash;2120. These projections are provided for GFDL CM3 and NCAR
+          CCSM4 model outputs, as well as a 5-model average (GFDL CM3, NCAR
+          CCSM4, GISS E2-R, IPSL CM5A-LR, MRI CGCM3), under the RCP 4.5 and RCP
+          8.5 emissions scenarios.
+        </p>
+      </div>
     </div>
-    <h4 class="title is-5 mb-1">Data preview</h4>
-    <p class="content is-size-5 mb-1">
-      CSV download includes annual values for the modeled projected
-      (2021&ndash;2100) dataset.
-    </p>
-    <table class="preview">
-      <thead>
-        <tr>
-          <th scope="col" v-for="col in csvHeader">{{ col }}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="row in csvHead">
-          <td v-for="value in row">{{ value }}</td>
-        </tr>
-        <tr>
-          <td :colspan="csvHeader.length" class="vellip">&#8942;</td>
-        </tr>
-        <tr v-for="row in csvTail">
-          <td v-for="value in row">{{ value }}</td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="block">
+      <h4 class="title is-5 mb-1">Data summary</h4>
+      <p class="content is-size-5">
+        The summary tables below shows the minimum, mean and maximum values
+        across two scenarios (RCP 4.5 and RCP 8.5) and three models (NCAR CCSM4,
+        GFDL CM3, and a 5-model average: GFDL-CM3, NCAR-CCSM4, GISS-E2-R,
+        IPSL-CM5A-LR, MRI-CGCM3) for the specified era, which can be helpful to
+        assess broad trends and variation. Summaries for three variables are
+        shown: mean annual ground temperature at 1m depth, mean annual ground
+        temperature at 3m depth, and permafrost top.
+      </p>
+      <table class="table">
+        <caption>
+          Mean annual ground temperature, 1m depth
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Early Century (2010&ndash;2039)</th>
+            <td>
+              {{
+                results.permafrost['summary']['2021-2039']['gipl1kmmin'][
+                  'magt1m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2021-2039']['gipl1kmmean'][
+                  'magt1m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2021-2039']['gipl1kmmax'][
+                  'magt1m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040&ndash;2069)</th>
+            <td>
+              {{
+                results.permafrost['summary']['2040-2069']['gipl1kmmin'][
+                  'magt1m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2040-2069']['gipl1kmmean'][
+                  'magt1m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2040-2069']['gipl1kmmax'][
+                  'magt1m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070&ndash;2099)</th>
+            <td>
+              {{
+                results.permafrost['summary']['2070-2099']['gipl1kmmin'][
+                  'magt1m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2070-2099']['gipl1kmmean'][
+                  'magt1m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2070-2099']['gipl1kmmax'][
+                  'magt1m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-    <DownloadCsvButton
-      text="Download permafrost data as CSV"
-      endpoint="permafrost/point"
-      class="mt-3 mb-5"
-    />
+      <table class="table">
+        <caption>
+          Mean annual ground temperature, 5m depth
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Early Century (2010&ndash;2039)</th>
+            <td>
+              {{
+                results.permafrost['summary']['2021-2039']['gipl1kmmin'][
+                  'magt5m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2021-2039']['gipl1kmmean'][
+                  'magt5m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2021-2039']['gipl1kmmax'][
+                  'magt5m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040&ndash;2069)</th>
+            <td>
+              {{
+                results.permafrost['summary']['2040-2069']['gipl1kmmin'][
+                  'magt5m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2040-2069']['gipl1kmmean'][
+                  'magt5m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2040-2069']['gipl1kmmax'][
+                  'magt5m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070&ndash;2099)</th>
+            <td>
+              {{
+                results.permafrost['summary']['2070-2099']['gipl1kmmin'][
+                  'magt5m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2070-2099']['gipl1kmmean'][
+                  'magt5m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2070-2099']['gipl1kmmax'][
+                  'magt5m'
+                ]
+              }}<UnitWidget unitType="temp" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <table class="table">
+        <caption>
+          Permafrost top
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">Min</th>
+            <th scope="col">Mean</th>
+            <th scope="col">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Early Century (2010&ndash;2039)</th>
+            <td>
+              {{
+                results.permafrost['summary']['2021-2039']['gipl1kmmin'][
+                  'permafrosttop'
+                ]
+              }}<UnitWidget unitType="m_in" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2021-2039']['gipl1kmmean'][
+                  'permafrosttop'
+                ]
+              }}<UnitWidget unitType="m_in" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2021-2039']['gipl1kmmax'][
+                  'permafrosttop'
+                ]
+              }}<UnitWidget unitType="m_in" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040&ndash;2069)</th>
+            <td>
+              {{
+                results.permafrost['summary']['2040-2069']['gipl1kmmin'][
+                  'permafrosttop'
+                ]
+              }}<UnitWidget unitType="m_in" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2040-2069']['gipl1kmmean'][
+                  'permafrosttop'
+                ]
+              }}<UnitWidget unitType="m_in" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2040-2069']['gipl1kmmax'][
+                  'permafrosttop'
+                ]
+              }}<UnitWidget unitType="m_in" />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070&ndash;2099)</th>
+            <td>
+              {{
+                results.permafrost['summary']['2070-2099']['gipl1kmmin'][
+                  'permafrosttop'
+                ]
+              }}<UnitWidget unitType="m_in" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2070-2099']['gipl1kmmean'][
+                  'permafrosttop'
+                ]
+              }}<UnitWidget unitType="m_in" />
+            </td>
+            <td>
+              {{
+                results.permafrost['summary']['2070-2099']['gipl1kmmax'][
+                  'permafrosttop'
+                ]
+              }}<UnitWidget unitType="m_in" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="block">
+      <h4 class="title is-5 mb-1">Data preview</h4>
+      <p class="content is-size-5 mb-1">
+        CSV download includes annual values for the modeled projected
+        (2021&ndash;2100) dataset.
+      </p>
+      <PreviewTable
+        :csvString="results.permafrost.preview"
+        sizeBlurb="~601 rows, 13 columns, ~42kb"
+      />
+    </div>
+
+    <div class="block data-outro content is-size-5 no-print">
+      <h4 class="title is-5 no-print">
+        Data access &amp; additional information
+      </h4>
+
+      <ul>
+        <li>
+          <DownloadCsvButton
+            text="Download this data as CSV"
+            endpoint="permafrost/point"
+          />
+        </li>
+        <li>
+          Source dataset and metadata:
+          <a
+            href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/c24a957b-8a56-40bf-bc09-43a567182d36"
+            >GIPL Permafrost Model Output</a
+          >
+        </li>
+        <li>
+          Academic reference:
+          <blockquote>
+            Marchenko, S., Romanovsky, V., &amp; Tipenko, G. (2008). Numerical
+            modeling of spatial permafrost dynamics in Alaska.
+            <i
+              >Ninth International Conference on Permafrost, Online Proceedings,
+              Volume 2</i
+            >, 1125–1130. Accessed 2023-09-08 from
+            <a href="https://www.permafrost.org/event/icop9/"
+              >https://www.permafrost.org/event/icop9/</a
+            >
+          </blockquote>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 
@@ -47,47 +344,18 @@
 import { mapGetters } from 'vuex'
 import DownloadCsvButton from '~/components/DownloadCsvButton'
 import UnitWidget from '~/components/UnitWidget'
+import PreviewTable from '~/components/PreviewTable'
 
 export default {
   name: 'PermafrostReport',
   components: {
     DownloadCsvButton,
     UnitWidget,
+    PreviewTable,
   },
   computed: {
     isDataLoaded() {
-      console.log(this.results.permafrost)
       return this.results.permafrost != undefined
-    },
-    csvParsed() {
-      if (this.isDataLoaded) {
-        let csvString = this.results.permafrost.preview
-        if (csvString) {
-          let csvSplit = csvString.split('\r\n')
-          csvSplit = csvSplit.map(row => {
-            return row.split(',')
-          })
-          console.log(csvSplit)
-          return csvSplit
-        }
-      } else {
-        return []
-      }
-    },
-    csvHeader() {
-      if (this.csvParsed) {
-        return this.csvParsed[0]
-      }
-    },
-    csvHead() {
-      if (this.csvParsed) {
-        return this.csvParsed.slice(1, 6)
-      }
-    },
-    csvTail() {
-      if (this.csvParsed) {
-        return this.csvParsed.slice(6)
-      }
     },
     ...mapGetters({
       results: 'report/results',

--- a/components/reports/Permafrost.vue
+++ b/components/reports/Permafrost.vue
@@ -78,7 +78,7 @@ export default {
           csvSubset[key]['RCP 4.5']['talikthickness'],
         ])
       }
-      let cvh = csvPreview.slice(0, 4)
+      let cvh = csvPreview.slice(0, 5)
       console.log(cvh)
       return cvh
     },
@@ -102,7 +102,7 @@ export default {
           csvSubset[key]['RCP 8.5']['talikthickness'],
         ])
       }
-      let cvh = csvPreview.slice(5, 9)
+      let cvh = csvPreview.slice(5, 10)
       console.log(cvh)
       return cvh
     },

--- a/components/reports/Permafrost.vue
+++ b/components/reports/Permafrost.vue
@@ -1,9 +1,25 @@
 <template>
-  <div v-if="Object.keys(results.permafrost).length != 0">
+  <div v-if="isDataLoaded">
+    <h2 id="permafrost" class="title is-2">Permafrost</h2>
+    <div class="content is-size-5">
+      <p>
+        Annual projections of permafrost top and base depths, talik thickness,
+        and mean annual ground temperature at seven different depths are
+        provided by the GIPL 2.0 model at a resolution of 1km for years
+        2021&ndash;2120. These projections are provided for GFDL CM3 and NCAR
+        CCSM4 model outputs, as well as a 5-model average, under the RCP 4.5 and
+        RCP 8.5 emissions scenarios.
+      </p>
+    </div>
+    <h4 class="title is-5 mb-1">Data preview</h4>
+    <p class="content is-size-5 mb-1">
+      CSV download includes annual values for the modeled projected
+      (2021&ndash;2100) dataset.
+    </p>
     <table class="preview">
       <thead>
         <tr>
-          <th scope="col" v-for="column in csvHeader">{{ column }}</th>
+          <th scope="col" v-for="col in csvHeader">{{ col }}</th>
         </tr>
       </thead>
       <tbody>
@@ -38,80 +54,47 @@ export default {
     DownloadCsvButton,
     UnitWidget,
   },
-  data() {
-    return {
-      csvHeader: [
-        'year',
-        'model',
-        'scenario',
-        'magt0.5m',
-        'magt1m',
-        'magt2m',
-        'magt3m',
-        'magt4m',
-        'magt5m',
-        'magtsurface',
-        'permafrostbase',
-        'permafrosttop',
-        'talikthickness',
-      ],
-    }
-  },
   computed: {
-    csvHead() {
-      let csvPreview = []
-      let csvSubset = this.results.permafrost['GFDL-CM3']
-      for (const key in csvSubset) {
-        csvPreview.push([
-          key,
-          'GFDL-CM3',
-          'RCP 4.5',
-          csvSubset[key]['RCP 4.5']['magt0.5m'],
-          csvSubset[key]['RCP 4.5']['magt1m'],
-          csvSubset[key]['RCP 4.5']['magt2m'],
-          csvSubset[key]['RCP 4.5']['magt3m'],
-          csvSubset[key]['RCP 4.5']['magt4m'],
-          csvSubset[key]['RCP 4.5']['magt5m'],
-          csvSubset[key]['RCP 4.5']['magtsurface'],
-          csvSubset[key]['RCP 4.5']['permafrostbase'],
-          csvSubset[key]['RCP 4.5']['permafrosttop'],
-          csvSubset[key]['RCP 4.5']['talikthickness'],
-        ])
+    isDataLoaded() {
+      console.log(this.results.permafrost)
+      return this.results.permafrost != undefined
+    },
+    csvParsed() {
+      if (this.isDataLoaded) {
+        let csvString = this.results.permafrost.preview
+        if (csvString) {
+          let csvSplit = csvString.split('\r\n')
+          csvSplit = csvSplit.map(row => {
+            return row.split(',')
+          })
+          console.log(csvSplit)
+          return csvSplit
+        }
+      } else {
+        return []
       }
-      let cvh = csvPreview.slice(0, 5)
-      console.log(cvh)
-      return cvh
+    },
+    csvHeader() {
+      if (this.csvParsed) {
+        return this.csvParsed[0]
+      }
+    },
+    csvHead() {
+      if (this.csvParsed) {
+        return this.csvParsed.slice(1, 6)
+      }
     },
     csvTail() {
-      let csvPreview = []
-      let csvSubset = this.results.permafrost['NCAR-CCSM4']
-      for (const key in csvSubset) {
-        csvPreview.push([
-          key,
-          'NCAR-CCSM4',
-          'RCP 8.5',
-          csvSubset[key]['RCP 8.5']['magt0.5m'],
-          csvSubset[key]['RCP 8.5']['magt1m'],
-          csvSubset[key]['RCP 8.5']['magt2m'],
-          csvSubset[key]['RCP 8.5']['magt3m'],
-          csvSubset[key]['RCP 8.5']['magt4m'],
-          csvSubset[key]['RCP 8.5']['magt5m'],
-          csvSubset[key]['RCP 8.5']['magtsurface'],
-          csvSubset[key]['RCP 8.5']['permafrostbase'],
-          csvSubset[key]['RCP 8.5']['permafrosttop'],
-          csvSubset[key]['RCP 8.5']['talikthickness'],
-        ])
+      if (this.csvParsed) {
+        return this.csvParsed.slice(6)
       }
-      let cvh = csvPreview.slice(5, 10)
-      console.log(cvh)
-      return cvh
     },
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
     }),
-  }
+  },
 }
 </script>
 

--- a/components/reports/Permafrost.vue
+++ b/components/reports/Permafrost.vue
@@ -1,110 +1,24 @@
 <template>
   <div v-if="Object.keys(results.permafrost).length != 0">
-    <h4 class="title is-4">GIPL Mean Annual Ground Temperature</h4>
-
-    <table class="table">
+    <table class="preview">
       <thead>
         <tr>
-          <th scope="col"></th>
-          <th scope="col">MAGT</th>
-          <th scope="col">Change from Historical</th>
+          <th scope="col" v-for="column in csvHeader">{{ column }}</th>
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <th scope="row">Historical (1995)</th>
-          <td>
-            {{ results.permafrost.gipl_magt_1995 }}<UnitWidget type="light" />
-          </td>
-          <td></td>
+        <tr v-for="row in csvHead">
+          <td v-for="value in row">{{ value }}</td>
         </tr>
         <tr>
-          <th scope="row">2011 - 2040</th>
-          <td>
-            {{ results.permafrost.gipl_magt_2025 }}<UnitWidget type="light" />
-          </td>
-          <td>
-            {{
-              signedDiff(
-                results.permafrost.gipl_magt_1995,
-                results.permafrost.gipl_magt_2025,
-                'magt'
-              )
-            }}<UnitWidget type="light" />
-          </td>
+          <td :colspan="csvHeader.length" class="vellip">&#8942;</td>
         </tr>
-        <tr>
-          <th scope="row">2036 - 2065</th>
-          <td>
-            {{ results.permafrost.gipl_magt_2050 }}<UnitWidget type="light" />
-          </td>
-          <td>
-            {{
-              signedDiff(
-                results.permafrost.gipl_magt_1995,
-                results.permafrost.gipl_magt_2050,
-                'magt'
-              )
-            }}<UnitWidget type="light" />
-          </td>
-        </tr>
-        <tr>
-          <th scope="row">2061 – 2090</th>
-          <td>
-            {{ results.permafrost.gipl_magt_2075 }}<UnitWidget type="light" />
-          </td>
-          <td>
-            {{
-              signedDiff(
-                results.permafrost.gipl_magt_1995,
-                results.permafrost.gipl_magt_2075,
-                'magt'
-              )
-            }}<UnitWidget type="light" />
-          </td>
-        </tr>
-        <tr>
-          <th scope="row">2086 – 2100</th>
-          <td>
-            {{ results.permafrost.gipl_magt_2095 }}<UnitWidget type="light" />
-          </td>
-          <td>
-            {{
-              signedDiff(
-                results.permafrost.gipl_magt_1995,
-                results.permafrost.gipl_magt_2095,
-                'magt'
-              )
-            }}<UnitWidget type="light" />
-          </td>
+        <tr v-for="row in csvTail">
+          <td v-for="value in row">{{ value }}</td>
         </tr>
       </tbody>
     </table>
 
-    <h4 class="title is-5">Additional data</h4>
-    <div class="content">
-      <ul>
-        <li v-if="results.permafrost.magt_2018">
-          Obu et al. (2018) Mean Annual Ground Temperature at Top of Permafrost:
-          <strong
-            >{{ results.permafrost.magt_2018
-            }}<UnitWidget unitType="temp" type="light"
-          /></strong>
-        </li>
-        <li v-if="results.permafrost.giv_2008">
-          Jorgenson et al. (2008) Ground Ice Volume:
-          <strong>{{ results.permafrost.giv_2008 }}</strong>
-        </li>
-        <li v-if="results.permafrost.pe_2008">
-          Jorgenson et al. (2008) Permafrost Extent:
-          <strong>{{ results.permafrost.pe_2008 }}</strong>
-        </li>
-        <li v-if="results.permafrost.pe_2018">
-          Obu et al. (2018) Permafrost Extent:
-          <strong>{{ results.permafrost.pe_2018 }}</strong>
-        </li>
-      </ul>
-    </div>
     <DownloadCsvButton
       text="Download permafrost data as CSV"
       endpoint="permafrost/point"
@@ -124,76 +38,80 @@ export default {
     DownloadCsvButton,
     UnitWidget,
   },
+  data() {
+    return {
+      csvHeader: [
+        'year',
+        'model',
+        'scenario',
+        'magt0.5m',
+        'magt1m',
+        'magt2m',
+        'magt3m',
+        'magt4m',
+        'magt5m',
+        'magtsurface',
+        'permafrostbase',
+        'permafrosttop',
+        'talikthickness',
+      ],
+    }
+  },
   computed: {
+    csvHead() {
+      let csvPreview = []
+      let csvSubset = this.results.permafrost['GFDL-CM3']
+      for (const key in csvSubset) {
+        csvPreview.push([
+          key,
+          'GFDL-CM3',
+          'RCP 4.5',
+          csvSubset[key]['RCP 4.5']['magt0.5m'],
+          csvSubset[key]['RCP 4.5']['magt1m'],
+          csvSubset[key]['RCP 4.5']['magt2m'],
+          csvSubset[key]['RCP 4.5']['magt3m'],
+          csvSubset[key]['RCP 4.5']['magt4m'],
+          csvSubset[key]['RCP 4.5']['magt5m'],
+          csvSubset[key]['RCP 4.5']['magtsurface'],
+          csvSubset[key]['RCP 4.5']['permafrostbase'],
+          csvSubset[key]['RCP 4.5']['permafrosttop'],
+          csvSubset[key]['RCP 4.5']['talikthickness'],
+        ])
+      }
+      let cvh = csvPreview.slice(0, 4)
+      console.log(cvh)
+      return cvh
+    },
+    csvTail() {
+      let csvPreview = []
+      let csvSubset = this.results.permafrost['NCAR-CCSM4']
+      for (const key in csvSubset) {
+        csvPreview.push([
+          key,
+          'NCAR-CCSM4',
+          'RCP 8.5',
+          csvSubset[key]['RCP 8.5']['magt0.5m'],
+          csvSubset[key]['RCP 8.5']['magt1m'],
+          csvSubset[key]['RCP 8.5']['magt2m'],
+          csvSubset[key]['RCP 8.5']['magt3m'],
+          csvSubset[key]['RCP 8.5']['magt4m'],
+          csvSubset[key]['RCP 8.5']['magt5m'],
+          csvSubset[key]['RCP 8.5']['magtsurface'],
+          csvSubset[key]['RCP 8.5']['permafrostbase'],
+          csvSubset[key]['RCP 8.5']['permafrosttop'],
+          csvSubset[key]['RCP 8.5']['talikthickness'],
+        ])
+      }
+      let cvh = csvPreview.slice(5, 9)
+      console.log(cvh)
+      return cvh
+    },
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
     }),
-  },
-  methods: {
-    signedDiff(historical, projected, variable) {
-      let decimals
-      if (variable == 'magt') {
-        decimals = 1
-      }
-      let rawDiff = (projected - historical).toFixed(decimals)
-      if (rawDiff > 0) {
-        return '+' + rawDiff
-      } else {
-        return rawDiff
-      }
-    },
-  },
-  watch: {
-    isPlaceDefined: function () {
-      this.$fetch()
-    },
-  },
-  fetch() {
-    let plateResults = {
-      // "magt_" substrings are converted between °C and °F
-      gipl_magt_1995:
-        this.results['permafrost']['gipl']['1995']['cruts31']['historical'][
-          'magt'
-        ],
-      gipl_magt_2025:
-        this.results['permafrost']['gipl']['2025']['ncarccsm4']['rcp85'][
-          'magt'
-        ],
-      gipl_magt_2050:
-        this.results['permafrost']['gipl']['2050']['ncarccsm4']['rcp85'][
-          'magt'
-        ],
-      gipl_magt_2075:
-        this.results['permafrost']['gipl']['2075']['ncarccsm4']['rcp85'][
-          'magt'
-        ],
-      gipl_magt_2095:
-        this.results['permafrost']['gipl']['2095']['ncarccsm4']['rcp85'][
-          'magt'
-        ],
-    }
-
-    if (this.results['permafrost']['jorg'] != null) {
-      plateResults['giv_2008'] = this.results['permafrost']['jorg']['ice']
-      plateResults['pe_2008'] = this.results['permafrost']['jorg']['pfx']
-    }
-
-    if (this.results['permafrost']['obu_magt'] != null) {
-      // "magt_" substrings are converted between °C and °F
-      plateResults['magt_2018'] = this.results['permafrost']['obu_magt']['temp']
-    }
-
-    if (this.results['permafrost']['obupfx'] != null) {
-      plateResults['pe_2018'] = this.results['permafrost']['obupfx']['pfx']
-    }
-
-    this.$store.commit('report/setPlateResults', {
-      plateResults: plateResults,
-      variable: 'permafrost',
-    })
-  },
+  }
 }
 </script>
 

--- a/components/reports/PrecipitationFrequency.vue
+++ b/components/reports/PrecipitationFrequency.vue
@@ -227,11 +227,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.pf table {
-  font-family: 'IBM Plex Mono', monospace;
-  line-height: 1;
-}
-
 .small-text {
   font-size: 80%;
 }

--- a/components/reports/PrecipitationFrequency.vue
+++ b/components/reports/PrecipitationFrequency.vue
@@ -133,19 +133,22 @@
           used to prepare this dataset
         </li>
         <li>
-          Academic reference: Bieniek P, Walsh J, Fresco N, Tauxe C, Redilla K.
-          Anticipated changes in Alaska extreme precipitation. Journal of
-          Applied Meteorology and Climatology. 2022; 61(2):97-108.
-          <a href="https://doi.org/10.1175/JAMC-D-21-0106.1"
-            >https://doi.org/10.1175/JAMC-D-21-0106.1</a
-          >
-        </li>
-        <li>
           Source dataset and metadata:
           <a
             href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/304b6d89-961e-417d-b6ba-4139c7fe5ff6"
             >Annual maximum precipitation projections for Alaska</a
           >
+        </li>
+        <li>
+          Academic reference:
+          <blockquote>
+            Bieniek P, Walsh J, Fresco N, Tauxe C, Redilla K. Anticipated
+            changes in Alaska extreme precipitation. Journal of Applied
+            Meteorology and Climatology. 2022; 61(2):97-108.
+            <a href="https://doi.org/10.1175/JAMC-D-21-0106.1"
+              >https://doi.org/10.1175/JAMC-D-21-0106.1</a
+            >
+          </blockquote>
         </li>
       </ul>
     </div>

--- a/components/reports/ThawingIndex.vue
+++ b/components/reports/ThawingIndex.vue
@@ -13,49 +13,49 @@
         <tr>
           <th scope="row">Historical (1979-2015)</th>
           <td>
-            {{ results.thawing_index['historical']['ddmin'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['historical']['ddmin'] }}<UnitWidget />
           </td>
           <td>
-            {{ results.thawing_index['historical']['ddmean'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['historical']['ddmean'] }}<UnitWidget />
           </td>
           <td>
-            {{ results.thawing_index['historical']['ddmax'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['historical']['ddmax'] }}<UnitWidget />
           </td>
         </tr>
         <tr>
           <th scope="row">Early Century (2010-2039)</th>
           <td>
-            {{ results.thawing_index['2010-2039']['ddmin'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['2010-2039']['ddmin'] }}<UnitWidget />
           </td>
           <td>
-            {{ results.thawing_index['2010-2039']['ddmean'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['2010-2039']['ddmean'] }}<UnitWidget />
           </td>
           <td>
-            {{ results.thawing_index['2010-2039']['ddmax'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['2010-2039']['ddmax'] }}<UnitWidget />
           </td>
         </tr>
         <tr>
           <th scope="row">Mid Century (2040-2069)</th>
           <td>
-            {{ results.thawing_index['2040-2069']['ddmin'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['2040-2069']['ddmin'] }}<UnitWidget />
           </td>
           <td>
-            {{ results.thawing_index['2040-2069']['ddmean'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['2040-2069']['ddmean'] }}<UnitWidget />
           </td>
           <td>
-            {{ results.thawing_index['2040-2069']['ddmax'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['2040-2069']['ddmax'] }}<UnitWidget />
           </td>
         </tr>
         <tr>
           <th scope="row">Late Century (2070-2099)</th>
           <td>
-            {{ results.thawing_index['2070-2099']['ddmin'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['2070-2099']['ddmin'] }}<UnitWidget />
           </td>
           <td>
-            {{ results.thawing_index['2070-2099']['ddmean'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['2070-2099']['ddmean'] }}<UnitWidget />
           </td>
           <td>
-            {{ results.thawing_index['2070-2099']['ddmax'] }}<UnitWidget />
+            {{ results.thawing_index['summary']['2070-2099']['ddmax'] }}<UnitWidget />
           </td>
         </tr>
       </tbody>

--- a/store/report.js
+++ b/store/report.js
@@ -147,7 +147,8 @@ export default {
     convertResults(state) {
       // Converts all convertible units at the same time for shared report
       let conversions = [
-        { type: 'temperature', substring: 'magt_', variable: 'permafrost' },
+        // This needs to be adapted after the summarized data are restored.
+        // { type: 'temperature', substring: 'magt_', variable: 'permafrost' },
         { type: 'temperature', substring: '', variable: 'temperature' },
         { type: 'mm_in', substring: '', variable: 'precipitation' },
         { type: 'mm_in', substring: '', variable: 'snowfall' },


### PR DESCRIPTION
This PR accomplishes two main + some minor things,

- establishes the preview/summary pattern in some reports (heating degree days + permafrost), which can be a template for the remaining sections,
- modifies the code to match updated API responses,
- changes the async fetch pattern in report sub-sections so fetch isn't called (it's not needed post-consolidation of all reports into one thing)

To test this branch, run the API locally from this branch with `export API_RAS_BASE_URL=https://apollo.snap.uaf.edu/rasdaman/` & run this code with

```
export SNAP_API_URL=http://localhost:5000
export RASDAMAN_URL=https://apollo.snap.uaf.edu/rasdaman/ows
```

Choose multiple locations and generate the report.  For each,

1. the report should generate / not have errors,
2. the HDD and permafrost sections should show the pattern [outlined in this doc](https://docs.google.com/document/d/1NKMHTm-spR-omse7mzbJfhvPX5sJ8foFKI5GbQ-EWhU/edit#heading=h.bmdb087ema9m),
3. test rehydration: direct-link to a report should load properly.

A few known issues:

- Unit conversion isn't working for the preview tables for these sections; that's going to require a rework of the unit conversion code which I prefer to do in a new PR because this one is already large. 