### PR TITLE
Add Wet Days Per Year to precipitation map

### DIFF
--- a/components/map_content.js
+++ b/components/map_content.js
@@ -45,6 +45,23 @@ export default {
         style: 'snowfall_mm',
         legend: 'snowfall',
       },
+      {
+        id: 'historical_wet_days_per_year',
+        title: 'Historical Wet Days Per Year (1980&ndash;2009)',
+        source: 'rasdaman',
+        wmsLayerName: 'wet_days_per_year',
+        style: 'arctic_eds_historical_wet_days_per_year',
+        legend: 'wet_days_per_year',
+      },
+      {
+        id: 'projected_wet_days_per_year',
+        title:
+          'Projected Wet Days Per Year (2040&ndash;2069, NCAR CCSM4, RCP 8.5)',
+        source: 'rasdaman',
+        wmsLayerName: 'wet_days_per_year',
+        style: 'arctic_eds_projected_wet_days_per_year',
+        legend: 'wet_days_per_year',
+      },
     ],
     temperature: [
       {
@@ -310,6 +327,12 @@ export default {
       { color: '#8c6bb1', label: '20in' },
       { color: '#8841a7', label: '50in' },
       { color: '#0006e016b000', label: '&ge; 100in' },
+    ],
+    wet_days_per_year: [
+      { color: '#edf8fb', label: '&ge;0 days, &lt;60 days' },
+      { color: '#ccece6', label: '&ge;60 days, &lt;120 days' },
+      { color: '#99d8c9', label: '&ge;120 days, &lt;180 days' },
+      { color: '#66c2a4', label: '&ge;180 days' },
     ],
     temperature: [
       { color: '#2166ac', label: '&le; &minus;22&deg;F' },


### PR DESCRIPTION
Closes #320.

This PR adds historical and projected Wet Days Per Year layers to the Precipitation map. There were already styles + color maps on Apollo for the `wet_days_per_year` coverage, so I used these same color maps but dropped the last two color buckets (240 and 300 days) because the "300 days" color bucket was not visible at all on these maps, and the "240 days" color bucket was only used for a handful of pixels and added little to the historical vs. projected comparison.

To test, view the Precipitation map, look at both Wet Days Per Year layers, and verify that the colors look good and match the legend.