### PR TITLE
Glued unit spans together to remove spurious whitespace

### DIFF
--- a/components/UnitWidget.vue
+++ b/components/UnitWidget.vue
@@ -1,7 +1,7 @@
 <template>
   <span class="units">
-    <span v-html="symbol.space"></span>
-    <span class="light" v-html="symbol.symbol"></span>
+    <span v-html="symbol.space"></span
+    ><span class="light" v-html="symbol.symbol"></span>
   </span>
 </template>
 <style lang="scss" scoped>
@@ -30,7 +30,7 @@ export default {
   computed: {
     symbol() {
       let symbol = ''
-      let space = ''
+      let space = '' // for units that start with a symbol (º), no space
 
       switch (this.unitType) {
         case 'temp':


### PR DESCRIPTION
Closes #319 

To test -- enable mock mode `export MOCK_API=True` then check a generated report.  There should be a small half-space for units that don't start with symbols, and no space for those that do start with symbols.