### PR TITLE
Restyle lat/lng activate button + fix error messages

### DIFF
--- a/components/LatLngSelector.vue
+++ b/components/LatLngSelector.vue
@@ -122,7 +122,7 @@ export default {
         return this.validLatLng(lat, lon)
       } else {
         return this.invalidLatLng(
-          'This point is outside the bounding box of data: latitude between 51.229-71.3526, longitude between -179.1506-129.9795'
+          'This point is outside the bounding box of data: latitude between 51.229–71.3526, longitude between -179.1506–129.9795'
         )
       }
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="main">
       <div v-if="!reportIsVisible">
-        <p class="content mt-6 mb-6 is-size-4 blurb">
+        <p class="mt-6 mb-6 is-size-4 blurb">
           Use Arctic-EDS to query historical, current and projected
           environmental data for engineering applications.<br />Download data or
           use our computational notebooks for analysis.
@@ -89,6 +89,6 @@ export default {
     ...mapGetters({
       reportIsVisible: 'report/reportIsVisible',
     }),
-  }
+  },
 }
 </script>


### PR DESCRIPTION
Closes #318 
Closes #323 

Testing:

 - try junk characters (abcdef) -- you should get a warning that it's not parse-able + a clue on what formats are accepted
 - try 65,-120 -- you should get a "not in bbox" note
 - try something valid!  observe that the button is styled with yellow/black/white text
 - observe that the text above the two controls (place + latlng) is centered (it'd been off-center before, oops).