### PR TITLE
New temperature report section

### DIFF
--- a/assets/mock.json
+++ b/assets/mock.json
@@ -1,34 +1,34 @@
 {
   "elevation": {
-    "max": 185,
-    "mean": 145,
-    "min": 117,
+    "max": 148,
+    "mean": 132,
+    "min": 116,
     "res": "1 kilometer",
     "title": "ASTER Global Digital Elevation Model",
     "units": "meters difference from sea level"
   },
   "freezing_index": {
-    "preview": "model,year,dd\r\nERA-Interim,1980,2303\r\nERA-Interim,1981,1709\r\nERA-Interim,1982,2796\r\nERA-Interim,1983,1793\r\nERA-Interim,1984,2095\r\nNCAR-CCSM4,2096,1202\r\nNCAR-CCSM4,2097,846\r\nNCAR-CCSM4,2098,826\r\nNCAR-CCSM4,2099,680\r\nNCAR-CCSM4,2100,647\r\n",
+    "preview": "model,year,dd\r\nERA-Interim,1980,3897\r\nERA-Interim,1981,2602\r\nERA-Interim,1982,4669\r\nERA-Interim,1983,3953\r\nERA-Interim,1984,4318\r\nNCAR-CCSM4,2096,2197\r\nNCAR-CCSM4,2097,1340\r\nNCAR-CCSM4,2098,1703\r\nNCAR-CCSM4,2099,1675\r\nNCAR-CCSM4,2100,1437\r\n",
     "summary": {
       "2010-2039": {
-        "ddmax": 3002,
-        "ddmean": 2022,
-        "ddmin": 859
+        "ddmax": 5308,
+        "ddmean": 3254,
+        "ddmin": 1467
       },
       "2040-2069": {
-        "ddmax": 2552,
-        "ddmean": 1427,
-        "ddmin": 620
+        "ddmax": 4534,
+        "ddmean": 2280,
+        "ddmin": 768
       },
       "2070-2099": {
-        "ddmax": 1995,
-        "ddmean": 905,
-        "ddmin": 262
+        "ddmax": 3845,
+        "ddmean": 1457,
+        "ddmin": 274
       },
       "historical": {
-        "ddmax": 3060,
-        "ddmean": 2233,
-        "ddmin": 1612
+        "ddmax": 5263,
+        "ddmean": 4027,
+        "ddmin": 2602
       }
     }
   },
@@ -38,3427 +38,717 @@
     "title": "USGS Geologic Map of Alaska"
   },
   "heating_degree_days": {
-    "preview": "model,year,dd\r\nERA-Interim,1980,13631\r\nERA-Interim,1981,12989\r\nERA-Interim,1982,14216\r\nERA-Interim,1983,13143\r\nERA-Interim,1984,13424\r\nNCAR-CCSM4,2096,9536\r\nNCAR-CCSM4,2097,8634\r\nNCAR-CCSM4,2098,9594\r\nNCAR-CCSM4,2099,8673\r\nNCAR-CCSM4,2100,8505\r\n",
+    "preview": "model,year,dd\r\nERA-Interim,1980,12281\r\nERA-Interim,1981,11011\r\nERA-Interim,1982,13144\r\nERA-Interim,1983,12370\r\nERA-Interim,1984,12774\r\nNCAR-CCSM4,2096,9888\r\nNCAR-CCSM4,2097,8903\r\nNCAR-CCSM4,2098,10060\r\nNCAR-CCSM4,2099,9119\r\nNCAR-CCSM4,2100,8906\r\n",
     "summary": {
       "2010-2039": {
-        "ddmax": 13335,
-        "ddmean": 11751,
-        "ddmin": 9647
+        "ddmax": 14538,
+        "ddmean": 11959,
+        "ddmin": 8911
       },
       "2040-2069": {
-        "ddmax": 12766,
-        "ddmean": 10340,
-        "ddmin": 8338
+        "ddmax": 13927,
+        "ddmean": 10327,
+        "ddmin": 7942
       },
       "2070-2099": {
-        "ddmax": 11277,
-        "ddmean": 8862,
-        "ddmin": 6990
+        "ddmax": 11709,
+        "ddmean": 8783,
+        "ddmin": 6321
       },
       "historical": {
-        "ddmax": 14339,
-        "ddmean": 13541,
-        "ddmin": 12915
+        "ddmax": 13574,
+        "ddmean": 12274,
+        "ddmin": 11011
       }
     }
   },
   "permafrost": {
-    "preview": "model,year,scenario,magt0.5m,magt1m,magt2m,magt3m,magt4m,magt5m,magtsurface,permafrostbase,permafrosttop,talikthickness\r\n5ModelAvg,2021,RCP 4.5,2.5,2.1,1.4,1.1,1.0,0.9,3.2,0,0,0\r\n5ModelAvg,2021,RCP 8.5,3.6,3.5,3.1,2.7,2.5,2.3,4.1,0,0,0\r\n5ModelAvg,2022,RCP 4.5,2.8,2.1,1.3,1.1,1.1,1.1,4.4,0,0,0\r\n5ModelAvg,2022,RCP 8.5,2.7,2.0,1.5,1.6,1.8,1.9,4.3,0,0,0\r\n5ModelAvg,2023,RCP 4.5,4.5,4.1,3.4,2.8,2.4,2.1,5.2,0,0,0\r\nNCAR-CCSM4,2098,RCP 8.5,2.7,2.4,2.2,2.2,2.2,2.1,3.3,0,0,0\r\nNCAR-CCSM4,2099,RCP 4.5,4.5,2.4,2.2,2.2,2.2,2.1,3.3,0,0,0\r\nNCAR-CCSM4,2099,RCP 8.5,4.5,4.3,3.8,3.5,3.2,3.1,5.5,0,0,0\r\nNCAR-CCSM4,2100,RCP 4.5,5.4,5.1,5.1,5.1,5.1,5.1,6.3,0,0,0\r\nNCAR-CCSM4,2100,RCP 8.5,6.2,6.3,6.7,7.1,7.3,7.4,6.6,0,0,0\r\n",
+    "preview": "model,year,scenario,magt0.5m,magt1m,magt2m,magt3m,magt4m,magt5m,magtsurface,permafrostbase,permafrosttop,talikthickness\r\n5ModelAvg,2021,RCP 4.5,-0.6,-1.0,-1.8,-2.0,-2.0,-1.9,0.9,66.0,2.5,0\r\n5ModelAvg,2021,RCP 8.5,-0.1,-0.3,-0.5,-0.5,-0.5,-0.5,1.2,62.8,1.9,0\r\n5ModelAvg,2022,RCP 4.5,-0.1,-0.3,-0.4,-0.5,-0.7,-0.7,2.0,65.7,2.3,0\r\n5ModelAvg,2022,RCP 8.5,0.1,-0.4,-0.9,-0.9,-0.8,-0.8,1.9,62.1,2.2,0\r\n5ModelAvg,2023,RCP 4.5,0.4,0.1,-0.3,-0.4,-0.5,-0.5,2.4,65.7,2.0,0.0\r\nNCAR-CCSM4,2098,RCP 8.5,-0.3,-0.2,-0.2,-0.2,-0.3,-0.3,0.7,64.7,2.3,0\r\nNCAR-CCSM4,2099,RCP 4.5,-0.0,-0.2,-0.2,-0.2,-0.3,-0.3,0.7,64.7,2.3,0\r\nNCAR-CCSM4,2099,RCP 8.5,-0.0,-0.3,-0.4,-0.4,-0.4,-0.4,2.6,60.1,2.0,0\r\nNCAR-CCSM4,2100,RCP 4.5,1.6,1.2,0.5,0.2,-0.0,-0.1,4.3,51.0,4.0,2.2\r\nNCAR-CCSM4,2100,RCP 8.5,0.4,-0.2,-0.3,0.2,0.4,0.4,3.9,51.6,9.9,6.8\r\n",
     "summary": {
       "2021-2039": {
         "gipl1kmmax": {
-          "magt0.5m": 10.1,
-          "magt1m": 10.0,
-          "magt2m": 9.7,
-          "magt3m": 9.4,
-          "magt4m": 9.2,
-          "magt5m": 9.0,
-          "magtsurface": 10.3,
-          "permafrostbase": 0,
-          "permafrosttop": 0,
-          "talikthickness": 0
+          "magt0.5m": 4.1,
+          "magt1m": 3.5,
+          "magt2m": 2.8,
+          "magt3m": 2.2,
+          "magt4m": 1.8,
+          "magt5m": 1.6,
+          "magtsurface": 8.3,
+          "permafrostbase": 66.0,
+          "permafrosttop": 17.8,
+          "talikthickness": 16.9
         },
         "gipl1kmmean": {
-          "magt0.5m": 3.8,
-          "magt1m": 3.4,
-          "magt2m": 3.1,
-          "magt3m": 2.9,
-          "magt4m": 2.8,
-          "magt5m": 2.7,
-          "magtsurface": 4.8,
-          "permafrostbase": 0,
-          "permafrosttop": 0,
-          "talikthickness": 0
+          "magt0.5m": 0.3,
+          "magt1m": -0.1,
+          "magt2m": -0.4,
+          "magt3m": -0.4,
+          "magt4m": -0.4,
+          "magt5m": -0.5,
+          "magtsurface": 2.3,
+          "permafrostbase": 60.0,
+          "permafrosttop": 2.4,
+          "talikthickness": 0.3
         },
         "gipl1kmmin": {
-          "magt0.5m": 2.4,
-          "magt1m": 1.9,
-          "magt2m": 1.2,
-          "magt3m": 1.1,
-          "magt4m": 1.0,
-          "magt5m": 0.9,
-          "magtsurface": 3.2,
-          "permafrostbase": 0,
-          "permafrosttop": 0,
+          "magt0.5m": -0.8,
+          "magt1m": -1.0,
+          "magt2m": -1.8,
+          "magt3m": -2.0,
+          "magt4m": -2.0,
+          "magt5m": -1.9,
+          "magtsurface": 0.7,
+          "permafrostbase": 46.2,
+          "permafrosttop": 1.9,
           "talikthickness": 0
         }
       },
       "2040-2069": {
         "gipl1kmmax": {
-          "magt0.5m": 8.4,
-          "magt1m": 8.4,
-          "magt2m": 8.4,
-          "magt3m": 8.5,
-          "magt4m": 8.6,
-          "magt5m": 8.6,
-          "magtsurface": 8.9,
-          "permafrostbase": 0,
-          "permafrosttop": 0,
-          "talikthickness": 0
+          "magt0.5m": 3.2,
+          "magt1m": 2.4,
+          "magt2m": 2.0,
+          "magt3m": 1.8,
+          "magt4m": 1.7,
+          "magt5m": 1.6,
+          "magtsurface": 7.4,
+          "permafrostbase": 65.8,
+          "permafrosttop": 18.0,
+          "talikthickness": 16.3
         },
         "gipl1kmmean": {
-          "magt0.5m": 5.1,
-          "magt1m": 4.9,
-          "magt2m": 4.8,
-          "magt3m": 4.6,
-          "magt4m": 4.5,
-          "magt5m": 4.5,
-          "magtsurface": 5.9,
-          "permafrostbase": 0,
-          "permafrosttop": 0,
-          "talikthickness": 0
+          "magt0.5m": 0.9,
+          "magt1m": 0.4,
+          "magt2m": 0.1,
+          "magt3m": -0.0,
+          "magt4m": -0.1,
+          "magt5m": -0.1,
+          "magtsurface": 3.7,
+          "permafrostbase": 54.0,
+          "permafrosttop": 3.2,
+          "talikthickness": 1.1
         },
         "gipl1kmmin": {
-          "magt0.5m": 2.2,
-          "magt1m": 2.0,
-          "magt2m": 2.1,
-          "magt3m": 2.2,
-          "magt4m": 2.2,
-          "magt5m": 2.1,
-          "magtsurface": 3.0,
-          "permafrostbase": 0,
-          "permafrosttop": 0,
+          "magt0.5m": -0.8,
+          "magt1m": -1.0,
+          "magt2m": -0.9,
+          "magt3m": -0.9,
+          "magt4m": -0.9,
+          "magt5m": -0.9,
+          "magtsurface": 1.0,
+          "permafrostbase": 46.9,
+          "permafrosttop": 2.0,
           "talikthickness": 0
         }
       },
       "2070-2099": {
         "gipl1kmmax": {
-          "magt0.5m": 10.5,
-          "magt1m": 10.2,
-          "magt2m": 9.7,
-          "magt3m": 9.2,
-          "magt4m": 8.8,
-          "magt5m": 8.6,
-          "magtsurface": 10.8,
-          "permafrostbase": 0,
-          "permafrosttop": 0,
-          "talikthickness": 0
+          "magt0.5m": 5.6,
+          "magt1m": 4.8,
+          "magt2m": 3.9,
+          "magt3m": 3.3,
+          "magt4m": 2.8,
+          "magt5m": 2.6,
+          "magtsurface": 8.8,
+          "permafrostbase": 65.5,
+          "permafrosttop": 15.5,
+          "talikthickness": 14.5
         },
         "gipl1kmmean": {
-          "magt0.5m": 6.6,
-          "magt1m": 6.5,
-          "magt2m": 6.4,
-          "magt3m": 6.2,
-          "magt4m": 6.1,
-          "magt5m": 6.0,
-          "magtsurface": 7.1,
-          "permafrostbase": 0,
-          "permafrosttop": 0,
-          "talikthickness": 0
+          "magt0.5m": 1.7,
+          "magt1m": 1.1,
+          "magt2m": 0.6,
+          "magt3m": 0.4,
+          "magt4m": 0.3,
+          "magt5m": 0.2,
+          "magtsurface": 5.1,
+          "permafrostbase": 52.6,
+          "permafrosttop": 6.0,
+          "talikthickness": 4.1
         },
         "gipl1kmmin": {
-          "magt0.5m": 2.7,
-          "magt1m": 2.3,
-          "magt2m": 1.7,
-          "magt3m": 1.7,
-          "magt4m": 1.9,
-          "magt5m": 2.0,
-          "magtsurface": 3.3,
-          "permafrostbase": 0,
-          "permafrosttop": 0,
+          "magt0.5m": -0.6,
+          "magt1m": -0.5,
+          "magt2m": -0.8,
+          "magt3m": -0.8,
+          "magt4m": -0.7,
+          "magt5m": -0.7,
+          "magtsurface": 0.5,
+          "permafrostbase": 49.3,
+          "permafrosttop": 2.0,
           "talikthickness": 0
         }
       }
     }
   },
   "physiography": {
-    "name": "Cook Inlet",
+    "name": "Interior Bottomlands",
     "title": "EPA Level III Ecoregions of Alaska"
   },
   "precipitation": {
-    "preview": "model,scenario,year,pr\r\nCRU-TS,historical,1901,426\r\nCRU-TS,historical,1902,427\r\nCRU-TS,historical,1903,289\r\nCRU-TS,historical,1904,272\r\nCRU-TS,historical,1905,462\r\nNCAR-CCSM4,rcp85,2096,704\r\nNCAR-CCSM4,rcp85,2097,640\r\nNCAR-CCSM4,rcp85,2098,572\r\nNCAR-CCSM4,rcp85,2099,527\r\nNCAR-CCSM4,rcp85,2100,518\r\n",
+    "preview": "model,scenario,year,pr\r\nCRU-TS,historical,1901,293\r\nCRU-TS,historical,1902,293\r\nCRU-TS,historical,1903,185\r\nCRU-TS,historical,1904,196\r\nCRU-TS,historical,1905,351\r\nNCAR-CCSM4,rcp85,2096,417\r\nNCAR-CCSM4,rcp85,2097,543\r\nNCAR-CCSM4,rcp85,2098,402\r\nNCAR-CCSM4,rcp85,2099,433\r\nNCAR-CCSM4,rcp85,2100,442\r\n",
     "summary": {
       "2010-2039": {
-        "prmax": 716,
-        "prmean": 475,
-        "prmin": 330
+        "prmax": 505,
+        "prmean": 340,
+        "prmin": 231
       },
       "2040-2069": {
-        "prmax": 746,
-        "prmean": 500,
-        "prmin": 343
+        "prmax": 559,
+        "prmean": 365,
+        "prmin": 229
       },
       "2070-2099": {
-        "prmax": 883,
-        "prmean": 534,
-        "prmin": 348
+        "prmax": 676,
+        "prmean": 393,
+        "prmin": 235
       },
       "historical": {
-        "prmax": 592,
-        "prmean": 427,
-        "prmin": 272
+        "prmax": 450,
+        "prmean": 290,
+        "prmin": 185
       }
     }
   },
   "proj_precip": {
-    "10": {
-      "10d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 142.48,
-            "pf_lower": 105.26,
-            "pf_upper": 185.87
-          },
-          "2050-2079": {
-            "pf": 144.57,
-            "pf_lower": 111.46,
-            "pf_upper": 182.95
-          },
-          "2080-2099": {
-            "pf": 204.41,
-            "pf_lower": 143.7,
-            "pf_upper": 273.13
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 139.47,
-            "pf_lower": 90.04,
-            "pf_upper": 195.72
-          },
-          "2050-2079": {
-            "pf": 156.76,
-            "pf_lower": 102.06,
-            "pf_upper": 217.39
-          },
-          "2080-2099": {
-            "pf": 157.42,
-            "pf_lower": 91.79,
-            "pf_upper": 241.17
-          }
-        }
-      },
-      "12h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 46.66,
-            "pf_lower": 38.82,
-            "pf_upper": 55.93
-          },
-          "2050-2079": {
-            "pf": 58.06,
-            "pf_lower": 49.13,
-            "pf_upper": 68.14
-          },
-          "2080-2099": {
-            "pf": 77.68,
-            "pf_lower": 60.83,
-            "pf_upper": 97.37
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 44.12,
-            "pf_lower": 32.08,
-            "pf_upper": 57.46
-          },
-          "2050-2079": {
-            "pf": 52.39,
-            "pf_lower": 38.04,
-            "pf_upper": 68.37
-          },
-          "2080-2099": {
-            "pf": 50.74,
-            "pf_lower": 35.23,
-            "pf_upper": 69.42
-          }
-        }
-      },
-      "20d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 184.83,
-            "pf_lower": 135.83,
-            "pf_upper": 240.24
-          },
-          "2050-2079": {
-            "pf": 188.03,
-            "pf_lower": 152.43,
-            "pf_upper": 225.41
-          },
-          "2080-2099": {
-            "pf": 280.33,
-            "pf_lower": 167.68,
-            "pf_upper": 417.86
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 186.44,
-            "pf_lower": 117.78,
-            "pf_upper": 266.27
-          },
-          "2050-2079": {
-            "pf": 192.29,
-            "pf_lower": 137.14,
-            "pf_upper": 251.27
-          },
-          "2080-2099": {
-            "pf": 218.3,
-            "pf_lower": 126.12,
-            "pf_upper": 333.43
-          }
-        }
-      },
-      "24h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 56.99,
-            "pf_lower": 43.61,
-            "pf_upper": 73.29
-          },
-          "2050-2079": {
-            "pf": 67.39,
-            "pf_lower": 54.62,
-            "pf_upper": 81.67
-          },
-          "2080-2099": {
-            "pf": 93.35,
-            "pf_lower": 68.77,
-            "pf_upper": 120.41
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 55.0,
-            "pf_lower": 40.31,
-            "pf_upper": 71.15
-          },
-          "2050-2079": {
-            "pf": 70.43,
-            "pf_lower": 46.26,
-            "pf_upper": 97.96
-          },
-          "2080-2099": {
-            "pf": 72.72,
-            "pf_lower": 40.84,
-            "pf_upper": 113.91
-          }
-        }
-      },
-      "2d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 76.3,
-            "pf_lower": 56.59,
-            "pf_upper": 100.6
-          },
-          "2050-2079": {
-            "pf": 91.8,
-            "pf_lower": 72.28,
-            "pf_upper": 113.73
-          },
-          "2080-2099": {
-            "pf": 129.75,
-            "pf_lower": 94.47,
-            "pf_upper": 168.41
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 75.57,
-            "pf_lower": 47.79,
-            "pf_upper": 107.81
-          },
-          "2050-2079": {
-            "pf": 90.95,
-            "pf_lower": 58.54,
-            "pf_upper": 127.51
-          },
-          "2080-2099": {
-            "pf": 89.09,
-            "pf_lower": 48.3,
-            "pf_upper": 151.78
-          }
-        }
-      },
-      "2h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 19.04,
-            "pf_lower": 16.79,
-            "pf_upper": 21.76
-          },
-          "2050-2079": {
-            "pf": 24.37,
-            "pf_lower": 21.19,
-            "pf_upper": 28.12
-          },
-          "2080-2099": {
-            "pf": 29.35,
-            "pf_lower": 25.38,
-            "pf_upper": 33.95
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 19.45,
-            "pf_lower": 16.07,
-            "pf_upper": 23.45
-          },
-          "2050-2079": {
-            "pf": 22.97,
-            "pf_lower": 19.05,
-            "pf_upper": 27.63
-          },
-          "2080-2099": {
-            "pf": 24.17,
-            "pf_lower": 21.2,
-            "pf_upper": 27.1
-          }
-        }
-      },
-      "30d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 218.59,
-            "pf_lower": 156.36,
-            "pf_upper": 293.62
-          },
-          "2050-2079": {
-            "pf": 239.46,
-            "pf_lower": 184.45,
-            "pf_upper": 303.66
-          },
-          "2080-2099": {
-            "pf": 323.62,
-            "pf_lower": 212.28,
-            "pf_upper": 456.06
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 242.63,
-            "pf_lower": 154.66,
-            "pf_upper": 340.89
-          },
-          "2050-2079": {
-            "pf": 248.93,
-            "pf_lower": 190.42,
-            "pf_upper": 305.04
-          },
-          "2080-2099": {
-            "pf": 263.8,
-            "pf_lower": 177.59,
-            "pf_upper": 359.57
-          }
-        }
-      },
-      "3d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 97.47,
-            "pf_lower": 74.11,
-            "pf_upper": 125.48
-          },
-          "2050-2079": {
-            "pf": 115.98,
-            "pf_lower": 93.0,
-            "pf_upper": 141.1
-          },
-          "2080-2099": {
-            "pf": 157.65,
-            "pf_lower": 108.69,
-            "pf_upper": 215.76
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 81.9,
-            "pf_lower": 55.3,
-            "pf_upper": 110.85
-          },
-          "2050-2079": {
-            "pf": 106.27,
-            "pf_lower": 63.19,
-            "pf_upper": 156.34
-          },
-          "2080-2099": {
-            "pf": 104.67,
-            "pf_lower": 54.62,
-            "pf_upper": 179.53
-          }
-        }
-      },
-      "3h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 23.13,
-            "pf_lower": 19.92,
-            "pf_upper": 27.16
-          },
-          "2050-2079": {
-            "pf": 29.97,
-            "pf_lower": 25.92,
-            "pf_upper": 34.69
-          },
-          "2080-2099": {
-            "pf": 36.82,
-            "pf_lower": 30.87,
-            "pf_upper": 44.12
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 23.03,
-            "pf_lower": 18.41,
-            "pf_upper": 28.39
-          },
-          "2050-2079": {
-            "pf": 26.47,
-            "pf_lower": 21.17,
-            "pf_upper": 32.75
-          },
-          "2080-2099": {
-            "pf": 29.16,
-            "pf_lower": 24.57,
-            "pf_upper": 33.78
-          }
-        }
-      },
-      "45d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 262.52,
-            "pf_lower": 200.28,
-            "pf_upper": 328.17
-          },
-          "2050-2079": {
-            "pf": 276.2,
-            "pf_lower": 230.04,
-            "pf_upper": 320.22
-          },
-          "2080-2099": {
-            "pf": 360.94,
-            "pf_lower": 233.94,
-            "pf_upper": 520.07
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 299.57,
-            "pf_lower": 210.56,
-            "pf_upper": 393.7
-          },
-          "2050-2079": {
-            "pf": 297.55,
-            "pf_lower": 236.7,
-            "pf_upper": 355.36
-          },
-          "2080-2099": {
-            "pf": 307.17,
-            "pf_lower": 232.2,
-            "pf_upper": 382.71
-          }
-        }
-      },
-      "4d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 104.97,
-            "pf_lower": 76.81,
-            "pf_upper": 137.75
-          },
-          "2050-2079": {
-            "pf": 122.25,
-            "pf_lower": 93.09,
-            "pf_upper": 160.31
-          },
-          "2080-2099": {
-            "pf": 159.22,
-            "pf_lower": 111.1,
-            "pf_upper": 216.16
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 98.58,
-            "pf_lower": 62.42,
-            "pf_upper": 140.94
-          },
-          "2050-2079": {
-            "pf": 115.4,
-            "pf_lower": 77.05,
-            "pf_upper": 158.27
-          },
-          "2080-2099": {
-            "pf": 115.75,
-            "pf_lower": 64.64,
-            "pf_upper": 185.54
-          }
-        }
-      },
-      "60d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 326.11,
-            "pf_lower": 241.28,
-            "pf_upper": 418.49
-          },
-          "2050-2079": {
-            "pf": 321.53,
-            "pf_lower": 275.66,
-            "pf_upper": 363.86
-          },
-          "2080-2099": {
-            "pf": 433.58,
-            "pf_lower": 311.85,
-            "pf_upper": 578.25
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 330.79,
-            "pf_lower": 237.04,
-            "pf_upper": 431.22
-          },
-          "2050-2079": {
-            "pf": 357.27,
-            "pf_lower": 290.28,
-            "pf_upper": 417.8
-          },
-          "2080-2099": {
-            "pf": 341.3,
-            "pf_lower": 264.2,
-            "pf_upper": 413.1
-          }
-        }
-      },
-      "60m": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 14.47,
-            "pf_lower": 13.19,
-            "pf_upper": 16.02
-          },
-          "2050-2079": {
-            "pf": 18.27,
-            "pf_lower": 16.69,
-            "pf_upper": 20.03
-          },
-          "2080-2099": {
-            "pf": 22.73,
-            "pf_lower": 20.61,
-            "pf_upper": 25.03
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 16.34,
-            "pf_lower": 14.32,
-            "pf_upper": 18.84
-          },
-          "2050-2079": {
-            "pf": 18.47,
-            "pf_lower": 16.49,
-            "pf_upper": 20.89
-          },
-          "2080-2099": {
-            "pf": 20.04,
-            "pf_lower": 18.63,
-            "pf_upper": 21.32
-          }
-        }
-      },
-      "6h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 33.63,
-            "pf_lower": 28.06,
-            "pf_upper": 40.6
-          },
-          "2050-2079": {
-            "pf": 41.18,
-            "pf_lower": 35.35,
-            "pf_upper": 47.79
-          },
-          "2080-2099": {
-            "pf": 51.07,
-            "pf_lower": 41.28,
-            "pf_upper": 62.72
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 30.04,
-            "pf_lower": 23.37,
-            "pf_upper": 37.76
-          },
-          "2050-2079": {
-            "pf": 37.89,
-            "pf_lower": 28.37,
-            "pf_upper": 49.22
-          },
-          "2080-2099": {
-            "pf": 39.45,
-            "pf_lower": 30.3,
-            "pf_upper": 49.17
-          }
-        }
-      },
-      "7d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 123.15,
-            "pf_lower": 100.06,
-            "pf_upper": 146.86
-          },
-          "2050-2079": {
-            "pf": 138.63,
-            "pf_lower": 110.77,
-            "pf_upper": 170.55
-          },
-          "2080-2099": {
-            "pf": 186.3,
-            "pf_lower": 131.54,
-            "pf_upper": 250.69
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 101.38,
-            "pf_lower": 66.54,
-            "pf_upper": 141.74
-          },
-          "2050-2079": {
-            "pf": 132.69,
-            "pf_lower": 81.9,
-            "pf_upper": 191.56
-          },
-          "2080-2099": {
-            "pf": 126.71,
-            "pf_lower": 68.71,
-            "pf_upper": 200.28
-          }
-        }
-      }
-    },
-    "100": {
-      "10d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 170.92,
-            "pf_lower": 105.58,
-            "pf_upper": 348.32
-          },
-          "2050-2079": {
-            "pf": 166.93,
-            "pf_lower": 111.8,
-            "pf_upper": 327.79
-          },
-          "2080-2099": {
-            "pf": 237.86,
-            "pf_lower": 144.13,
-            "pf_upper": 536.79
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 221.0,
-            "pf_lower": 91.37,
-            "pf_upper": 462.94
-          },
-          "2050-2079": {
-            "pf": 239.06,
-            "pf_lower": 105.05,
-            "pf_upper": 470.49
-          },
-          "2080-2099": {
-            "pf": 272.75,
-            "pf_lower": 92.06,
-            "pf_upper": 755.67
-          }
-        }
-      },
-      "12h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 63.75,
-            "pf_lower": 41.59,
-            "pf_upper": 104.41
-          },
-          "2050-2079": {
-            "pf": 74.64,
-            "pf_lower": 52.52,
-            "pf_upper": 112.29
-          },
-          "2080-2099": {
-            "pf": 109.93,
-            "pf_lower": 64.27,
-            "pf_upper": 201.99
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 72.34,
-            "pf_lower": 39.79,
-            "pf_upper": 123.95
-          },
-          "2050-2079": {
-            "pf": 87.44,
-            "pf_lower": 47.63,
-            "pf_upper": 152.45
-          },
-          "2080-2099": {
-            "pf": 85.04,
-            "pf_lower": 40.65,
-            "pf_upper": 167.91
-          }
-        }
-      },
-      "20d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 262.65,
-            "pf_lower": 141.47,
-            "pf_upper": 466.32
-          },
-          "2050-2079": {
-            "pf": 234.82,
-            "pf_lower": 158.52,
-            "pf_upper": 346.07
-          },
-          "2080-2099": {
-            "pf": 480.19,
-            "pf_lower": 168.18,
-            "pf_upper": 1224.93
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 354.65,
-            "pf_lower": 137.57,
-            "pf_upper": 737.34
-          },
-          "2050-2079": {
-            "pf": 307.54,
-            "pf_lower": 173.77,
-            "pf_upper": 506.15
-          },
-          "2080-2099": {
-            "pf": 422.72,
-            "pf_lower": 129.77,
-            "pf_upper": 1016.15
-          }
-        }
-      },
-      "24h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 79.48,
-            "pf_lower": 43.75,
-            "pf_upper": 161.15
-          },
-          "2050-2079": {
-            "pf": 80.68,
-            "pf_lower": 54.79,
-            "pf_upper": 132.17
-          },
-          "2080-2099": {
-            "pf": 117.38,
-            "pf_lower": 68.98,
-            "pf_upper": 227.97
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 77.86,
-            "pf_lower": 41.48,
-            "pf_upper": 138.64
-          },
-          "2050-2079": {
-            "pf": 113.31,
-            "pf_lower": 47.68,
-            "pf_upper": 234.02
-          },
-          "2080-2099": {
-            "pf": 136.66,
-            "pf_lower": 40.96,
-            "pf_upper": 388.28
-          }
-        }
-      },
-      "2d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 104.19,
-            "pf_lower": 56.76,
-            "pf_upper": 231.62
-          },
-          "2050-2079": {
-            "pf": 105.45,
-            "pf_lower": 72.5,
-            "pf_upper": 183.89
-          },
-          "2080-2099": {
-            "pf": 151.64,
-            "pf_lower": 94.76,
-            "pf_upper": 299.86
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 98.65,
-            "pf_lower": 47.93,
-            "pf_upper": 249.32
-          },
-          "2050-2079": {
-            "pf": 114.45,
-            "pf_lower": 58.71,
-            "pf_upper": 267.33
-          },
-          "2080-2099": {
-            "pf": 165.19,
-            "pf_lower": 48.45,
-            "pf_upper": 654.6
-          }
-        }
-      },
-      "2h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 28.2,
-            "pf_lower": 21.18,
-            "pf_upper": 40.98
-          },
-          "2050-2079": {
-            "pf": 36.78,
-            "pf_lower": 27.32,
-            "pf_upper": 53.38
-          },
-          "2080-2099": {
-            "pf": 42.16,
-            "pf_lower": 30.82,
-            "pf_upper": 63.35
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 33.61,
-            "pf_lower": 23.73,
-            "pf_upper": 54.92
-          },
-          "2050-2079": {
-            "pf": 39.89,
-            "pf_lower": 26.01,
-            "pf_upper": 65.68
-          },
-          "2080-2099": {
-            "pf": 30.12,
-            "pf_lower": 24.41,
-            "pf_upper": 38.35
-          }
-        }
-      },
-      "30d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 343.9,
-            "pf_lower": 161.28,
-            "pf_upper": 700.08
-          },
-          "2050-2079": {
-            "pf": 338.6,
-            "pf_lower": 191.34,
-            "pf_upper": 599.96
-          },
-          "2080-2099": {
-            "pf": 511.48,
-            "pf_lower": 212.92,
-            "pf_upper": 1226.16
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 444.45,
-            "pf_lower": 199.65,
-            "pf_upper": 844.09
-          },
-          "2050-2079": {
-            "pf": 360.63,
-            "pf_lower": 251.99,
-            "pf_upper": 506.66
-          },
-          "2080-2099": {
-            "pf": 423.97,
-            "pf_lower": 218.09,
-            "pf_upper": 1017.16
-          }
-        }
-      },
-      "3d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 131.56,
-            "pf_lower": 74.33,
-            "pf_upper": 263.74
-          },
-          "2050-2079": {
-            "pf": 134.87,
-            "pf_lower": 93.28,
-            "pf_upper": 221.21
-          },
-          "2080-2099": {
-            "pf": 222.16,
-            "pf_lower": 109.01,
-            "pf_upper": 518.48
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 99.63,
-            "pf_lower": 55.47,
-            "pf_upper": 249.57
-          },
-          "2050-2079": {
-            "pf": 147.39,
-            "pf_lower": 63.38,
-            "pf_upper": 386.61
-          },
-          "2080-2099": {
-            "pf": 191.99,
-            "pf_lower": 54.78,
-            "pf_upper": 753.41
-          }
-        }
-      },
-      "3h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 40.22,
-            "pf_lower": 28.45,
-            "pf_upper": 63.61
-          },
-          "2050-2079": {
-            "pf": 47.49,
-            "pf_lower": 35.86,
-            "pf_upper": 67.4
-          },
-          "2080-2099": {
-            "pf": 62.7,
-            "pf_lower": 42.59,
-            "pf_upper": 103.15
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 38.56,
-            "pf_lower": 23.95,
-            "pf_upper": 64.29
-          },
-          "2050-2079": {
-            "pf": 46.23,
-            "pf_lower": 27.6,
-            "pf_upper": 80.73
-          },
-          "2080-2099": {
-            "pf": 37.81,
-            "pf_lower": 28.62,
-            "pf_upper": 51.35
-          }
-        }
-      },
-      "45d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 347.34,
-            "pf_lower": 209.07,
-            "pf_upper": 700.78
-          },
-          "2050-2079": {
-            "pf": 341.98,
-            "pf_lower": 258.37,
-            "pf_upper": 600.56
-          },
-          "2080-2099": {
-            "pf": 516.6,
-            "pf_lower": 234.64,
-            "pf_upper": 1324.35
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 506.28,
-            "pf_lower": 297.99,
-            "pf_upper": 844.93
-          },
-          "2050-2079": {
-            "pf": 436.0,
-            "pf_lower": 324.37,
-            "pf_upper": 581.89
-          },
-          "2080-2099": {
-            "pf": 459.32,
-            "pf_lower": 308.8,
-            "pf_upper": 1018.18
-          }
-        }
-      },
-      "4d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 132.87,
-            "pf_lower": 77.04,
-            "pf_upper": 265.42
-          },
-          "2050-2079": {
-            "pf": 138.04,
-            "pf_lower": 93.37,
-            "pf_upper": 307.26
-          },
-          "2080-2099": {
-            "pf": 224.38,
-            "pf_lower": 111.43,
-            "pf_upper": 519.0
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 140.8,
-            "pf_lower": 62.61,
-            "pf_upper": 355.23
-          },
-          "2050-2079": {
-            "pf": 148.87,
-            "pf_lower": 77.28,
-            "pf_upper": 386.99
-          },
-          "2080-2099": {
-            "pf": 192.46,
-            "pf_lower": 64.84,
-            "pf_upper": 754.16
-          }
-        }
-      },
-      "60d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 350.81,
-            "pf_lower": 242.0,
-            "pf_upper": 701.48
-          },
-          "2050-2079": {
-            "pf": 345.4,
-            "pf_lower": 276.49,
-            "pf_upper": 601.16
-          },
-          "2080-2099": {
-            "pf": 521.76,
-            "pf_lower": 312.79,
-            "pf_upper": 1325.68
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 511.34,
-            "pf_lower": 301.64,
-            "pf_upper": 845.78
-          },
-          "2050-2079": {
-            "pf": 440.36,
-            "pf_lower": 332.28,
-            "pf_upper": 582.48
-          },
-          "2080-2099": {
-            "pf": 463.91,
-            "pf_lower": 331.82,
-            "pf_upper": 1019.2
-          }
-        }
-      },
-      "60m": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 19.64,
-            "pf_lower": 15.53,
-            "pf_upper": 27.34
-          },
-          "2050-2079": {
-            "pf": 22.65,
-            "pf_lower": 18.66,
-            "pf_upper": 28.88
-          },
-          "2080-2099": {
-            "pf": 27.42,
-            "pf_lower": 22.41,
-            "pf_upper": 35.96
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 31.36,
-            "pf_lower": 23.71,
-            "pf_upper": 45.38
-          },
-          "2050-2079": {
-            "pf": 31.96,
-            "pf_lower": 25.17,
-            "pf_upper": 43.98
-          },
-          "2080-2099": {
-            "pf": 24.08,
-            "pf_lower": 21.77,
-            "pf_upper": 27.12
-          }
-        }
-      },
-      "6h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 56.6,
-            "pf_lower": 36.3,
-            "pf_upper": 96.89
-          },
-          "2050-2079": {
-            "pf": 58.91,
-            "pf_lower": 43.66,
-            "pf_upper": 83.43
-          },
-          "2080-2099": {
-            "pf": 81.28,
-            "pf_lower": 51.29,
-            "pf_upper": 139.08
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 48.25,
-            "pf_lower": 28.64,
-            "pf_upper": 81.05
-          },
-          "2050-2079": {
-            "pf": 66.88,
-            "pf_lower": 35.06,
-            "pf_upper": 123.78
-          },
-          "2080-2099": {
-            "pf": 55.26,
-            "pf_lower": 35.69,
-            "pf_upper": 85.58
-          }
-        }
-      },
-      "7d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 134.2,
-            "pf_lower": 100.36,
-            "pf_upper": 265.69
-          },
-          "2050-2079": {
-            "pf": 148.44,
-            "pf_lower": 111.11,
-            "pf_upper": 307.57
-          },
-          "2080-2099": {
-            "pf": 226.63,
-            "pf_lower": 131.94,
-            "pf_upper": 536.26
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 158.02,
-            "pf_lower": 66.74,
-            "pf_upper": 355.59
-          },
-          "2050-2079": {
-            "pf": 210.9,
-            "pf_lower": 82.14,
-            "pf_upper": 465.42
-          },
-          "2080-2099": {
-            "pf": 214.87,
-            "pf_lower": 68.91,
-            "pf_upper": 754.92
-          }
-        }
-      }
-    },
-    "1000": {
-      "10d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 178.53,
-            "pf_lower": 105.89,
-            "pf_upper": 748.74
-          },
-          "2050-2079": {
-            "pf": 172.72,
-            "pf_lower": 112.13,
-            "pf_upper": 770.67
-          },
-          "2080-2099": {
-            "pf": 295.57,
-            "pf_lower": 144.57,
-            "pf_upper": 1577.03
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 314.23,
-            "pf_lower": 91.64,
-            "pf_upper": 1133.33
-          },
-          "2050-2079": {
-            "pf": 321.34,
-            "pf_lower": 105.37,
-            "pf_upper": 1196.07
-          },
-          "2080-2099": {
-            "pf": 451.68,
-            "pf_lower": 92.34,
-            "pf_upper": 4073.37
-          }
-        }
-      },
-      "12h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 97.3,
-            "pf_lower": 48.32,
-            "pf_upper": 291.27
-          },
-          "2050-2079": {
-            "pf": 84.84,
-            "pf_lower": 52.68,
-            "pf_upper": 199.11
-          },
-          "2080-2099": {
-            "pf": 138.35,
-            "pf_lower": 64.47,
-            "pf_upper": 476.76
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 109.57,
-            "pf_lower": 45.3,
-            "pf_upper": 273.02
-          },
-          "2050-2079": {
-            "pf": 135.7,
-            "pf_lower": 56.47,
-            "pf_upper": 343.08
-          },
-          "2080-2099": {
-            "pf": 134.98,
-            "pf_lower": 45.09,
-            "pf_upper": 436.94
-          }
-        }
-      },
-      "20d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 346.53,
-            "pf_lower": 141.89,
-            "pf_upper": 941.11
-          },
-          "2050-2079": {
-            "pf": 272.9,
-            "pf_lower": 159.0,
-            "pf_upper": 771.44
-          },
-          "2080-2099": {
-            "pf": 807.18,
-            "pf_lower": 168.69,
-            "pf_upper": 4102.12
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 632.42,
-            "pf_lower": 145.38,
-            "pf_upper": 2061.88
-          },
-          "2050-2079": {
-            "pf": 447.13,
-            "pf_lower": 207.33,
-            "pf_upper": 1197.26
-          },
-          "2080-2099": {
-            "pf": 785.03,
-            "pf_lower": 130.16,
-            "pf_upper": 4077.45
-          }
-        }
-      },
-      "24h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 104.56,
-            "pf_lower": 48.37,
-            "pf_upper": 433.28
-          },
-          "2050-2079": {
-            "pf": 87.58,
-            "pf_lower": 54.95,
-            "pf_upper": 235.36
-          },
-          "2080-2099": {
-            "pf": 139.74,
-            "pf_lower": 69.19,
-            "pf_upper": 534.51
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 110.66,
-            "pf_lower": 45.35,
-            "pf_upper": 292.94
-          },
-          "2050-2079": {
-            "pf": 167.73,
-            "pf_lower": 56.53,
-            "pf_upper": 582.42
-          },
-          "2080-2099": {
-            "pf": 251.76,
-            "pf_lower": 45.14,
-            "pf_upper": 1522.33
-          }
-        }
-      },
-      "2d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 128.15,
-            "pf_lower": 56.93,
-            "pf_upper": 668.56
-          },
-          "2050-2079": {
-            "pf": 108.33,
-            "pf_lower": 72.72,
-            "pf_upper": 337.79
-          },
-          "2080-2099": {
-            "pf": 156.87,
-            "pf_lower": 95.04,
-            "pf_upper": 638.46
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 114.2,
-            "pf_lower": 48.07,
-            "pf_upper": 666.34
-          },
-          "2050-2079": {
-            "pf": 169.41,
-            "pf_lower": 58.89,
-            "pf_upper": 672.39
-          },
-          "2080-2099": {
-            "pf": 317.9,
-            "pf_lower": 48.6,
-            "pf_upper": 3764.22
-          }
-        }
-      },
-      "2h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 40.17,
-            "pf_lower": 24.72,
-            "pf_upper": 88.65
-          },
-          "2050-2079": {
-            "pf": 52.13,
-            "pf_lower": 32.06,
-            "pf_upper": 113.05
-          },
-          "2080-2099": {
-            "pf": 57.57,
-            "pf_lower": 34.56,
-            "pf_upper": 134.95
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 58.58,
-            "pf_lower": 37.85,
-            "pf_upper": 148.14
-          },
-          "2050-2079": {
-            "pf": 66.33,
-            "pf_lower": 36.32,
-            "pf_upper": 178.62
-          },
-          "2080-2099": {
-            "pf": 33.4,
-            "pf_lower": 25.21,
-            "pf_upper": 52.4
-          }
-        }
-      },
-      "30d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 516.5,
-            "pf_lower": 161.76,
-            "pf_upper": 1883.35
-          },
-          "2050-2079": {
-            "pf": 452.28,
-            "pf_lower": 191.91,
-            "pf_upper": 1287.71
-          },
-          "2080-2099": {
-            "pf": 815.25,
-            "pf_lower": 213.56,
-            "pf_upper": 4106.22
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 726.28,
-            "pf_lower": 237.73,
-            "pf_upper": 2063.94
-          },
-          "2050-2079": {
-            "pf": 463.78,
-            "pf_lower": 307.5,
-            "pf_upper": 1198.46
-          },
-          "2080-2099": {
-            "pf": 792.88,
-            "pf_lower": 438.06,
-            "pf_upper": 4081.53
-          }
-        }
-      },
-      "3d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 159.89,
-            "pf_lower": 74.56,
-            "pf_upper": 669.23
-          },
-          "2050-2079": {
-            "pf": 139.61,
-            "pf_lower": 93.56,
-            "pf_upper": 380.02
-          },
-          "2080-2099": {
-            "pf": 286.88,
-            "pf_lower": 109.34,
-            "pf_upper": 1572.31
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 115.34,
-            "pf_lower": 55.64,
-            "pf_upper": 667.01
-          },
-          "2050-2079": {
-            "pf": 179.14,
-            "pf_lower": 63.57,
-            "pf_upper": 1068.92
-          },
-          "2080-2099": {
-            "pf": 356.26,
-            "pf_lower": 54.94,
-            "pf_upper": 4061.18
-          }
-        }
-      },
-      "3h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 72.41,
-            "pf_lower": 42.05,
-            "pf_upper": 187.1
-          },
-          "2050-2079": {
-            "pf": 71.87,
-            "pf_lower": 48.05,
-            "pf_upper": 141.44
-          },
-          "2080-2099": {
-            "pf": 107.05,
-            "pf_lower": 59.34,
-            "pf_upper": 286.08
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 59.83,
-            "pf_lower": 37.89,
-            "pf_upper": 156.65
-          },
-          "2050-2079": {
-            "pf": 78.08,
-            "pf_lower": 36.35,
-            "pf_upper": 228.39
-          },
-          "2080-2099": {
-            "pf": 43.59,
-            "pf_lower": 29.81,
-            "pf_upper": 76.35
-          }
-        }
-      },
-      "45d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 521.67,
-            "pf_lower": 293.29,
-            "pf_upper": 1885.24
-          },
-          "2050-2079": {
-            "pf": 456.8,
-            "pf_lower": 339.69,
-            "pf_upper": 1289.0
-          },
-          "2080-2099": {
-            "pf": 823.4,
-            "pf_lower": 235.34,
-            "pf_upper": 4139.28
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 743.63,
-            "pf_lower": 381.15,
-            "pf_upper": 2066.0
-          },
-          "2050-2079": {
-            "pf": 564.9,
-            "pf_lower": 405.62,
-            "pf_upper": 1199.66
-          },
-          "2080-2099": {
-            "pf": 800.81,
-            "pf_lower": 573.4,
-            "pf_upper": 4085.61
-          }
-        }
-      },
-      "4d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 161.48,
-            "pf_lower": 77.27,
-            "pf_upper": 669.9
-          },
-          "2050-2079": {
-            "pf": 141.0,
-            "pf_lower": 93.65,
-            "pf_upper": 769.13
-          },
-          "2080-2099": {
-            "pf": 289.75,
-            "pf_lower": 111.77,
-            "pf_upper": 1573.88
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 180.29,
-            "pf_lower": 62.79,
-            "pf_upper": 1038.02
-          },
-          "2050-2079": {
-            "pf": 180.93,
-            "pf_lower": 77.51,
-            "pf_upper": 1069.99
-          },
-          "2080-2099": {
-            "pf": 359.82,
-            "pf_lower": 65.03,
-            "pf_upper": 4065.24
-          }
-        }
-      },
-      "60d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 526.89,
-            "pf_lower": 293.58,
-            "pf_upper": 1887.12
-          },
-          "2050-2079": {
-            "pf": 461.37,
-            "pf_lower": 359.54,
-            "pf_upper": 1290.29
-          },
-          "2080-2099": {
-            "pf": 831.63,
-            "pf_lower": 313.73,
-            "pf_upper": 4143.42
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 751.07,
-            "pf_lower": 407.11,
-            "pf_upper": 2068.07
-          },
-          "2050-2079": {
-            "pf": 570.55,
-            "pf_lower": 432.95,
-            "pf_upper": 1200.86
-          },
-          "2080-2099": {
-            "pf": 808.82,
-            "pf_lower": 632.7,
-            "pf_upper": 4089.69
-          }
-        }
-      },
-      "60m": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 25.31,
-            "pf_lower": 16.17,
-            "pf_upper": 56.97
-          },
-          "2050-2079": {
-            "pf": 25.12,
-            "pf_lower": 18.81,
-            "pf_upper": 42.81
-          },
-          "2080-2099": {
-            "pf": 29.56,
-            "pf_lower": 22.47,
-            "pf_upper": 55.06
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 58.0,
-            "pf_lower": 37.82,
-            "pf_upper": 125.13
-          },
-          "2050-2079": {
-            "pf": 52.54,
-            "pf_lower": 36.28,
-            "pf_upper": 101.88
-          },
-          "2080-2099": {
-            "pf": 26.09,
-            "pf_lower": 23.11,
-            "pf_upper": 32.45
-          }
-        }
-      },
-      "6h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 96.33,
-            "pf_lower": 44.42,
-            "pf_upper": 290.97
-          },
-          "2050-2079": {
-            "pf": 78.44,
-            "pf_lower": 49.8,
-            "pf_upper": 152.98
-          },
-          "2080-2099": {
-            "pf": 124.7,
-            "pf_lower": 59.94,
-            "pf_upper": 354.63
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 72.05,
-            "pf_lower": 37.93,
-            "pf_upper": 181.17
-          },
-          "2050-2079": {
-            "pf": 111.52,
-            "pf_lower": 37.25,
-            "pf_upper": 337.96
-          },
-          "2080-2099": {
-            "pf": 69.22,
-            "pf_lower": 38.07,
-            "pf_upper": 150.0
-          }
-        }
-      },
-      "7d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 163.1,
-            "pf_lower": 100.66,
-            "pf_upper": 670.57
-          },
-          "2050-2079": {
-            "pf": 152.94,
-            "pf_lower": 111.44,
-            "pf_upper": 769.9
-          },
-          "2080-2099": {
-            "pf": 292.64,
-            "pf_lower": 132.33,
-            "pf_upper": 1575.45
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 235.72,
-            "pf_lower": 66.94,
-            "pf_upper": 1039.06
-          },
-          "2050-2079": {
-            "pf": 309.55,
-            "pf_lower": 82.39,
-            "pf_upper": 1194.87
-          },
-          "2080-2099": {
-            "pf": 363.42,
-            "pf_lower": 69.12,
-            "pf_upper": 4069.3
-          }
-        }
-      }
-    },
     "2": {
       "10d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 96.93,
-            "pf_lower": 79.78,
-            "pf_upper": 116.34
-          },
-          "2050-2079": {
-            "pf": 104.81,
-            "pf_lower": 89.28,
-            "pf_upper": 122.29
-          },
-          "2080-2099": {
-            "pf": 141.8,
-            "pf_lower": 112.7,
-            "pf_upper": 175.38
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 82.42,
-            "pf_lower": 61.65,
-            "pf_upper": 107.3
-          },
-          "2050-2079": {
-            "pf": 91.92,
-            "pf_lower": 66.78,
-            "pf_upper": 121.39
-          },
-          "2080-2099": {
-            "pf": 95.52,
-            "pf_lower": 72.22,
-            "pf_upper": 126.3
-          }
-        }
-      },
-      "12h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 31.35,
-            "pf_lower": 27.96,
-            "pf_upper": 35.26
-          },
-          "2050-2079": {
-            "pf": 39.53,
-            "pf_lower": 34.97,
-            "pf_upper": 44.55
-          },
-          "2080-2099": {
-            "pf": 49.56,
-            "pf_lower": 42.31,
-            "pf_upper": 58.26
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 26.67,
-            "pf_lower": 21.14,
-            "pf_upper": 33.16
-          },
-          "2050-2079": {
-            "pf": 31.66,
-            "pf_lower": 25.28,
-            "pf_upper": 39.2
-          },
-          "2080-2099": {
-            "pf": 31.57,
-            "pf_lower": 24.7,
-            "pf_upper": 39.99
-          }
-        }
-      },
-      "20d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 126.58,
-            "pf_lower": 101.74,
-            "pf_upper": 154.23
-          },
-          "2050-2079": {
-            "pf": 143.98,
-            "pf_lower": 121.9,
-            "pf_upper": 167.22
-          },
-          "2080-2099": {
-            "pf": 176.58,
-            "pf_lower": 134.66,
-            "pf_upper": 229.93
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 105.63,
-            "pf_lower": 79.25,
-            "pf_upper": 137.96
-          },
-          "2050-2079": {
-            "pf": 118.55,
-            "pf_lower": 90.31,
-            "pf_upper": 150.7
-          },
-          "2080-2099": {
-            "pf": 125.27,
-            "pf_lower": 89.61,
-            "pf_upper": 171.12
-          }
-        }
-      },
-      "24h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 40.38,
-            "pf_lower": 35.18,
-            "pf_upper": 46.56
-          },
-          "2050-2079": {
-            "pf": 50.53,
-            "pf_lower": 43.91,
-            "pf_upper": 57.83
-          },
-          "2080-2099": {
-            "pf": 64.82,
-            "pf_lower": 52.17,
-            "pf_upper": 79.33
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 37.88,
-            "pf_lower": 31.0,
-            "pf_upper": 45.92
-          },
-          "2050-2079": {
-            "pf": 42.94,
-            "pf_lower": 32.89,
-            "pf_upper": 54.98
-          },
-          "2080-2099": {
-            "pf": 43.38,
-            "pf_lower": 32.74,
-            "pf_upper": 57.75
-          }
-        }
-      },
-      "2d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 50.54,
-            "pf_lower": 43.15,
-            "pf_upper": 59.41
-          },
-          "2050-2079": {
-            "pf": 63.5,
-            "pf_lower": 53.28,
-            "pf_upper": 74.7
-          },
-          "2080-2099": {
-            "pf": 86.73,
-            "pf_lower": 68.36,
-            "pf_upper": 107.66
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 51.24,
-            "pf_lower": 40.25,
-            "pf_upper": 64.6
-          },
-          "2050-2079": {
-            "pf": 62.09,
-            "pf_lower": 48.1,
-            "pf_upper": 78.78
-          },
-          "2080-2099": {
-            "pf": 57.72,
-            "pf_lower": 46.44,
-            "pf_upper": 75.09
-          }
-        }
-      },
-      "2h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 13.12,
-            "pf_lower": 12.19,
-            "pf_upper": 14.21
-          },
-          "2050-2079": {
-            "pf": 15.9,
-            "pf_lower": 14.52,
-            "pf_upper": 17.5
-          },
-          "2080-2099": {
-            "pf": 20.37,
-            "pf_lower": 18.65,
-            "pf_upper": 22.45
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 11.46,
-            "pf_lower": 10.25,
-            "pf_upper": 12.98
-          },
-          "2050-2079": {
-            "pf": 13.78,
-            "pf_lower": 12.43,
-            "pf_upper": 15.49
-          },
-          "2080-2099": {
-            "pf": 16.34,
-            "pf_lower": 14.19,
-            "pf_upper": 18.6
-          }
-        }
-      },
-      "30d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 145.02,
-            "pf_lower": 119.87,
-            "pf_upper": 174.54
-          },
-          "2050-2079": {
-            "pf": 171.61,
-            "pf_lower": 146.22,
-            "pf_upper": 200.4
-          },
-          "2080-2099": {
-            "pf": 211.3,
-            "pf_lower": 166.19,
-            "pf_upper": 266.73
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 130.63,
-            "pf_lower": 91.71,
-            "pf_upper": 176.72
-          },
-          "2050-2079": {
-            "pf": 153.96,
-            "pf_lower": 112.08,
-            "pf_upper": 198.22
-          },
-          "2080-2099": {
-            "pf": 159.07,
-            "pf_lower": 111.99,
-            "pf_upper": 213.19
-          }
-        }
-      },
-      "3d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 65.47,
-            "pf_lower": 55.91,
-            "pf_upper": 76.62
+            "pf": 64.0,
+            "pf_lower": 56.83,
+            "pf_upper": 72.52
           },
           "2050-2079": {
             "pf": 81.3,
-            "pf_lower": 68.39,
-            "pf_upper": 95.24
+            "pf_lower": 72.88,
+            "pf_upper": 90.28
           },
           "2080-2099": {
-            "pf": 99.91,
-            "pf_lower": 79.65,
-            "pf_upper": 124.71
+            "pf": 84.61,
+            "pf_lower": 74.63,
+            "pf_upper": 96.03
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 56.96,
-            "pf_lower": 44.12,
-            "pf_upper": 71.8
+            "pf": 52.26,
+            "pf_lower": 42.66,
+            "pf_upper": 63.62
           },
           "2050-2079": {
-            "pf": 67.12,
-            "pf_lower": 50.48,
-            "pf_upper": 87.49
+            "pf": 59.61,
+            "pf_lower": 50.54,
+            "pf_upper": 69.45
           },
           "2080-2099": {
-            "pf": 65.66,
-            "pf_lower": 51.18,
-            "pf_upper": 87.29
+            "pf": 55.76,
+            "pf_lower": 44.74,
+            "pf_upper": 69.14
+          }
+        }
+      },
+      "12h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 26.04,
+            "pf_lower": 23.99,
+            "pf_upper": 28.48
+          },
+          "2050-2079": {
+            "pf": 31.41,
+            "pf_lower": 29.05,
+            "pf_upper": 34.19
+          },
+          "2080-2099": {
+            "pf": 36.63,
+            "pf_lower": 33.56,
+            "pf_upper": 40.09
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 20.42,
+            "pf_lower": 18.25,
+            "pf_upper": 22.88
+          },
+          "2050-2079": {
+            "pf": 23.02,
+            "pf_lower": 20.73,
+            "pf_upper": 25.58
+          },
+          "2080-2099": {
+            "pf": 24.7,
+            "pf_lower": 22.02,
+            "pf_upper": 27.7
+          }
+        }
+      },
+      "20d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 88.27,
+            "pf_lower": 78.81,
+            "pf_upper": 99.6
+          },
+          "2050-2079": {
+            "pf": 108.54,
+            "pf_lower": 99.11,
+            "pf_upper": 119.34
+          },
+          "2080-2099": {
+            "pf": 115.34,
+            "pf_lower": 99.89,
+            "pf_upper": 134.12
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 66.53,
+            "pf_lower": 53.53,
+            "pf_upper": 82.28
+          },
+          "2050-2079": {
+            "pf": 86.98,
+            "pf_lower": 73.53,
+            "pf_upper": 100.12
+          },
+          "2080-2099": {
+            "pf": 76.22,
+            "pf_lower": 62.56,
+            "pf_upper": 91.63
+          }
+        }
+      },
+      "24h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 32.24,
+            "pf_lower": 29.77,
+            "pf_upper": 35.23
+          },
+          "2050-2079": {
+            "pf": 39.89,
+            "pf_lower": 36.62,
+            "pf_upper": 44.01
+          },
+          "2080-2099": {
+            "pf": 45.23,
+            "pf_lower": 41.18,
+            "pf_upper": 49.52
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 26.71,
+            "pf_lower": 23.09,
+            "pf_upper": 30.77
+          },
+          "2050-2079": {
+            "pf": 28.33,
+            "pf_lower": 25.47,
+            "pf_upper": 31.51
+          },
+          "2080-2099": {
+            "pf": 30.12,
+            "pf_lower": 27.06,
+            "pf_upper": 33.76
+          }
+        }
+      },
+      "2d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 41.02,
+            "pf_lower": 37.34,
+            "pf_upper": 45.48
+          },
+          "2050-2079": {
+            "pf": 48.51,
+            "pf_lower": 44.35,
+            "pf_upper": 53.62
+          },
+          "2080-2099": {
+            "pf": 53.95,
+            "pf_lower": 49.06,
+            "pf_upper": 59.49
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 33.33,
+            "pf_lower": 28.16,
+            "pf_upper": 39.19
+          },
+          "2050-2079": {
+            "pf": 37.39,
+            "pf_lower": 33.31,
+            "pf_upper": 41.89
+          },
+          "2080-2099": {
+            "pf": 38.16,
+            "pf_lower": 32.85,
+            "pf_upper": 44.52
+          }
+        }
+      },
+      "2h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 12.22,
+            "pf_lower": 11.63,
+            "pf_upper": 12.91
+          },
+          "2050-2079": {
+            "pf": 14.98,
+            "pf_lower": 14.11,
+            "pf_upper": 15.94
+          },
+          "2080-2099": {
+            "pf": 18.0,
+            "pf_lower": 16.62,
+            "pf_upper": 19.72
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 10.73,
+            "pf_lower": 10.13,
+            "pf_upper": 11.47
+          },
+          "2050-2079": {
+            "pf": 13.08,
+            "pf_lower": 12.41,
+            "pf_upper": 13.85
+          },
+          "2080-2099": {
+            "pf": 13.45,
+            "pf_lower": 12.61,
+            "pf_upper": 14.4
+          }
+        }
+      },
+      "30d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 102.51,
+            "pf_lower": 91.58,
+            "pf_upper": 115.06
+          },
+          "2050-2079": {
+            "pf": 132.94,
+            "pf_lower": 120.29,
+            "pf_upper": 146.71
+          },
+          "2080-2099": {
+            "pf": 128.45,
+            "pf_lower": 111.13,
+            "pf_upper": 149.66
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 87.34,
+            "pf_lower": 70.42,
+            "pf_upper": 107.43
+          },
+          "2050-2079": {
+            "pf": 105.69,
+            "pf_lower": 90.98,
+            "pf_upper": 120.7
+          },
+          "2080-2099": {
+            "pf": 101.99,
+            "pf_lower": 83.0,
+            "pf_upper": 121.94
+          }
+        }
+      },
+      "3d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 47.13,
+            "pf_lower": 43.1,
+            "pf_upper": 51.98
+          },
+          "2050-2079": {
+            "pf": 58.91,
+            "pf_lower": 53.89,
+            "pf_upper": 65.13
+          },
+          "2080-2099": {
+            "pf": 58.27,
+            "pf_lower": 52.62,
+            "pf_upper": 65.12
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 34.07,
+            "pf_lower": 28.76,
+            "pf_upper": 40.4
+          },
+          "2050-2079": {
+            "pf": 41.65,
+            "pf_lower": 35.08,
+            "pf_upper": 48.53
+          },
+          "2080-2099": {
+            "pf": 39.2,
+            "pf_lower": 33.53,
+            "pf_upper": 46.16
           }
         }
       },
       "3h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 15.3,
-            "pf_lower": 14.19,
-            "pf_upper": 16.67
+            "pf": 14.01,
+            "pf_lower": 13.27,
+            "pf_upper": 14.88
           },
           "2050-2079": {
-            "pf": 19.22,
-            "pf_lower": 17.39,
-            "pf_upper": 21.31
+            "pf": 17.24,
+            "pf_lower": 16.11,
+            "pf_upper": 18.53
           },
           "2080-2099": {
-            "pf": 24.12,
-            "pf_lower": 21.98,
-            "pf_upper": 26.89
+            "pf": 19.96,
+            "pf_lower": 18.38,
+            "pf_upper": 21.81
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 13.56,
-            "pf_lower": 11.79,
-            "pf_upper": 15.74
+            "pf": 12.11,
+            "pf_lower": 11.3,
+            "pf_upper": 13.1
           },
           "2050-2079": {
-            "pf": 15.9,
-            "pf_lower": 14.04,
-            "pf_upper": 18.24
+            "pf": 14.28,
+            "pf_lower": 13.34,
+            "pf_upper": 15.35
           },
           "2080-2099": {
-            "pf": 19.11,
-            "pf_lower": 15.95,
-            "pf_upper": 22.48
+            "pf": 15.43,
+            "pf_lower": 14.06,
+            "pf_upper": 16.87
           }
         }
       },
       "45d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 199.27,
-            "pf_lower": 161.81,
-            "pf_upper": 239.36
+            "pf": 132.2,
+            "pf_lower": 119.07,
+            "pf_upper": 147.48
           },
           "2050-2079": {
-            "pf": 229.69,
-            "pf_lower": 193.74,
-            "pf_upper": 266.1
+            "pf": 170.93,
+            "pf_lower": 154.05,
+            "pf_upper": 188.85
           },
           "2080-2099": {
-            "pf": 258.55,
-            "pf_lower": 206.55,
-            "pf_upper": 323.36
+            "pf": 178.86,
+            "pf_lower": 154.48,
+            "pf_upper": 206.8
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 166.79,
-            "pf_lower": 119.35,
-            "pf_upper": 220.13
+            "pf": 115.77,
+            "pf_lower": 93.37,
+            "pf_upper": 141.15
           },
           "2050-2079": {
-            "pf": 186.12,
-            "pf_lower": 141.79,
-            "pf_upper": 232.6
+            "pf": 134.97,
+            "pf_lower": 114.57,
+            "pf_upper": 155.8
           },
           "2080-2099": {
-            "pf": 193.94,
-            "pf_lower": 141.42,
-            "pf_upper": 249.63
+            "pf": 130.91,
+            "pf_lower": 104.37,
+            "pf_upper": 159.35
           }
         }
       },
       "4d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 72.85,
-            "pf_lower": 59.72,
-            "pf_upper": 87.71
+            "pf": 47.6,
+            "pf_lower": 43.26,
+            "pf_upper": 53.39
           },
           "2050-2079": {
-            "pf": 86.07,
-            "pf_lower": 71.59,
-            "pf_upper": 102.6
+            "pf": 60.38,
+            "pf_lower": 55.44,
+            "pf_upper": 66.1
           },
           "2080-2099": {
-            "pf": 104.91,
-            "pf_lower": 84.83,
-            "pf_upper": 129.36
+            "pf": 65.38,
+            "pf_lower": 58.41,
+            "pf_upper": 73.4
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 62.98,
-            "pf_lower": 49.61,
-            "pf_upper": 79.55
+            "pf": 38.23,
+            "pf_lower": 31.82,
+            "pf_upper": 45.75
           },
           "2050-2079": {
-            "pf": 75.95,
-            "pf_lower": 58.8,
-            "pf_upper": 96.26
+            "pf": 42.51,
+            "pf_lower": 36.45,
+            "pf_upper": 49.12
           },
           "2080-2099": {
-            "pf": 73.14,
-            "pf_lower": 57.1,
-            "pf_upper": 95.64
+            "pf": 44.09,
+            "pf_lower": 36.08,
+            "pf_upper": 53.26
           }
         }
       },
       "60d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 239.14,
-            "pf_lower": 191.87,
-            "pf_upper": 290.4
+            "pf": 156.76,
+            "pf_lower": 139.74,
+            "pf_upper": 176.46
           },
           "2050-2079": {
-            "pf": 274.59,
-            "pf_lower": 234.18,
-            "pf_upper": 314.51
+            "pf": 200.01,
+            "pf_lower": 182.55,
+            "pf_upper": 219.45
           },
           "2080-2099": {
-            "pf": 331.2,
-            "pf_lower": 268.91,
-            "pf_upper": 403.15
+            "pf": 204.96,
+            "pf_lower": 178.4,
+            "pf_upper": 236.8
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 197.4,
-            "pf_lower": 140.43,
-            "pf_upper": 258.1
+            "pf": 132.47,
+            "pf_lower": 107.05,
+            "pf_upper": 159.93
           },
           "2050-2079": {
-            "pf": 236.74,
-            "pf_lower": 172.31,
-            "pf_upper": 299.58
+            "pf": 154.0,
+            "pf_lower": 129.18,
+            "pf_upper": 180.95
           },
           "2080-2099": {
-            "pf": 232.51,
-            "pf_lower": 169.37,
-            "pf_upper": 298.09
+            "pf": 154.23,
+            "pf_lower": 123.38,
+            "pf_upper": 185.01
           }
         }
       },
       "60m": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 10.41,
-            "pf_lower": 9.91,
-            "pf_upper": 11.02
+            "pf": 10.56,
+            "pf_lower": 10.2,
+            "pf_upper": 10.98
           },
           "2050-2079": {
-            "pf": 12.78,
-            "pf_lower": 11.95,
-            "pf_upper": 13.69
+            "pf": 12.93,
+            "pf_lower": 12.42,
+            "pf_upper": 13.52
           },
           "2080-2099": {
-            "pf": 16.44,
-            "pf_lower": 15.3,
-            "pf_upper": 17.71
+            "pf": 16.23,
+            "pf_lower": 15.37,
+            "pf_upper": 17.32
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 9.08,
-            "pf_lower": 8.4,
+            "pf": 9.5,
+            "pf_lower": 9.16,
             "pf_upper": 9.94
           },
           "2050-2079": {
-            "pf": 10.95,
-            "pf_lower": 10.21,
-            "pf_upper": 11.86
+            "pf": 11.37,
+            "pf_lower": 11.01,
+            "pf_upper": 11.8
           },
           "2080-2099": {
-            "pf": 13.76,
-            "pf_lower": 12.53,
-            "pf_upper": 15.01
+            "pf": 12.07,
+            "pf_lower": 11.61,
+            "pf_upper": 12.58
           }
         }
       },
       "6h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 22.25,
-            "pf_lower": 20.32,
-            "pf_upper": 24.63
+            "pf": 18.79,
+            "pf_lower": 17.59,
+            "pf_upper": 20.25
           },
           "2050-2079": {
-            "pf": 27.66,
-            "pf_lower": 24.73,
-            "pf_upper": 30.9
+            "pf": 22.68,
+            "pf_lower": 21.05,
+            "pf_upper": 24.6
           },
           "2080-2099": {
-            "pf": 33.25,
-            "pf_lower": 29.32,
-            "pf_upper": 38.09
+            "pf": 26.43,
+            "pf_lower": 24.29,
+            "pf_upper": 28.89
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 18.42,
-            "pf_lower": 15.39,
-            "pf_upper": 21.87
+            "pf": 15.77,
+            "pf_lower": 14.28,
+            "pf_upper": 17.52
           },
           "2050-2079": {
-            "pf": 22.21,
-            "pf_lower": 18.47,
-            "pf_upper": 26.66
+            "pf": 18.06,
+            "pf_lower": 16.48,
+            "pf_upper": 19.93
           },
           "2080-2099": {
-            "pf": 24.95,
-            "pf_lower": 19.48,
-            "pf_upper": 30.91
+            "pf": 18.86,
+            "pf_lower": 16.9,
+            "pf_upper": 21.03
           }
         }
       },
       "7d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 88.69,
-            "pf_lower": 73.68,
-            "pf_upper": 104.51
+            "pf": 54.03,
+            "pf_lower": 49.21,
+            "pf_upper": 60.02
           },
           "2050-2079": {
-            "pf": 101.52,
-            "pf_lower": 88.06,
-            "pf_upper": 116.53
+            "pf": 70.39,
+            "pf_lower": 63.51,
+            "pf_upper": 78.39
           },
           "2080-2099": {
-            "pf": 126.1,
-            "pf_lower": 102.79,
-            "pf_upper": 154.26
+            "pf": 71.52,
+            "pf_lower": 63.24,
+            "pf_upper": 81.45
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 67.47,
-            "pf_lower": 52.21,
-            "pf_upper": 85.08
+            "pf": 46.85,
+            "pf_lower": 39.12,
+            "pf_upper": 56.29
           },
           "2050-2079": {
-            "pf": 82.45,
-            "pf_lower": 59.76,
-            "pf_upper": 108.52
+            "pf": 52.46,
+            "pf_lower": 45.61,
+            "pf_upper": 59.72
           },
           "2080-2099": {
-            "pf": 82.13,
-            "pf_lower": 61.03,
-            "pf_upper": 109.1
-          }
-        }
-      }
-    },
-    "200": {
-      "10d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 174.93,
-            "pf_lower": 105.68,
-            "pf_upper": 435.19
-          },
-          "2050-2079": {
-            "pf": 169.31,
-            "pf_lower": 111.91,
-            "pf_upper": 411.93
-          },
-          "2080-2099": {
-            "pf": 248.93,
-            "pf_lower": 144.28,
-            "pf_upper": 717.96
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 248.62,
-            "pf_lower": 91.46,
-            "pf_upper": 606.72
-          },
-          "2050-2079": {
-            "pf": 264.76,
-            "pf_lower": 105.16,
-            "pf_upper": 616.59
-          },
-          "2080-2099": {
-            "pf": 319.65,
-            "pf_lower": 92.16,
-            "pf_upper": 1224.92
-          }
-        }
-      },
-      "12h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 68.86,
-            "pf_lower": 41.63,
-            "pf_upper": 133.49
-          },
-          "2050-2079": {
-            "pf": 78.76,
-            "pf_lower": 52.57,
-            "pf_upper": 133.16
-          },
-          "2080-2099": {
-            "pf": 119.52,
-            "pf_lower": 64.34,
-            "pf_upper": 258.22
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 82.91,
-            "pf_lower": 41.82,
-            "pf_upper": 157.7
-          },
-          "2050-2079": {
-            "pf": 100.91,
-            "pf_lower": 50.6,
-            "pf_upper": 194.76
-          },
-          "2080-2099": {
-            "pf": 98.67,
-            "pf_lower": 42.44,
-            "pf_upper": 224.83
-          }
-        }
-      },
-      "20d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 287.44,
-            "pf_lower": 141.61,
-            "pf_upper": 576.82
-          },
-          "2050-2079": {
-            "pf": 247.4,
-            "pf_lower": 158.68,
-            "pf_upper": 412.35
-          },
-          "2080-2099": {
-            "pf": 562.13,
-            "pf_lower": 168.35,
-            "pf_upper": 1740.23
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 424.8,
-            "pf_lower": 139.88,
-            "pf_upper": 1005.94
-          },
-          "2050-2079": {
-            "pf": 347.29,
-            "pf_lower": 183.15,
-            "pf_upper": 624.86
-          },
-          "2080-2099": {
-            "pf": 511.51,
-            "pf_lower": 129.9,
-            "pf_upper": 1471.67
-          }
-        }
-      },
-      "24h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 87.16,
-            "pf_lower": 43.79,
-            "pf_upper": 214.93
-          },
-          "2050-2079": {
-            "pf": 83.77,
-            "pf_lower": 54.84,
-            "pf_upper": 157.44
-          },
-          "2080-2099": {
-            "pf": 123.74,
-            "pf_lower": 69.05,
-            "pf_upper": 288.37
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 85.48,
-            "pf_lower": 41.86,
-            "pf_upper": 171.87
-          },
-          "2050-2079": {
-            "pf": 128.98,
-            "pf_lower": 50.65,
-            "pf_upper": 307.5
-          },
-          "2080-2099": {
-            "pf": 165.31,
-            "pf_lower": 42.48,
-            "pf_upper": 589.36
-          }
-        }
-      },
-      "2d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 112.11,
-            "pf_lower": 56.82,
-            "pf_upper": 314.44
-          },
-          "2050-2079": {
-            "pf": 106.2,
-            "pf_lower": 72.57,
-            "pf_upper": 217.66
-          },
-          "2080-2099": {
-            "pf": 153.78,
-            "pf_lower": 94.85,
-            "pf_upper": 372.85
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 104.42,
-            "pf_lower": 47.98,
-            "pf_upper": 331.77
-          },
-          "2050-2079": {
-            "pf": 130.27,
-            "pf_lower": 58.77,
-            "pf_upper": 353.56
-          },
-          "2080-2099": {
-            "pf": 201.39,
-            "pf_lower": 48.5,
-            "pf_upper": 1089.01
-          }
-        }
-      },
-      "2h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 31.65,
-            "pf_lower": 22.49,
-            "pf_upper": 51.26
-          },
-          "2050-2079": {
-            "pf": 41.28,
-            "pf_lower": 29.1,
-            "pf_upper": 66.62
-          },
-          "2080-2099": {
-            "pf": 46.75,
-            "pf_lower": 32.37,
-            "pf_upper": 78.38
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 39.33,
-            "pf_lower": 27.51,
-            "pf_upper": 72.49
-          },
-          "2050-2079": {
-            "pf": 46.9,
-            "pf_lower": 28.39,
-            "pf_upper": 87.66
-          },
-          "2080-2099": {
-            "pf": 31.52,
-            "pf_lower": 24.96,
-            "pf_upper": 42.29
-          }
-        }
-      },
-      "30d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 389.74,
-            "pf_lower": 161.44,
-            "pf_upper": 942.01
-          },
-          "2050-2079": {
-            "pf": 370.91,
-            "pf_lower": 191.53,
-            "pf_upper": 751.74
-          },
-          "2080-2099": {
-            "pf": 578.94,
-            "pf_lower": 213.13,
-            "pf_upper": 1741.97
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 519.57,
-            "pf_lower": 209.58,
-            "pf_upper": 1098.51
-          },
-          "2050-2079": {
-            "pf": 392.19,
-            "pf_lower": 268.2,
-            "pf_upper": 625.48
-          },
-          "2080-2099": {
-            "pf": 516.63,
-            "pf_lower": 267.93,
-            "pf_upper": 1473.15
-          }
-        }
-      },
-      "3d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 140.96,
-            "pf_lower": 74.41,
-            "pf_upper": 345.05
-          },
-          "2050-2079": {
-            "pf": 136.86,
-            "pf_lower": 93.37,
-            "pf_upper": 258.25
-          },
-          "2080-2099": {
-            "pf": 241.6,
-            "pf_lower": 109.12,
-            "pf_upper": 710.04
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 105.47,
-            "pf_lower": 55.52,
-            "pf_upper": 332.1
-          },
-          "2050-2079": {
-            "pf": 158.3,
-            "pf_lower": 63.44,
-            "pf_upper": 518.76
-          },
-          "2080-2099": {
-            "pf": 231.64,
-            "pf_lower": 54.83,
-            "pf_upper": 1221.26
-          }
-        }
-      },
-      "3h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 48.11,
-            "pf_lower": 32.06,
-            "pf_upper": 87.06
-          },
-          "2050-2079": {
-            "pf": 54.26,
-            "pf_lower": 39.45,
-            "pf_upper": 84.17
-          },
-          "2080-2099": {
-            "pf": 74.03,
-            "pf_lower": 47.26,
-            "pf_upper": 139.1
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 44.5,
-            "pf_lower": 27.53,
-            "pf_upper": 83.74
-          },
-          "2050-2079": {
-            "pf": 54.54,
-            "pf_lower": 29.4,
-            "pf_upper": 109.3
-          },
-          "2080-2099": {
-            "pf": 40.02,
-            "pf_lower": 29.4,
-            "pf_upper": 58.26
-          }
-        }
-      },
-      "45d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 393.64,
-            "pf_lower": 228.24,
-            "pf_upper": 942.95
-          },
-          "2050-2079": {
-            "pf": 374.62,
-            "pf_lower": 279.95,
-            "pf_upper": 752.5
-          },
-          "2080-2099": {
-            "pf": 584.73,
-            "pf_lower": 234.87,
-            "pf_upper": 1836.11
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 573.37,
-            "pf_lower": 319.93,
-            "pf_upper": 1099.61
-          },
-          "2050-2079": {
-            "pf": 474.65,
-            "pf_lower": 347.33,
-            "pf_upper": 662.36
-          },
-          "2080-2099": {
-            "pf": 521.8,
-            "pf_lower": 347.9,
-            "pf_upper": 1474.62
-          }
-        }
-      },
-      "4d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 142.37,
-            "pf_lower": 77.11,
-            "pf_upper": 345.4
-          },
-          "2050-2079": {
-            "pf": 138.19,
-            "pf_lower": 93.46,
-            "pf_upper": 397.23
-          },
-          "2080-2099": {
-            "pf": 244.02,
-            "pf_lower": 111.54,
-            "pf_upper": 710.75
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 153.25,
-            "pf_lower": 62.67,
-            "pf_upper": 486.36
-          },
-          "2050-2079": {
-            "pf": 159.88,
-            "pf_lower": 77.36,
-            "pf_upper": 519.28
-          },
-          "2080-2099": {
-            "pf": 233.96,
-            "pf_lower": 64.9,
-            "pf_upper": 1222.48
-          }
-        }
-      },
-      "60d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 397.57,
-            "pf_lower": 242.25,
-            "pf_upper": 943.9
-          },
-          "2050-2079": {
-            "pf": 378.37,
-            "pf_lower": 292.67,
-            "pf_upper": 753.25
-          },
-          "2080-2099": {
-            "pf": 590.58,
-            "pf_lower": 313.1,
-            "pf_upper": 1837.94
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 579.1,
-            "pf_lower": 327.74,
-            "pf_upper": 1100.71
-          },
-          "2050-2079": {
-            "pf": 479.4,
-            "pf_lower": 360.8,
-            "pf_upper": 663.02
-          },
-          "2080-2099": {
-            "pf": 527.01,
-            "pf_lower": 379.66,
-            "pf_upper": 1476.09
-          }
-        }
-      },
-      "60m": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 21.4,
-            "pf_lower": 15.98,
-            "pf_upper": 33.55
-          },
-          "2050-2079": {
-            "pf": 23.68,
-            "pf_lower": 18.77,
-            "pf_upper": 32.54
-          },
-          "2080-2099": {
-            "pf": 28.44,
-            "pf_lower": 22.43,
-            "pf_upper": 40.66
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 38.01,
-            "pf_lower": 27.48,
-            "pf_upper": 61.03
-          },
-          "2050-2079": {
-            "pf": 37.45,
-            "pf_lower": 28.36,
-            "pf_upper": 56.27
-          },
-          "2080-2099": {
-            "pf": 24.96,
-            "pf_lower": 22.4,
-            "pf_upper": 28.92
-          }
-        }
-      },
-      "6h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 66.67,
-            "pf_lower": 39.07,
-            "pf_upper": 133.36
-          },
-          "2050-2079": {
-            "pf": 64.89,
-            "pf_lower": 46.0,
-            "pf_upper": 100.18
-          },
-          "2080-2099": {
-            "pf": 93.17,
-            "pf_lower": 54.29,
-            "pf_upper": 181.81
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 55.01,
-            "pf_lower": 29.85,
-            "pf_upper": 102.99
-          },
-          "2050-2079": {
-            "pf": 78.73,
-            "pf_lower": 36.44,
-            "pf_upper": 167.45
-          },
-          "2080-2099": {
-            "pf": 59.93,
-            "pf_lower": 36.75,
-            "pf_upper": 101.86
-          }
-        }
-      },
-      "7d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 143.8,
-            "pf_lower": 100.46,
-            "pf_upper": 345.74
-          },
-          "2050-2079": {
-            "pf": 149.93,
-            "pf_lower": 111.22,
-            "pf_upper": 397.63
-          },
-          "2080-2099": {
-            "pf": 246.46,
-            "pf_lower": 132.07,
-            "pf_upper": 717.24
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 179.4,
-            "pf_lower": 66.81,
-            "pf_upper": 486.85
-          },
-          "2050-2079": {
-            "pf": 238.97,
-            "pf_lower": 82.23,
-            "pf_upper": 615.97
-          },
-          "2080-2099": {
-            "pf": 251.42,
-            "pf_lower": 68.98,
-            "pf_upper": 1223.7
-          }
-        }
-      }
-    },
-    "25": {
-      "10d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 157.59,
-            "pf_lower": 105.36,
-            "pf_upper": 234.27
-          },
-          "2050-2079": {
-            "pf": 157.01,
-            "pf_lower": 111.57,
-            "pf_upper": 225.24
-          },
-          "2080-2099": {
-            "pf": 223.45,
-            "pf_lower": 143.84,
-            "pf_upper": 343.41
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 170.87,
-            "pf_lower": 91.19,
-            "pf_upper": 271.66
-          },
-          "2050-2079": {
-            "pf": 189.78,
-            "pf_lower": 104.85,
-            "pf_upper": 292.64
-          },
-          "2080-2099": {
-            "pf": 197.74,
-            "pf_lower": 91.88,
-            "pf_upper": 365.33
-          }
-        }
-      },
-      "12h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 53.91,
-            "pf_lower": 41.34,
-            "pf_upper": 70.75
-          },
-          "2050-2079": {
-            "pf": 65.71,
-            "pf_lower": 52.19,
-            "pf_upper": 82.83
-          },
-          "2080-2099": {
-            "pf": 91.29,
-            "pf_lower": 64.18,
-            "pf_upper": 127.38
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 54.64,
-            "pf_lower": 35.89,
-            "pf_upper": 77.51
-          },
-          "2050-2079": {
-            "pf": 65.25,
-            "pf_lower": 42.74,
-            "pf_upper": 93.17
-          },
-          "2080-2099": {
-            "pf": 63.1,
-            "pf_lower": 38.04,
-            "pf_upper": 97.14
-          }
-        }
-      },
-      "20d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 215.36,
-            "pf_lower": 141.19,
-            "pf_upper": 307.58
-          },
-          "2050-2079": {
-            "pf": 207.85,
-            "pf_lower": 158.1,
-            "pf_upper": 264.28
-          },
-          "2080-2099": {
-            "pf": 349.29,
-            "pf_lower": 167.85,
-            "pf_upper": 618.04
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 243.45,
-            "pf_lower": 128.83,
-            "pf_upper": 393.39
-          },
-          "2050-2079": {
-            "pf": 235.49,
-            "pf_lower": 153.47,
-            "pf_upper": 330.4
-          },
-          "2080-2099": {
-            "pf": 286.11,
-            "pf_lower": 129.52,
-            "pf_upper": 509.42
-          }
-        }
-      },
-      "24h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 65.75,
-            "pf_lower": 43.66,
-            "pf_upper": 96.79
-          },
-          "2050-2079": {
-            "pf": 73.64,
-            "pf_lower": 54.68,
-            "pf_upper": 97.24
-          },
-          "2080-2099": {
-            "pf": 104.19,
-            "pf_lower": 68.84,
-            "pf_upper": 150.38
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 63.99,
-            "pf_lower": 41.4,
-            "pf_upper": 91.12
-          },
-          "2050-2079": {
-            "pf": 86.43,
-            "pf_lower": 47.37,
-            "pf_upper": 136.33
-          },
-          "2080-2099": {
-            "pf": 93.93,
-            "pf_lower": 40.88,
-            "pf_upper": 178.56
-          }
-        }
-      },
-      "2d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 88.08,
-            "pf_lower": 56.65,
-            "pf_upper": 134.92
-          },
-          "2050-2079": {
-            "pf": 99.92,
-            "pf_lower": 72.36,
-            "pf_upper": 136.16
-          },
-          "2080-2099": {
-            "pf": 142.24,
-            "pf_lower": 94.57,
-            "pf_upper": 207.06
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 85.82,
-            "pf_lower": 47.83,
-            "pf_upper": 145.5
-          },
-          "2050-2079": {
-            "pf": 101.54,
-            "pf_lower": 58.59,
-            "pf_upper": 166.24
-          },
-          "2080-2099": {
-            "pf": 113.24,
-            "pf_lower": 48.35,
-            "pf_upper": 250.96
-          }
-        }
-      },
-      "2h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 22.55,
-            "pf_lower": 18.84,
-            "pf_upper": 27.6
-          },
-          "2050-2079": {
-            "pf": 29.2,
-            "pf_lower": 24.09,
-            "pf_upper": 36.02
-          },
-          "2080-2099": {
-            "pf": 34.4,
-            "pf_lower": 28.06,
-            "pf_upper": 42.76
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 24.59,
-            "pf_lower": 18.76,
-            "pf_upper": 32.39
-          },
-          "2050-2079": {
-            "pf": 29.02,
-            "pf_lower": 22.18,
-            "pf_upper": 38.27
-          },
-          "2080-2099": {
-            "pf": 27.12,
-            "pf_lower": 23.13,
-            "pf_upper": 31.43
-          }
-        }
-      },
-      "30d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 263.79,
-            "pf_lower": 160.96,
-            "pf_upper": 404.24
-          },
-          "2050-2079": {
-            "pf": 277.19,
-            "pf_lower": 190.95,
-            "pf_upper": 390.23
-          },
-          "2080-2099": {
-            "pf": 391.95,
-            "pf_lower": 212.49,
-            "pf_upper": 641.41
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 314.56,
-            "pf_lower": 176.07,
-            "pf_upper": 486.26
-          },
-          "2050-2079": {
-            "pf": 294.5,
-            "pf_lower": 217.64,
-            "pf_upper": 372.29
-          },
-          "2080-2099": {
-            "pf": 324.18,
-            "pf_lower": 195.4,
-            "pf_upper": 509.93
-          }
-        }
-      },
-      "3d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 111.88,
-            "pf_lower": 74.19,
-            "pf_upper": 164.17
-          },
-          "2050-2079": {
-            "pf": 126.37,
-            "pf_lower": 93.09,
-            "pf_upper": 166.79
-          },
-          "2080-2099": {
-            "pf": 184.2,
-            "pf_lower": 108.79,
-            "pf_upper": 293.61
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 89.9,
-            "pf_lower": 55.36,
-            "pf_upper": 145.65
-          },
-          "2050-2079": {
-            "pf": 123.87,
-            "pf_lower": 63.25,
-            "pf_upper": 218.07
-          },
-          "2080-2099": {
-            "pf": 133.08,
-            "pf_lower": 54.67,
-            "pf_upper": 293.91
-          }
-        }
-      },
-      "3h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 28.87,
-            "pf_lower": 23.18,
-            "pf_upper": 37.01
-          },
-          "2050-2079": {
-            "pf": 36.5,
-            "pf_lower": 30.1,
-            "pf_upper": 44.95
-          },
-          "2080-2099": {
-            "pf": 45.75,
-            "pf_lower": 35.51,
-            "pf_upper": 60.22
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 28.81,
-            "pf_lower": 21.1,
-            "pf_upper": 38.87
-          },
-          "2050-2079": {
-            "pf": 33.46,
-            "pf_lower": 24.24,
-            "pf_upper": 45.83
-          },
-          "2080-2099": {
-            "pf": 33.21,
-            "pf_lower": 26.92,
-            "pf_upper": 40.22
-          }
-        }
-      },
-      "45d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 277.25,
-            "pf_lower": 200.48,
-            "pf_upper": 404.64
-          },
-          "2050-2079": {
-            "pf": 279.0,
-            "pf_lower": 230.27,
-            "pf_upper": 390.62
-          },
-          "2080-2099": {
-            "pf": 407.96,
-            "pf_lower": 234.17,
-            "pf_upper": 711.11
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 377.45,
-            "pf_lower": 246.97,
-            "pf_upper": 524.79
-          },
-          "2050-2079": {
-            "pf": 353.4,
-            "pf_lower": 273.65,
-            "pf_upper": 433.29
-          },
-          "2080-2099": {
-            "pf": 367.01,
-            "pf_lower": 264.39,
-            "pf_upper": 510.44
-          }
-        }
-      },
-      "4d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 112.88,
-            "pf_lower": 76.88,
-            "pf_upper": 169.92
-          },
-          "2050-2079": {
-            "pf": 132.08,
-            "pf_lower": 93.18,
-            "pf_upper": 200.84
-          },
-          "2080-2099": {
-            "pf": 186.04,
-            "pf_lower": 111.21,
-            "pf_upper": 293.9
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 115.85,
-            "pf_lower": 62.48,
-            "pf_upper": 196.86
-          },
-          "2050-2079": {
-            "pf": 130.35,
-            "pf_lower": 77.13,
-            "pf_upper": 218.29
-          },
-          "2080-2099": {
-            "pf": 142.77,
-            "pf_lower": 64.71,
-            "pf_upper": 294.2
-          }
-        }
-      },
-      "60d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 340.67,
-            "pf_lower": 241.52,
-            "pf_upper": 487.26
-          },
-          "2050-2079": {
-            "pf": 324.74,
-            "pf_lower": 275.94,
-            "pf_upper": 391.01
-          },
-          "2080-2099": {
-            "pf": 453.4,
-            "pf_lower": 312.17,
-            "pf_upper": 711.82
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 390.23,
-            "pf_lower": 256.17,
-            "pf_upper": 538.92
-          },
-          "2050-2079": {
-            "pf": 395.54,
-            "pf_lower": 312.87,
-            "pf_upper": 474.55
-          },
-          "2080-2099": {
-            "pf": 378.43,
-            "pf_lower": 280.36,
-            "pf_upper": 510.95
-          }
-        }
-      },
-      "60m": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 16.59,
-            "pf_lower": 14.46,
-            "pf_upper": 19.52
-          },
-          "2050-2079": {
-            "pf": 20.42,
-            "pf_lower": 18.06,
-            "pf_upper": 23.32
-          },
-          "2080-2099": {
-            "pf": 25.12,
-            "pf_lower": 21.96,
-            "pf_upper": 28.93
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 21.48,
-            "pf_lower": 17.85,
-            "pf_upper": 26.47
-          },
-          "2050-2079": {
-            "pf": 23.35,
-            "pf_lower": 19.92,
-            "pf_upper": 27.93
-          },
-          "2080-2099": {
-            "pf": 22.15,
-            "pf_lower": 20.39,
-            "pf_upper": 23.84
-          }
-        }
-      },
-      "6h": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 41.6,
-            "pf_lower": 31.76,
-            "pf_upper": 55.64
-          },
-          "2050-2079": {
-            "pf": 48.38,
-            "pf_lower": 39.53,
-            "pf_upper": 59.48
-          },
-          "2080-2099": {
-            "pf": 62.25,
-            "pf_lower": 46.13,
-            "pf_upper": 84.29
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 36.98,
-            "pf_lower": 26.36,
-            "pf_upper": 50.75
-          },
-          "2050-2079": {
-            "pf": 48.29,
-            "pf_lower": 32.24,
-            "pf_upper": 69.91
-          },
-          "2080-2099": {
-            "pf": 46.3,
-            "pf_lower": 33.68,
-            "pf_upper": 61.13
-          }
-        }
-      },
-      "7d": {
-        "GFDL-CM3": {
-          "2020-2049": {
-            "pf": 125.93,
-            "pf_lower": 100.16,
-            "pf_upper": 170.09
-          },
-          "2050-2079": {
-            "pf": 145.92,
-            "pf_lower": 110.89,
-            "pf_upper": 202.03
-          },
-          "2080-2099": {
-            "pf": 204.0,
-            "pf_lower": 131.67,
-            "pf_upper": 322.85
-          }
-        },
-        "NCAR-CCSM4": {
-          "2020-2049": {
-            "pf": 122.0,
-            "pf_lower": 66.61,
-            "pf_upper": 197.05
-          },
-          "2050-2079": {
-            "pf": 161.89,
-            "pf_lower": 81.98,
-            "pf_upper": 267.77
-          },
-          "2080-2099": {
-            "pf": 157.09,
-            "pf_lower": 68.78,
-            "pf_upper": 299.58
+            "pf": 54.97,
+            "pf_lower": 44.02,
+            "pf_upper": 67.98
           }
         }
       }
@@ -3467,540 +757,1624 @@
       "10d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 126.66,
-            "pf_lower": 100.23,
-            "pf_upper": 155.96
+            "pf": 90.07,
+            "pf_lower": 78.27,
+            "pf_upper": 103.76
           },
           "2050-2079": {
-            "pf": 131.08,
-            "pf_lower": 107.52,
-            "pf_upper": 157.14
+            "pf": 107.81,
+            "pf_lower": 97.17,
+            "pf_upper": 118.88
           },
           "2080-2099": {
-            "pf": 183.28,
-            "pf_lower": 139.84,
-            "pf_upper": 231.32
+            "pf": 113.03,
+            "pf_lower": 98.33,
+            "pf_upper": 129.1
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 115.91,
-            "pf_lower": 81.67,
-            "pf_upper": 154.37
+            "pf": 78.11,
+            "pf_lower": 62.18,
+            "pf_upper": 96.07
           },
           "2050-2079": {
-            "pf": 130.76,
-            "pf_lower": 91.61,
-            "pf_upper": 173.73
+            "pf": 82.11,
+            "pf_lower": 70.07,
+            "pf_upper": 94.51
           },
           "2080-2099": {
-            "pf": 130.21,
-            "pf_lower": 87.37,
-            "pf_upper": 183.08
+            "pf": 80.47,
+            "pf_lower": 62.7,
+            "pf_upper": 100.72
           }
         }
       },
       "12h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 40.66,
-            "pf_lower": 35.23,
-            "pf_upper": 46.76
+            "pf": 36.03,
+            "pf_lower": 32.64,
+            "pf_upper": 39.97
           },
           "2050-2079": {
-            "pf": 51.15,
-            "pf_lower": 44.57,
-            "pf_upper": 58.27
+            "pf": 42.78,
+            "pf_lower": 38.98,
+            "pf_upper": 47.15
           },
           "2080-2099": {
-            "pf": 66.54,
-            "pf_lower": 54.96,
-            "pf_upper": 79.7
+            "pf": 47.98,
+            "pf_lower": 43.72,
+            "pf_upper": 52.45
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 36.62,
-            "pf_lower": 28.01,
-            "pf_upper": 46.07
+            "pf": 30.14,
+            "pf_lower": 26.84,
+            "pf_upper": 33.76
           },
           "2050-2079": {
-            "pf": 43.37,
-            "pf_lower": 33.21,
-            "pf_upper": 54.6
+            "pf": 33.18,
+            "pf_lower": 29.91,
+            "pf_upper": 36.66
           },
           "2080-2099": {
-            "pf": 42.27,
-            "pf_lower": 31.25,
-            "pf_upper": 54.91
+            "pf": 34.74,
+            "pf_lower": 31.05,
+            "pf_upper": 38.66
           }
         }
       },
       "20d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 161.33,
-            "pf_lower": 125.16,
-            "pf_upper": 200.63
+            "pf": 124.15,
+            "pf_lower": 108.27,
+            "pf_upper": 142.71
           },
           "2050-2079": {
-            "pf": 171.31,
-            "pf_lower": 143.1,
-            "pf_upper": 200.37
+            "pf": 144.17,
+            "pf_lower": 129.94,
+            "pf_upper": 160.18
           },
           "2080-2099": {
-            "pf": 234.39,
-            "pf_lower": 160.99,
-            "pf_upper": 321.98
+            "pf": 162.69,
+            "pf_lower": 137.35,
+            "pf_upper": 191.71
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 149.68,
-            "pf_lower": 103.79,
-            "pf_upper": 202.18
+            "pf": 102.39,
+            "pf_lower": 79.38,
+            "pf_upper": 128.91
           },
           "2050-2079": {
-            "pf": 161.08,
-            "pf_lower": 119.9,
-            "pf_upper": 205.15
+            "pf": 116.23,
+            "pf_lower": 102.86,
+            "pf_upper": 128.25
           },
           "2080-2099": {
-            "pf": 175.49,
-            "pf_lower": 113.3,
-            "pf_upper": 250.19
+            "pf": 105.49,
+            "pf_lower": 86.25,
+            "pf_upper": 125.89
           }
         }
       },
       "24h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 50.29,
-            "pf_lower": 41.43,
-            "pf_upper": 60.58
+            "pf": 43.71,
+            "pf_lower": 39.47,
+            "pf_upper": 48.73
           },
           "2050-2079": {
-            "pf": 61.45,
-            "pf_lower": 51.96,
-            "pf_upper": 71.69
+            "pf": 55.69,
+            "pf_lower": 49.66,
+            "pf_upper": 63.01
           },
           "2080-2099": {
-            "pf": 83.25,
-            "pf_lower": 65.3,
-            "pf_upper": 102.77
+            "pf": 57.88,
+            "pf_lower": 52.81,
+            "pf_upper": 62.94
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 48.08,
-            "pf_lower": 37.46,
-            "pf_upper": 59.66
+            "pf": 39.54,
+            "pf_lower": 34.27,
+            "pf_upper": 45.17
           },
           "2050-2079": {
-            "pf": 58.86,
-            "pf_lower": 42.21,
-            "pf_upper": 77.57
+            "pf": 39.18,
+            "pf_lower": 35.1,
+            "pf_upper": 43.52
           },
           "2080-2099": {
-            "pf": 59.29,
-            "pf_lower": 38.98,
-            "pf_upper": 84.79
+            "pf": 40.85,
+            "pf_lower": 36.07,
+            "pf_upper": 46.25
           }
         }
       },
       "2d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 66.46,
-            "pf_lower": 53.58,
-            "pf_upper": 81.53
+            "pf": 57.71,
+            "pf_lower": 51.36,
+            "pf_upper": 65.24
           },
           "2050-2079": {
-            "pf": 82.55,
-            "pf_lower": 68.04,
-            "pf_upper": 98.23
+            "pf": 67.88,
+            "pf_lower": 60.53,
+            "pf_upper": 76.7
           },
           "2080-2099": {
-            "pf": 115.7,
-            "pf_lower": 89.72,
-            "pf_upper": 143.77
+            "pf": 70.83,
+            "pf_lower": 63.86,
+            "pf_upper": 78.31
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 66.56,
-            "pf_lower": 47.74,
-            "pf_upper": 87.97
+            "pf": 51.12,
+            "pf_lower": 43.33,
+            "pf_upper": 59.61
           },
           "2050-2079": {
-            "pf": 80.79,
-            "pf_lower": 58.12,
-            "pf_upper": 106.03
+            "pf": 52.09,
+            "pf_lower": 46.42,
+            "pf_upper": 58.05
           },
           "2080-2099": {
-            "pf": 74.52,
-            "pf_lower": 48.26,
-            "pf_upper": 110.65
+            "pf": 54.65,
+            "pf_lower": 46.41,
+            "pf_upper": 63.95
           }
         }
       },
       "2h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 16.48,
-            "pf_lower": 14.95,
-            "pf_upper": 18.23
+            "pf": 16.91,
+            "pf_lower": 15.98,
+            "pf_upper": 17.95
           },
           "2050-2079": {
-            "pf": 20.76,
-            "pf_lower": 18.56,
-            "pf_upper": 23.25
+            "pf": 21.2,
+            "pf_lower": 19.99,
+            "pf_upper": 22.53
           },
           "2080-2099": {
-            "pf": 25.54,
-            "pf_lower": 22.8,
-            "pf_upper": 28.63
+            "pf": 26.89,
+            "pf_lower": 24.58,
+            "pf_upper": 29.58
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 15.91,
-            "pf_lower": 13.7,
-            "pf_upper": 18.46
+            "pf": 15.94,
+            "pf_lower": 14.84,
+            "pf_upper": 17.23
           },
           "2050-2079": {
-            "pf": 18.85,
-            "pf_lower": 16.33,
-            "pf_upper": 21.8
+            "pf": 18.54,
+            "pf_lower": 17.52,
+            "pf_upper": 19.67
           },
           "2080-2099": {
-            "pf": 21.32,
-            "pf_lower": 18.8,
-            "pf_upper": 23.83
+            "pf": 18.9,
+            "pf_lower": 17.71,
+            "pf_upper": 20.15
           }
         }
       },
       "30d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 186.93,
-            "pf_lower": 144.98,
-            "pf_upper": 235.09
+            "pf": 142.82,
+            "pf_lower": 126.26,
+            "pf_upper": 161.4
           },
           "2050-2079": {
-            "pf": 211.37,
-            "pf_lower": 172.18,
-            "pf_upper": 254.76
+            "pf": 178.6,
+            "pf_lower": 161.52,
+            "pf_upper": 197.06
           },
           "2080-2099": {
-            "pf": 275.44,
-            "pf_lower": 200.58,
-            "pf_upper": 362.26
+            "pf": 183.2,
+            "pf_lower": 154.27,
+            "pf_upper": 216.68
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 193.46,
-            "pf_lower": 131.39,
-            "pf_upper": 262.13
+            "pf": 128.45,
+            "pf_lower": 99.93,
+            "pf_upper": 160.76
           },
           "2050-2079": {
-            "pf": 211.94,
-            "pf_lower": 162.23,
-            "pf_upper": 260.16
+            "pf": 135.83,
+            "pf_lower": 119.25,
+            "pf_upper": 151.69
           },
           "2080-2099": {
-            "pf": 219.72,
-            "pf_lower": 153.12,
-            "pf_upper": 291.32
+            "pf": 133.94,
+            "pf_lower": 111.4,
+            "pf_upper": 155.7
           }
         }
       },
       "3d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 85.24,
-            "pf_lower": 69.45,
-            "pf_upper": 103.31
+            "pf": 66.39,
+            "pf_lower": 59.56,
+            "pf_upper": 74.43
           },
           "2050-2079": {
-            "pf": 104.5,
-            "pf_lower": 86.97,
-            "pf_upper": 123.1
+            "pf": 83.62,
+            "pf_lower": 74.7,
+            "pf_upper": 94.29
           },
           "2080-2099": {
-            "pf": 135.48,
-            "pf_lower": 102.41,
-            "pf_upper": 173.96
+            "pf": 80.47,
+            "pf_lower": 71.25,
+            "pf_upper": 91.04
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 73.45,
-            "pf_lower": 54.06,
-            "pf_upper": 94.47
+            "pf": 51.63,
+            "pf_lower": 43.37,
+            "pf_upper": 62.0
           },
           "2050-2079": {
-            "pf": 91.28,
-            "pf_lower": 62.45,
-            "pf_upper": 124.21
+            "pf": 57.59,
+            "pf_lower": 49.59,
+            "pf_upper": 65.51
           },
           "2080-2099": {
-            "pf": 86.85,
-            "pf_lower": 54.56,
-            "pf_upper": 130.26
+            "pf": 55.19,
+            "pf_lower": 46.46,
+            "pf_upper": 65.85
           }
         }
       },
       "3h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 19.46,
-            "pf_lower": 17.43,
-            "pf_upper": 21.92
+            "pf": 19.14,
+            "pf_lower": 17.93,
+            "pf_upper": 20.54
           },
           "2050-2079": {
-            "pf": 25.28,
-            "pf_lower": 22.43,
-            "pf_upper": 28.45
+            "pf": 24.34,
+            "pf_lower": 22.66,
+            "pf_upper": 26.23
           },
           "2080-2099": {
-            "pf": 30.95,
-            "pf_lower": 27.11,
-            "pf_upper": 35.55
+            "pf": 28.19,
+            "pf_lower": 25.8,
+            "pf_upper": 30.86
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 18.9,
-            "pf_lower": 15.81,
-            "pf_upper": 22.42
+            "pf": 17.74,
+            "pf_lower": 16.28,
+            "pf_upper": 19.43
           },
           "2050-2079": {
-            "pf": 21.73,
-            "pf_lower": 18.31,
-            "pf_upper": 25.72
+            "pf": 20.33,
+            "pf_lower": 18.89,
+            "pf_upper": 21.9
           },
           "2080-2099": {
-            "pf": 25.41,
-            "pf_lower": 21.58,
-            "pf_upper": 29.27
+            "pf": 21.78,
+            "pf_lower": 20.09,
+            "pf_upper": 23.46
           }
         }
       },
       "45d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 243.36,
-            "pf_lower": 194.44,
-            "pf_upper": 294.3
+            "pf": 174.69,
+            "pf_lower": 154.22,
+            "pf_upper": 197.94
           },
           "2050-2079": {
-            "pf": 265.47,
-            "pf_lower": 225.52,
-            "pf_upper": 303.89
+            "pf": 218.87,
+            "pf_lower": 198.1,
+            "pf_upper": 240.21
           },
           "2080-2099": {
-            "pf": 321.8,
-            "pf_lower": 233.7,
-            "pf_upper": 425.05
+            "pf": 239.98,
+            "pf_lower": 203.85,
+            "pf_upper": 279.74
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 243.14,
-            "pf_lower": 175.6,
-            "pf_upper": 314.6
+            "pf": 165.87,
+            "pf_lower": 132.37,
+            "pf_upper": 202.12
           },
           "2050-2079": {
-            "pf": 253.21,
-            "pf_lower": 201.27,
-            "pf_upper": 303.45
+            "pf": 175.52,
+            "pf_lower": 152.4,
+            "pf_upper": 197.7
           },
           "2080-2099": {
-            "pf": 261.16,
-            "pf_lower": 198.2,
-            "pf_upper": 324.25
+            "pf": 175.88,
+            "pf_lower": 142.48,
+            "pf_upper": 209.15
           }
         }
       },
       "4d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 94.84,
-            "pf_lower": 74.79,
-            "pf_upper": 117.07
+            "pf": 68.06,
+            "pf_lower": 59.62,
+            "pf_upper": 79.25
           },
           "2050-2079": {
-            "pf": 110.52,
-            "pf_lower": 87.96,
-            "pf_upper": 135.84
+            "pf": 84.45,
+            "pf_lower": 76.78,
+            "pf_upper": 94.38
           },
           "2080-2099": {
-            "pf": 136.84,
-            "pf_lower": 104.09,
-            "pf_upper": 174.55
+            "pf": 88.63,
+            "pf_lower": 78.37,
+            "pf_upper": 99.94
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 84.58,
-            "pf_lower": 60.74,
-            "pf_upper": 112.03
+            "pf": 58.07,
+            "pf_lower": 47.54,
+            "pf_upper": 69.9
           },
           "2050-2079": {
-            "pf": 101.2,
-            "pf_lower": 74.02,
-            "pf_upper": 131.22
+            "pf": 60.13,
+            "pf_lower": 51.87,
+            "pf_upper": 68.72
           },
           "2080-2099": {
-            "pf": 97.26,
-            "pf_lower": 64.58,
-            "pf_upper": 139.5
+            "pf": 63.72,
+            "pf_lower": 52.04,
+            "pf_upper": 76.33
           }
         }
       },
       "60d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 301.35,
-            "pf_lower": 236.57,
-            "pf_upper": 369.87
+            "pf": 209.47,
+            "pf_lower": 183.29,
+            "pf_upper": 239.0
           },
           "2050-2079": {
-            "pf": 316.02,
-            "pf_lower": 274.28,
-            "pf_upper": 354.71
+            "pf": 254.14,
+            "pf_lower": 229.39,
+            "pf_upper": 281.24
           },
           "2080-2099": {
-            "pf": 403.64,
-            "pf_lower": 311.54,
-            "pf_upper": 505.2
+            "pf": 274.54,
+            "pf_lower": 231.89,
+            "pf_upper": 322.99
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 279.91,
-            "pf_lower": 205.07,
-            "pf_upper": 359.49
+            "pf": 185.52,
+            "pf_lower": 153.47,
+            "pf_upper": 217.7
           },
           "2050-2079": {
-            "pf": 317.3,
-            "pf_lower": 253.58,
-            "pf_upper": 375.59
+            "pf": 208.03,
+            "pf_lower": 176.37,
+            "pf_upper": 240.02
           },
           "2080-2099": {
-            "pf": 304.12,
-            "pf_lower": 233.91,
-            "pf_upper": 368.85
+            "pf": 202.73,
+            "pf_lower": 171.44,
+            "pf_upper": 230.93
           }
         }
       },
       "60m": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 12.81,
-            "pf_lower": 11.96,
-            "pf_upper": 13.8
+            "pf": 14.8,
+            "pf_lower": 14.22,
+            "pf_upper": 15.48
           },
           "2050-2079": {
-            "pf": 16.25,
-            "pf_lower": 15.07,
-            "pf_upper": 17.53
+            "pf": 18.58,
+            "pf_lower": 17.8,
+            "pf_upper": 19.46
           },
           "2080-2099": {
-            "pf": 20.44,
-            "pf_lower": 18.86,
-            "pf_upper": 22.12
+            "pf": 24.48,
+            "pf_lower": 23.0,
+            "pf_upper": 26.24
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 13.02,
-            "pf_lower": 11.75,
-            "pf_upper": 14.62
+            "pf": 14.06,
+            "pf_lower": 13.4,
+            "pf_upper": 14.84
           },
           "2050-2079": {
-            "pf": 15.14,
-            "pf_lower": 13.83,
-            "pf_upper": 16.72
+            "pf": 15.93,
+            "pf_lower": 15.34,
+            "pf_upper": 16.59
           },
           "2080-2099": {
-            "pf": 17.89,
-            "pf_lower": 16.58,
-            "pf_upper": 19.08
+            "pf": 16.47,
+            "pf_lower": 15.87,
+            "pf_upper": 17.1
           }
         }
       },
       "6h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 28.44,
-            "pf_lower": 24.92,
-            "pf_upper": 32.7
+            "pf": 25.48,
+            "pf_lower": 23.42,
+            "pf_upper": 27.91
           },
           "2050-2079": {
-            "pf": 35.62,
-            "pf_lower": 31.35,
-            "pf_upper": 40.27
+            "pf": 31.27,
+            "pf_lower": 28.65,
+            "pf_upper": 34.29
           },
           "2080-2099": {
-            "pf": 43.27,
-            "pf_lower": 36.72,
-            "pf_upper": 50.88
+            "pf": 35.32,
+            "pf_lower": 32.19,
+            "pf_upper": 38.73
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 25.05,
-            "pf_lower": 20.3,
-            "pf_upper": 30.28
+            "pf": 23.3,
+            "pf_lower": 20.98,
+            "pf_upper": 25.9
           },
           "2050-2079": {
-            "pf": 30.89,
-            "pf_lower": 24.48,
-            "pf_upper": 38.16
+            "pf": 26.21,
+            "pf_lower": 23.77,
+            "pf_upper": 28.97
           },
           "2080-2099": {
-            "pf": 33.76,
-            "pf_lower": 26.49,
-            "pf_upper": 41.27
+            "pf": 26.7,
+            "pf_lower": 24.14,
+            "pf_upper": 29.35
           }
         }
       },
       "7d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 114.29,
-            "pf_lower": 95.6,
-            "pf_upper": 133.38
+            "pf": 77.45,
+            "pf_lower": 68.67,
+            "pf_upper": 88.04
           },
           "2050-2079": {
-            "pf": 127.45,
-            "pf_lower": 107.45,
-            "pf_upper": 149.38
+            "pf": 100.41,
+            "pf_lower": 89.61,
+            "pf_upper": 112.73
           },
           "2080-2099": {
-            "pf": 166.03,
-            "pf_lower": 128.53,
-            "pf_upper": 209.17
+            "pf": 102.2,
+            "pf_lower": 88.96,
+            "pf_upper": 117.45
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 86.84,
-            "pf_lower": 62.42,
-            "pf_upper": 113.96
+            "pf": 67.02,
+            "pf_lower": 54.03,
+            "pf_upper": 82.07
           },
           "2050-2079": {
-            "pf": 111.54,
-            "pf_lower": 75.53,
-            "pf_upper": 151.34
+            "pf": 67.42,
+            "pf_lower": 59.3,
+            "pf_upper": 75.53
           },
           "2080-2099": {
-            "pf": 106.7,
-            "pf_lower": 68.49,
-            "pf_upper": 153.08
+            "pf": 76.92,
+            "pf_lower": 60.57,
+            "pf_upper": 94.87
+          }
+        }
+      }
+    },
+    "10": {
+      "10d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 110.42,
+            "pf_lower": 93.24,
+            "pf_upper": 130.82
+          },
+          "2050-2079": {
+            "pf": 125.21,
+            "pf_lower": 111.97,
+            "pf_upper": 143.08
+          },
+          "2080-2099": {
+            "pf": 133.63,
+            "pf_lower": 113.51,
+            "pf_upper": 155.84
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 100.0,
+            "pf_lower": 76.79,
+            "pf_upper": 126.8
+          },
+          "2050-2079": {
+            "pf": 98.62,
+            "pf_lower": 83.41,
+            "pf_upper": 114.41
+          },
+          "2080-2099": {
+            "pf": 100.97,
+            "pf_lower": 75.86,
+            "pf_upper": 129.95
+          }
+        }
+      },
+      "12h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 44.39,
+            "pf_lower": 39.44,
+            "pf_upper": 50.27
+          },
+          "2050-2079": {
+            "pf": 52.18,
+            "pf_lower": 46.69,
+            "pf_upper": 58.6
+          },
+          "2080-2099": {
+            "pf": 56.31,
+            "pf_lower": 50.78,
+            "pf_upper": 62.14
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 38.14,
+            "pf_lower": 33.57,
+            "pf_upper": 43.25
+          },
+          "2050-2079": {
+            "pf": 41.2,
+            "pf_lower": 36.83,
+            "pf_upper": 45.96
+          },
+          "2080-2099": {
+            "pf": 42.55,
+            "pf_lower": 37.78,
+            "pf_upper": 47.64
+          }
+        }
+      },
+      "20d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 153.81,
+            "pf_lower": 130.37,
+            "pf_upper": 181.83
+          },
+          "2050-2079": {
+            "pf": 171.52,
+            "pf_lower": 151.88,
+            "pf_upper": 194.01
+          },
+          "2080-2099": {
+            "pf": 200.99,
+            "pf_lower": 164.29,
+            "pf_upper": 243.75
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 135.07,
+            "pf_lower": 100.09,
+            "pf_upper": 176.85
+          },
+          "2050-2079": {
+            "pf": 135.65,
+            "pf_lower": 121.48,
+            "pf_upper": 148.28
+          },
+          "2080-2099": {
+            "pf": 128.52,
+            "pf_lower": 103.56,
+            "pf_upper": 155.21
+          }
+        }
+      },
+      "24h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 54.1,
+            "pf_lower": 47.73,
+            "pf_upper": 61.79
+          },
+          "2050-2079": {
+            "pf": 70.58,
+            "pf_lower": 61.15,
+            "pf_upper": 82.21
+          },
+          "2080-2099": {
+            "pf": 67.26,
+            "pf_lower": 61.0,
+            "pf_upper": 73.51
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 49.91,
+            "pf_lower": 42.85,
+            "pf_upper": 57.59
+          },
+          "2050-2079": {
+            "pf": 47.85,
+            "pf_lower": 42.45,
+            "pf_upper": 53.68
+          },
+          "2080-2099": {
+            "pf": 49.96,
+            "pf_lower": 43.28,
+            "pf_upper": 57.56
+          }
+        }
+      },
+      "2d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 73.06,
+            "pf_lower": 63.47,
+            "pf_upper": 84.61
+          },
+          "2050-2079": {
+            "pf": 85.98,
+            "pf_lower": 74.72,
+            "pf_upper": 99.72
+          },
+          "2080-2099": {
+            "pf": 84.61,
+            "pf_lower": 75.27,
+            "pf_upper": 94.79
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 64.76,
+            "pf_lower": 54.07,
+            "pf_upper": 76.6
+          },
+          "2050-2079": {
+            "pf": 62.59,
+            "pf_lower": 55.25,
+            "pf_upper": 70.4
+          },
+          "2080-2099": {
+            "pf": 67.58,
+            "pf_lower": 56.04,
+            "pf_upper": 80.75
+          }
+        }
+      },
+      "2h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 20.85,
+            "pf_lower": 19.53,
+            "pf_upper": 22.33
+          },
+          "2050-2079": {
+            "pf": 26.13,
+            "pf_lower": 24.5,
+            "pf_upper": 27.95
+          },
+          "2080-2099": {
+            "pf": 34.58,
+            "pf_lower": 31.2,
+            "pf_upper": 38.57
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 19.78,
+            "pf_lower": 18.07,
+            "pf_upper": 21.86
+          },
+          "2050-2079": {
+            "pf": 22.01,
+            "pf_lower": 20.55,
+            "pf_upper": 23.65
+          },
+          "2080-2099": {
+            "pf": 22.06,
+            "pf_lower": 20.53,
+            "pf_upper": 23.7
+          }
+        }
+      },
+      "30d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 174.91,
+            "pf_lower": 152.01,
+            "pf_upper": 200.93
+          },
+          "2050-2079": {
+            "pf": 213.5,
+            "pf_lower": 190.89,
+            "pf_upper": 238.71
+          },
+          "2080-2099": {
+            "pf": 229.63,
+            "pf_lower": 187.14,
+            "pf_upper": 279.75
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 163.29,
+            "pf_lower": 121.29,
+            "pf_upper": 212.42
+          },
+          "2050-2079": {
+            "pf": 155.93,
+            "pf_lower": 136.92,
+            "pf_upper": 174.14
+          },
+          "2080-2099": {
+            "pf": 155.43,
+            "pf_lower": 129.26,
+            "pf_upper": 180.38
+          }
+        }
+      },
+      "3d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 84.04,
+            "pf_lower": 73.81,
+            "pf_upper": 96.15
+          },
+          "2050-2079": {
+            "pf": 106.93,
+            "pf_lower": 93.31,
+            "pf_upper": 123.57
+          },
+          "2080-2099": {
+            "pf": 100.29,
+            "pf_lower": 86.92,
+            "pf_upper": 115.89
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 65.41,
+            "pf_lower": 54.13,
+            "pf_upper": 81.33
+          },
+          "2050-2079": {
+            "pf": 67.87,
+            "pf_lower": 58.29,
+            "pf_upper": 77.37
+          },
+          "2080-2099": {
+            "pf": 68.25,
+            "pf_lower": 56.1,
+            "pf_upper": 83.68
+          }
+        }
+      },
+      "3h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 23.39,
+            "pf_lower": 21.62,
+            "pf_upper": 25.48
+          },
+          "2050-2079": {
+            "pf": 29.87,
+            "pf_lower": 27.55,
+            "pf_upper": 32.51
+          },
+          "2080-2099": {
+            "pf": 34.63,
+            "pf_lower": 31.31,
+            "pf_upper": 38.61
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 21.94,
+            "pf_lower": 19.7,
+            "pf_upper": 24.64
+          },
+          "2050-2079": {
+            "pf": 24.32,
+            "pf_lower": 22.31,
+            "pf_upper": 26.6
+          },
+          "2080-2099": {
+            "pf": 25.38,
+            "pf_lower": 23.34,
+            "pf_upper": 27.39
+          }
+        }
+      },
+      "45d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 208.0,
+            "pf_lower": 179.11,
+            "pf_upper": 241.34
+          },
+          "2050-2079": {
+            "pf": 250.79,
+            "pf_lower": 225.52,
+            "pf_upper": 276.18
+          },
+          "2080-2099": {
+            "pf": 287.07,
+            "pf_lower": 237.22,
+            "pf_upper": 342.87
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 203.18,
+            "pf_lower": 157.62,
+            "pf_upper": 253.35
+          },
+          "2050-2079": {
+            "pf": 201.01,
+            "pf_lower": 174.33,
+            "pf_upper": 226.74
+          },
+          "2080-2099": {
+            "pf": 205.49,
+            "pf_lower": 165.34,
+            "pf_upper": 245.15
+          }
+        }
+      },
+      "4d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 90.05,
+            "pf_lower": 75.25,
+            "pf_upper": 108.72
+          },
+          "2050-2079": {
+            "pf": 108.0,
+            "pf_lower": 97.27,
+            "pf_upper": 123.69
+          },
+          "2080-2099": {
+            "pf": 108.8,
+            "pf_lower": 94.57,
+            "pf_upper": 124.85
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 75.41,
+            "pf_lower": 60.17,
+            "pf_upper": 93.02
+          },
+          "2050-2079": {
+            "pf": 73.89,
+            "pf_lower": 63.3,
+            "pf_upper": 84.99
+          },
+          "2080-2099": {
+            "pf": 79.6,
+            "pf_lower": 64.17,
+            "pf_upper": 96.4
+          }
+        }
+      },
+      "60d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 245.55,
+            "pf_lower": 209.03,
+            "pf_upper": 287.36
+          },
+          "2050-2079": {
+            "pf": 288.72,
+            "pf_lower": 255.83,
+            "pf_upper": 325.04
+          },
+          "2080-2099": {
+            "pf": 324.14,
+            "pf_lower": 262.87,
+            "pf_upper": 395.01
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 219.13,
+            "pf_lower": 179.8,
+            "pf_upper": 258.58
+          },
+          "2050-2079": {
+            "pf": 242.54,
+            "pf_lower": 203.37,
+            "pf_upper": 282.44
+          },
+          "2080-2099": {
+            "pf": 229.36,
+            "pf_lower": 195.38,
+            "pf_upper": 259.61
+          }
+        }
+      },
+      "60m": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 18.43,
+            "pf_lower": 17.59,
+            "pf_upper": 19.42
+          },
+          "2050-2079": {
+            "pf": 23.24,
+            "pf_lower": 22.15,
+            "pf_upper": 24.5
+          },
+          "2080-2099": {
+            "pf": 31.73,
+            "pf_lower": 29.51,
+            "pf_upper": 34.39
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 17.09,
+            "pf_lower": 16.03,
+            "pf_upper": 18.4
+          },
+          "2050-2079": {
+            "pf": 18.43,
+            "pf_lower": 17.56,
+            "pf_upper": 19.42
+          },
+          "2080-2099": {
+            "pf": 18.37,
+            "pf_lower": 17.6,
+            "pf_upper": 19.19
+          }
+        }
+      },
+      "6h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 31.12,
+            "pf_lower": 28.03,
+            "pf_upper": 34.84
+          },
+          "2050-2079": {
+            "pf": 38.18,
+            "pf_lower": 34.41,
+            "pf_upper": 42.59
+          },
+          "2080-2099": {
+            "pf": 41.95,
+            "pf_lower": 37.71,
+            "pf_upper": 46.58
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 28.92,
+            "pf_lower": 25.67,
+            "pf_upper": 32.61
+          },
+          "2050-2079": {
+            "pf": 32.19,
+            "pf_lower": 28.78,
+            "pf_upper": 36.01
+          },
+          "2080-2099": {
+            "pf": 31.96,
+            "pf_lower": 28.69,
+            "pf_upper": 35.45
+          }
+        }
+      },
+      "7d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 98.49,
+            "pf_lower": 84.83,
+            "pf_upper": 115.3
+          },
+          "2050-2079": {
+            "pf": 125.06,
+            "pf_lower": 109.73,
+            "pf_upper": 142.93
+          },
+          "2080-2099": {
+            "pf": 127.96,
+            "pf_lower": 108.65,
+            "pf_upper": 150.57
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 83.53,
+            "pf_lower": 64.54,
+            "pf_upper": 105.78
+          },
+          "2050-2079": {
+            "pf": 77.18,
+            "pf_lower": 67.62,
+            "pf_upper": 86.52
+          },
+          "2080-2099": {
+            "pf": 93.56,
+            "pf_lower": 71.33,
+            "pf_upper": 118.3
+          }
+        }
+      }
+    },
+    "25": {
+      "10d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 140.54,
+            "pf_lower": 112.29,
+            "pf_upper": 177.89
+          },
+          "2050-2079": {
+            "pf": 164.89,
+            "pf_lower": 146.07,
+            "pf_upper": 194.85
+          },
+          "2080-2099": {
+            "pf": 170.96,
+            "pf_lower": 140.27,
+            "pf_upper": 211.47
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 134.7,
+            "pf_lower": 97.03,
+            "pf_upper": 183.9
+          },
+          "2050-2079": {
+            "pf": 121.8,
+            "pf_lower": 100.44,
+            "pf_upper": 145.53
+          },
+          "2080-2099": {
+            "pf": 132.87,
+            "pf_lower": 93.63,
+            "pf_upper": 185.72
+          }
+        }
+      },
+      "12h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 56.75,
+            "pf_lower": 48.6,
+            "pf_upper": 67.56
+          },
+          "2050-2079": {
+            "pf": 65.92,
+            "pf_lower": 56.93,
+            "pf_upper": 77.62
+          },
+          "2080-2099": {
+            "pf": 67.11,
+            "pf_lower": 59.14,
+            "pf_upper": 76.2
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 49.88,
+            "pf_lower": 42.78,
+            "pf_upper": 58.65
+          },
+          "2050-2079": {
+            "pf": 52.65,
+            "pf_lower": 46.1,
+            "pf_upper": 60.68
+          },
+          "2080-2099": {
+            "pf": 53.59,
+            "pf_lower": 46.62,
+            "pf_upper": 62.13
+          }
+        }
+      },
+      "20d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 199.85,
+            "pf_lower": 160.81,
+            "pf_upper": 251.91
+          },
+          "2050-2079": {
+            "pf": 211.24,
+            "pf_lower": 180.54,
+            "pf_upper": 249.7
+          },
+          "2080-2099": {
+            "pf": 259.41,
+            "pf_lower": 200.55,
+            "pf_upper": 336.37
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 190.17,
+            "pf_lower": 130.83,
+            "pf_upper": 270.69
+          },
+          "2050-2079": {
+            "pf": 161.13,
+            "pf_lower": 144.17,
+            "pf_upper": 177.59
+          },
+          "2080-2099": {
+            "pf": 162.72,
+            "pf_lower": 126.65,
+            "pf_upper": 206.72
+          }
+        }
+      },
+      "24h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 71.36,
+            "pf_lower": 60.61,
+            "pf_upper": 85.93
+          },
+          "2050-2079": {
+            "pf": 96.31,
+            "pf_lower": 79.63,
+            "pf_upper": 119.58
+          },
+          "2080-2099": {
+            "pf": 80.64,
+            "pf_lower": 71.99,
+            "pf_upper": 90.11
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 65.76,
+            "pf_lower": 55.24,
+            "pf_upper": 78.37
+          },
+          "2050-2079": {
+            "pf": 60.97,
+            "pf_lower": 52.97,
+            "pf_upper": 70.53
+          },
+          "2080-2099": {
+            "pf": 64.51,
+            "pf_lower": 54.06,
+            "pf_upper": 78.39
+          }
+        }
+      },
+      "2d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 99.24,
+            "pf_lower": 82.84,
+            "pf_upper": 121.6
+          },
+          "2050-2079": {
+            "pf": 117.04,
+            "pf_lower": 97.59,
+            "pf_upper": 143.72
+          },
+          "2080-2099": {
+            "pf": 105.71,
+            "pf_lower": 91.67,
+            "pf_upper": 122.61
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 84.72,
+            "pf_lower": 68.33,
+            "pf_upper": 104.76
+          },
+          "2050-2079": {
+            "pf": 77.09,
+            "pf_lower": 66.48,
+            "pf_upper": 89.26
+          },
+          "2080-2099": {
+            "pf": 87.4,
+            "pf_lower": 69.1,
+            "pf_upper": 111.68
+          }
+        }
+      },
+      "2h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 26.4,
+            "pf_lower": 24.29,
+            "pf_upper": 29.07
+          },
+          "2050-2079": {
+            "pf": 32.75,
+            "pf_lower": 30.26,
+            "pf_upper": 35.82
+          },
+          "2080-2099": {
+            "pf": 45.86,
+            "pf_lower": 40.36,
+            "pf_upper": 53.18
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 24.55,
+            "pf_lower": 21.56,
+            "pf_upper": 28.68
+          },
+          "2050-2079": {
+            "pf": 25.66,
+            "pf_lower": 23.32,
+            "pf_upper": 28.71
+          },
+          "2080-2099": {
+            "pf": 24.84,
+            "pf_lower": 22.63,
+            "pf_upper": 27.53
+          }
+        }
+      },
+      "30d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 223.02,
+            "pf_lower": 187.41,
+            "pf_upper": 267.6
+          },
+          "2050-2079": {
+            "pf": 264.86,
+            "pf_lower": 230.24,
+            "pf_upper": 307.37
+          },
+          "2080-2099": {
+            "pf": 303.72,
+            "pf_lower": 234.22,
+            "pf_upper": 395.67
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 218.44,
+            "pf_lower": 149.56,
+            "pf_upper": 309.54
+          },
+          "2050-2079": {
+            "pf": 182.14,
+            "pf_lower": 157.62,
+            "pf_upper": 207.12
+          },
+          "2080-2099": {
+            "pf": 183.62,
+            "pf_lower": 149.62,
+            "pf_upper": 219.63
+          }
+        }
+      },
+      "3d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 113.67,
+            "pf_lower": 96.42,
+            "pf_upper": 136.69
+          },
+          "2050-2079": {
+            "pf": 147.14,
+            "pf_lower": 123.57,
+            "pf_upper": 179.42
+          },
+          "2080-2099": {
+            "pf": 132.84,
+            "pf_lower": 111.1,
+            "pf_upper": 161.04
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 85.57,
+            "pf_lower": 68.4,
+            "pf_upper": 115.71
+          },
+          "2050-2079": {
+            "pf": 80.84,
+            "pf_lower": 68.02,
+            "pf_upper": 94.26
+          },
+          "2080-2099": {
+            "pf": 88.27,
+            "pf_lower": 69.17,
+            "pf_upper": 116.7
+          }
+        }
+      },
+      "3h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 29.37,
+            "pf_lower": 26.42,
+            "pf_upper": 33.23
+          },
+          "2050-2079": {
+            "pf": 37.22,
+            "pf_lower": 33.58,
+            "pf_upper": 41.79
+          },
+          "2080-2099": {
+            "pf": 46.32,
+            "pf_lower": 41.17,
+            "pf_upper": 53.23
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 27.27,
+            "pf_lower": 23.4,
+            "pf_upper": 32.55
+          },
+          "2050-2079": {
+            "pf": 28.7,
+            "pf_lower": 25.56,
+            "pf_upper": 32.75
+          },
+          "2080-2099": {
+            "pf": 28.48,
+            "pf_lower": 25.74,
+            "pf_upper": 31.54
+          }
+        }
+      },
+      "45d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 257.21,
+            "pf_lower": 211.32,
+            "pf_upper": 316.01
+          },
+          "2050-2079": {
+            "pf": 291.88,
+            "pf_lower": 257.43,
+            "pf_upper": 328.67
+          },
+          "2080-2099": {
+            "pf": 356.39,
+            "pf_lower": 279.23,
+            "pf_upper": 453.79
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 255.86,
+            "pf_lower": 187.01,
+            "pf_upper": 339.79
+          },
+          "2050-2079": {
+            "pf": 232.56,
+            "pf_lower": 197.96,
+            "pf_upper": 267.9
+          },
+          "2080-2099": {
+            "pf": 243.25,
+            "pf_lower": 189.54,
+            "pf_upper": 302.52
+          }
+        }
+      },
+      "4d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 131.48,
+            "pf_lower": 103.44,
+            "pf_upper": 171.57
+          },
+          "2050-2079": {
+            "pf": 148.61,
+            "pf_lower": 131.61,
+            "pf_upper": 179.59
+          },
+          "2080-2099": {
+            "pf": 141.1,
+            "pf_lower": 118.93,
+            "pf_upper": 169.2
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 103.49,
+            "pf_lower": 78.86,
+            "pf_upper": 135.51
+          },
+          "2050-2079": {
+            "pf": 94.06,
+            "pf_lower": 78.88,
+            "pf_upper": 111.16
+          },
+          "2080-2099": {
+            "pf": 103.62,
+            "pf_lower": 81.0,
+            "pf_upper": 131.95
+          }
+        }
+      },
+      "60d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 292.8,
+            "pf_lower": 235.56,
+            "pf_upper": 365.41
+          },
+          "2050-2079": {
+            "pf": 331.39,
+            "pf_lower": 281.74,
+            "pf_upper": 390.55
+          },
+          "2080-2099": {
+            "pf": 392.21,
+            "pf_lower": 294.33,
+            "pf_upper": 519.16
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 259.93,
+            "pf_lower": 205.66,
+            "pf_upper": 340.13
+          },
+          "2050-2079": {
+            "pf": 284.92,
+            "pf_lower": 230.33,
+            "pf_upper": 344.77
+          },
+          "2080-2099": {
+            "pf": 258.28,
+            "pf_lower": 216.42,
+            "pf_upper": 302.82
+          }
+        }
+      },
+      "60m": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 23.73,
+            "pf_lower": 22.32,
+            "pf_upper": 25.55
+          },
+          "2050-2079": {
+            "pf": 29.86,
+            "pf_lower": 28.1,
+            "pf_upper": 32.11
+          },
+          "2080-2099": {
+            "pf": 42.65,
+            "pf_lower": 38.94,
+            "pf_upper": 47.65
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 20.29,
+            "pf_lower": 18.34,
+            "pf_upper": 23.01
+          },
+          "2050-2079": {
+            "pf": 20.49,
+            "pf_lower": 19.02,
+            "pf_upper": 22.38
+          },
+          "2080-2099": {
+            "pf": 19.04,
+            "pf_lower": 17.93,
+            "pf_upper": 20.37
+          }
+        }
+      },
+      "6h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 39.23,
+            "pf_lower": 33.96,
+            "pf_upper": 46.34
+          },
+          "2050-2079": {
+            "pf": 47.61,
+            "pf_lower": 41.5,
+            "pf_upper": 55.62
+          },
+          "2080-2099": {
+            "pf": 50.26,
+            "pf_lower": 43.91,
+            "pf_upper": 57.93
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 36.12,
+            "pf_lower": 31.06,
+            "pf_upper": 42.59
+          },
+          "2050-2079": {
+            "pf": 39.71,
+            "pf_lower": 34.42,
+            "pf_upper": 46.38
+          },
+          "2080-2099": {
+            "pf": 37.97,
+            "pf_lower": 33.25,
+            "pf_upper": 43.78
+          }
+        }
+      },
+      "7d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 133.98,
+            "pf_lower": 109.9,
+            "pf_upper": 171.74
+          },
+          "2050-2079": {
+            "pf": 163.26,
+            "pf_lower": 138.65,
+            "pf_upper": 194.66
+          },
+          "2080-2099": {
+            "pf": 169.27,
+            "pf_lower": 137.32,
+            "pf_upper": 211.26
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 108.98,
+            "pf_lower": 78.93,
+            "pf_upper": 149.78
+          },
+          "2050-2079": {
+            "pf": 95.0,
+            "pf_lower": 82.43,
+            "pf_upper": 111.27
+          },
+          "2080-2099": {
+            "pf": 117.62,
+            "pf_lower": 84.12,
+            "pf_upper": 159.92
           }
         }
       }
@@ -4009,540 +2383,1624 @@
       "10d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 165.5,
-            "pf_lower": 105.47,
-            "pf_upper": 282.85
+            "pf": 179.87,
+            "pf_lower": 142.97,
+            "pf_upper": 248.32
           },
           "2050-2079": {
-            "pf": 163.16,
-            "pf_lower": 111.68,
-            "pf_upper": 270.42
+            "pf": 199.76,
+            "pf_lower": 175.79,
+            "pf_upper": 247.43
           },
           "2080-2099": {
-            "pf": 232.52,
-            "pf_lower": 143.99,
-            "pf_upper": 418.06
+            "pf": 210.24,
+            "pf_lower": 169.44,
+            "pf_upper": 277.72
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 195.44,
-            "pf_lower": 91.28,
-            "pf_upper": 351.0
+            "pf": 166.7,
+            "pf_lower": 114.12,
+            "pf_upper": 245.4
           },
           "2050-2079": {
-            "pf": 214.44,
-            "pf_lower": 104.95,
-            "pf_upper": 370.01
+            "pf": 140.91,
+            "pf_lower": 113.7,
+            "pf_upper": 174.48
           },
           "2080-2099": {
-            "pf": 232.81,
-            "pf_lower": 91.97,
-            "pf_upper": 516.33
+            "pf": 161.77,
+            "pf_lower": 108.51,
+            "pf_upper": 245.53
           }
         }
       },
       "12h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 58.98,
-            "pf_lower": 41.55,
-            "pf_upper": 85.6
+            "pf": 67.35,
+            "pf_lower": 55.92,
+            "pf_upper": 84.51
           },
           "2050-2079": {
-            "pf": 70.54,
-            "pf_lower": 52.47,
-            "pf_upper": 96.07
+            "pf": 77.65,
+            "pf_lower": 65.1,
+            "pf_upper": 96.23
           },
           "2080-2099": {
-            "pf": 100.87,
-            "pf_lower": 64.21,
-            "pf_upper": 158.62
+            "pf": 75.27,
+            "pf_lower": 65.15,
+            "pf_upper": 88.45
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 63.18,
-            "pf_lower": 37.98,
-            "pf_upper": 97.85
+            "pf": 59.91,
+            "pf_lower": 50.29,
+            "pf_upper": 73.34
           },
           "2050-2079": {
-            "pf": 75.88,
-            "pf_lower": 45.27,
-            "pf_upper": 118.12
+            "pf": 62.28,
+            "pf_lower": 53.53,
+            "pf_upper": 74.52
           },
           "2080-2099": {
-            "pf": 73.52,
-            "pf_lower": 39.67,
-            "pf_upper": 126.62
+            "pf": 62.81,
+            "pf_lower": 53.71,
+            "pf_upper": 75.77
           }
         }
       },
       "20d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 238.7,
-            "pf_lower": 141.33,
-            "pf_upper": 377.14
+            "pf": 241.56,
+            "pf_lower": 186.13,
+            "pf_upper": 326.09
           },
           "2050-2079": {
-            "pf": 221.69,
-            "pf_lower": 158.37,
-            "pf_upper": 301.31
+            "pf": 245.04,
+            "pf_lower": 203.33,
+            "pf_upper": 304.04
           },
           "2080-2099": {
-            "pf": 409.99,
-            "pf_lower": 168.02,
-            "pf_upper": 862.61
+            "pf": 311.54,
+            "pf_lower": 230.93,
+            "pf_upper": 434.47
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 294.73,
-            "pf_lower": 133.94,
-            "pf_upper": 535.38
+            "pf": 243.95,
+            "pf_lower": 158.75,
+            "pf_upper": 377.67
           },
           "2050-2079": {
-            "pf": 270.36,
-            "pf_lower": 163.63,
-            "pf_upper": 407.84
+            "pf": 181.14,
+            "pf_lower": 161.28,
+            "pf_upper": 202.92
           },
           "2080-2099": {
-            "pf": 348.44,
-            "pf_lower": 129.65,
-            "pf_upper": 715.9
+            "pf": 192.46,
+            "pf_lower": 145.99,
+            "pf_upper": 258.03
           }
         }
       },
       "24h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 72.52,
-            "pf_lower": 43.7,
-            "pf_upper": 123.8
+            "pf": 87.91,
+            "pf_lower": 72.57,
+            "pf_upper": 111.85
           },
           "2050-2079": {
-            "pf": 77.49,
-            "pf_lower": 54.73,
-            "pf_upper": 112.83
+            "pf": 121.94,
+            "pf_lower": 97.43,
+            "pf_upper": 161.56
           },
           "2080-2099": {
-            "pf": 111.17,
-            "pf_lower": 68.91,
-            "pf_upper": 183.71
+            "pf": 91.84,
+            "pf_lower": 81.05,
+            "pf_upper": 105.52
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 70.87,
-            "pf_lower": 41.44,
-            "pf_upper": 111.69
+            "pf": 79.85,
+            "pf_lower": 65.92,
+            "pf_upper": 98.54
           },
           "2050-2079": {
-            "pf": 99.41,
-            "pf_lower": 47.42,
-            "pf_upper": 176.8
+            "pf": 72.53,
+            "pf_lower": 62.0,
+            "pf_upper": 86.56
           },
           "2080-2099": {
-            "pf": 113.44,
-            "pf_lower": 40.92,
-            "pf_upper": 260.41
+            "pf": 77.99,
+            "pf_lower": 63.71,
+            "pf_upper": 100.25
           }
         }
       },
       "2d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 96.33,
-            "pf_lower": 56.7,
-            "pf_upper": 175.55
+            "pf": 124.98,
+            "pf_lower": 101.45,
+            "pf_upper": 161.47
           },
           "2050-2079": {
-            "pf": 103.55,
-            "pf_lower": 72.43,
-            "pf_upper": 157.5
+            "pf": 147.59,
+            "pf_lower": 119.47,
+            "pf_upper": 191.85
           },
           "2080-2099": {
-            "pf": 148.11,
-            "pf_lower": 94.66,
-            "pf_upper": 247.71
+            "pf": 124.32,
+            "pf_lower": 105.96,
+            "pf_upper": 150.16
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 92.57,
-            "pf_lower": 47.88,
-            "pf_upper": 187.75
+            "pf": 101.7,
+            "pf_lower": 79.67,
+            "pf_upper": 131.85
           },
           "2050-2079": {
-            "pf": 107.78,
-            "pf_lower": 58.65,
-            "pf_upper": 207.11
+            "pf": 88.77,
+            "pf_lower": 75.06,
+            "pf_upper": 106.32
           },
           "2080-2099": {
-            "pf": 136.44,
-            "pf_lower": 48.4,
-            "pf_upper": 392.02
+            "pf": 105.34,
+            "pf_lower": 80.03,
+            "pf_upper": 144.94
           }
         }
       },
       "2h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 25.33,
-            "pf_lower": 20.12,
-            "pf_upper": 33.52
+            "pf": 30.96,
+            "pf_lower": 28.02,
+            "pf_upper": 35.14
           },
           "2050-2079": {
-            "pf": 32.97,
-            "pf_lower": 25.86,
-            "pf_upper": 43.85
+            "pf": 37.92,
+            "pf_lower": 34.56,
+            "pf_upper": 42.73
           },
           "2080-2099": {
-            "pf": 38.28,
-            "pf_lower": 29.71,
-            "pf_upper": 51.62
+            "pf": 55.4,
+            "pf_lower": 47.79,
+            "pf_upper": 67.12
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 28.92,
-            "pf_lower": 20.73,
-            "pf_upper": 41.85
+            "pf": 27.96,
+            "pf_lower": 23.57,
+            "pf_upper": 34.97
           },
           "2050-2079": {
-            "pf": 34.19,
-            "pf_lower": 24.29,
-            "pf_upper": 49.74
+            "pf": 27.9,
+            "pf_lower": 24.62,
+            "pf_upper": 32.89
           },
           "2080-2099": {
-            "pf": 28.84,
-            "pf_lower": 23.98,
-            "pf_upper": 34.83
+            "pf": 25.99,
+            "pf_lower": 23.14,
+            "pf_upper": 30.0
           }
         }
       },
       "30d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 301.82,
-            "pf_lower": 161.12,
-            "pf_upper": 529.87
+            "pf": 265.2,
+            "pf_lower": 216.99,
+            "pf_upper": 332.83
           },
           "2050-2079": {
-            "pf": 307.13,
-            "pf_lower": 191.15,
-            "pf_upper": 480.66
+            "pf": 309.47,
+            "pf_lower": 262.89,
+            "pf_upper": 374.37
           },
           "2080-2099": {
-            "pf": 448.95,
-            "pf_lower": 212.71,
-            "pf_upper": 863.47
+            "pf": 372.85,
+            "pf_lower": 276.63,
+            "pf_upper": 522.06
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 375.97,
-            "pf_lower": 187.83,
-            "pf_upper": 637.3
+            "pf": 269.25,
+            "pf_lower": 172.29,
+            "pf_upper": 416.82
           },
           "2050-2079": {
-            "pf": 327.83,
-            "pf_lower": 235.12,
-            "pf_upper": 433.47
+            "pf": 202.5,
+            "pf_lower": 172.6,
+            "pf_upper": 236.63
           },
           "2080-2099": {
-            "pf": 372.65,
-            "pf_lower": 207.0,
-            "pf_upper": 716.61
+            "pf": 205.61,
+            "pf_lower": 164.32,
+            "pf_upper": 258.29
           }
         }
       },
       "3d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 122.04,
-            "pf_lower": 74.26,
-            "pf_upper": 206.93
+            "pf": 142.38,
+            "pf_lower": 117.93,
+            "pf_upper": 179.91
           },
           "2050-2079": {
-            "pf": 131.61,
-            "pf_lower": 93.18,
-            "pf_upper": 191.16
+            "pf": 187.12,
+            "pf_lower": 152.91,
+            "pf_upper": 240.94
           },
           "2080-2099": {
-            "pf": 203.41,
-            "pf_lower": 108.9,
-            "pf_upper": 384.17
+            "pf": 163.8,
+            "pf_lower": 133.9,
+            "pf_upper": 209.28
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 94.2,
-            "pf_lower": 55.41,
-            "pf_upper": 187.94
+            "pf": 102.71,
+            "pf_lower": 79.75,
+            "pf_upper": 151.82
           },
           "2050-2079": {
-            "pf": 136.11,
-            "pf_lower": 63.31,
-            "pf_upper": 286.61
+            "pf": 90.55,
+            "pf_lower": 75.14,
+            "pf_upper": 109.04
           },
           "2080-2099": {
-            "pf": 159.78,
-            "pf_lower": 54.72,
-            "pf_upper": 463.09
+            "pf": 106.39,
+            "pf_lower": 80.11,
+            "pf_upper": 152.01
           }
         }
       },
       "3h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 34.09,
-            "pf_lower": 25.74,
-            "pf_upper": 48.1
+            "pf": 34.23,
+            "pf_lower": 30.05,
+            "pf_upper": 40.44
           },
           "2050-2079": {
-            "pf": 41.82,
-            "pf_lower": 33.02,
-            "pf_upper": 55.09
+            "pf": 42.88,
+            "pf_lower": 37.9,
+            "pf_upper": 50.17
           },
           "2080-2099": {
-            "pf": 53.66,
-            "pf_lower": 39.1,
-            "pf_upper": 78.27
+            "pf": 55.96,
+            "pf_lower": 49.06,
+            "pf_upper": 67.19
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 33.53,
-            "pf_lower": 22.72,
-            "pf_upper": 49.74
+            "pf": 31.14,
+            "pf_lower": 25.52,
+            "pf_upper": 39.99
           },
           "2050-2079": {
-            "pf": 39.49,
-            "pf_lower": 26.17,
-            "pf_upper": 60.26
+            "pf": 31.38,
+            "pf_lower": 27.05,
+            "pf_upper": 37.73
           },
           "2080-2099": {
-            "pf": 35.73,
-            "pf_lower": 28.0,
-            "pf_upper": 45.46
+            "pf": 29.7,
+            "pf_lower": 26.3,
+            "pf_upper": 34.03
           }
         }
       },
       "45d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 304.84,
-            "pf_lower": 200.68,
-            "pf_upper": 530.4
+            "pf": 299.84,
+            "pf_lower": 236.67,
+            "pf_upper": 391.95
           },
           "2050-2079": {
-            "pf": 310.2,
-            "pf_lower": 239.48,
-            "pf_upper": 481.14
+            "pf": 323.33,
+            "pf_lower": 280.53,
+            "pf_upper": 374.58
           },
           "2080-2099": {
-            "pf": 453.44,
-            "pf_lower": 234.41,
-            "pf_upper": 953.99
+            "pf": 416.72,
+            "pf_lower": 312.77,
+            "pf_upper": 568.81
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 440.03,
-            "pf_lower": 272.39,
-            "pf_upper": 651.77
+            "pf": 299.61,
+            "pf_lower": 207.71,
+            "pf_upper": 423.94
           },
           "2050-2079": {
-            "pf": 394.81,
-            "pf_lower": 299.37,
-            "pf_upper": 503.5
+            "pf": 255.98,
+            "pf_lower": 213.77,
+            "pf_upper": 304.5
           },
           "2080-2099": {
-            "pf": 412.73,
-            "pf_lower": 286.48,
-            "pf_upper": 717.33
+            "pf": 271.85,
+            "pf_lower": 205.39,
+            "pf_upper": 354.97
           }
         }
       },
       "4d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 123.26,
-            "pf_lower": 76.96,
-            "pf_upper": 211.01
+            "pf": 176.33,
+            "pf_lower": 133.1,
+            "pf_upper": 247.82
           },
           "2050-2079": {
-            "pf": 136.25,
-            "pf_lower": 93.28,
-            "pf_upper": 246.56
+            "pf": 188.99,
+            "pf_lower": 165.64,
+            "pf_upper": 241.18
           },
           "2080-2099": {
-            "pf": 205.45,
-            "pf_lower": 111.32,
-            "pf_upper": 384.55
+            "pf": 171.17,
+            "pf_lower": 141.32,
+            "pf_upper": 215.34
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 128.48,
-            "pf_lower": 62.54,
-            "pf_upper": 260.55
+            "pf": 129.87,
+            "pf_lower": 95.63,
+            "pf_upper": 180.46
           },
           "2050-2079": {
-            "pf": 139.47,
-            "pf_lower": 77.2,
-            "pf_upper": 286.9
+            "pf": 111.31,
+            "pf_lower": 91.81,
+            "pf_upper": 135.86
           },
           "2080-2099": {
-            "pf": 166.11,
-            "pf_lower": 64.77,
-            "pf_upper": 463.55
+            "pf": 124.78,
+            "pf_lower": 95.31,
+            "pf_upper": 167.28
           }
         }
       },
       "60d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 341.81,
-            "pf_lower": 241.76,
-            "pf_upper": 555.01
+            "pf": 329.36,
+            "pf_lower": 251.41,
+            "pf_upper": 440.0
           },
           "2050-2079": {
-            "pf": 327.99,
-            "pf_lower": 276.21,
-            "pf_upper": 481.62
+            "pf": 362.69,
+            "pf_lower": 296.8,
+            "pf_upper": 450.36
           },
           "2080-2099": {
-            "pf": 457.72,
-            "pf_lower": 312.48,
-            "pf_upper": 954.95
+            "pf": 447.75,
+            "pf_lower": 313.85,
+            "pf_upper": 650.08
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 444.43,
-            "pf_lower": 274.23,
-            "pf_upper": 652.42
+            "pf": 302.61,
+            "pf_lower": 233.89,
+            "pf_upper": 424.36
           },
           "2050-2079": {
-            "pf": 417.25,
-            "pf_lower": 322.22,
-            "pf_upper": 520.92
+            "pf": 315.78,
+            "pf_lower": 246.35,
+            "pf_upper": 398.5
           },
           "2080-2099": {
-            "pf": 416.85,
-            "pf_lower": 301.62,
-            "pf_upper": 718.05
+            "pf": 277.22,
+            "pf_lower": 228.75,
+            "pf_upper": 355.33
           }
         }
       },
       "60m": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 18.14,
-            "pf_lower": 15.11,
-            "pf_upper": 23.0
+            "pf": 28.26,
+            "pf_lower": 26.25,
+            "pf_upper": 31.23
           },
           "2050-2079": {
-            "pf": 21.68,
-            "pf_lower": 18.55,
-            "pf_upper": 25.98
+            "pf": 35.37,
+            "pf_lower": 32.92,
+            "pf_upper": 39.01
           },
           "2080-2099": {
-            "pf": 26.45,
-            "pf_lower": 22.38,
-            "pf_upper": 32.19
+            "pf": 52.19,
+            "pf_lower": 46.95,
+            "pf_upper": 60.41
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 26.06,
-            "pf_lower": 20.71,
-            "pf_upper": 34.56
+            "pf": 22.13,
+            "pf_lower": 19.18,
+            "pf_upper": 26.87
           },
           "2050-2079": {
-            "pf": 27.45,
-            "pf_lower": 22.57,
-            "pf_upper": 34.89
+            "pf": 21.43,
+            "pf_lower": 19.28,
+            "pf_upper": 24.61
           },
           "2080-2099": {
-            "pf": 23.27,
-            "pf_lower": 21.23,
-            "pf_upper": 25.51
+            "pf": 19.23,
+            "pf_lower": 17.95,
+            "pf_upper": 21.23
           }
         }
       },
       "6h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 48.6,
-            "pf_lower": 34.16,
-            "pf_upper": 73.01
+            "pf": 45.9,
+            "pf_lower": 38.34,
+            "pf_upper": 57.47
           },
           "2050-2079": {
-            "pf": 53.69,
-            "pf_lower": 41.85,
-            "pf_upper": 70.47
+            "pf": 54.95,
+            "pf_lower": 46.47,
+            "pf_upper": 67.44
           },
           "2080-2099": {
-            "pf": 71.41,
-            "pf_lower": 49.14,
-            "pf_upper": 107.51
+            "pf": 56.18,
+            "pf_lower": 49.11,
+            "pf_upper": 67.75
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 42.49,
-            "pf_lower": 27.76,
-            "pf_upper": 63.79
+            "pf": 41.36,
+            "pf_lower": 34.45,
+            "pf_upper": 51.46
           },
           "2050-2079": {
-            "pf": 57.12,
-            "pf_lower": 34.15,
-            "pf_upper": 92.46
+            "pf": 45.09,
+            "pf_lower": 37.96,
+            "pf_upper": 55.37
           },
           "2080-2099": {
-            "pf": 50.99,
-            "pf_lower": 35.05,
-            "pf_upper": 72.58
+            "pf": 41.83,
+            "pf_lower": 35.71,
+            "pf_upper": 50.69
           }
         }
       },
       "7d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 127.19,
-            "pf_lower": 100.26,
-            "pf_upper": 211.22
+            "pf": 178.09,
+            "pf_lower": 142.83,
+            "pf_upper": 248.07
           },
           "2050-2079": {
-            "pf": 146.97,
-            "pf_lower": 111.0,
-            "pf_upper": 246.8
+            "pf": 197.78,
+            "pf_lower": 165.81,
+            "pf_upper": 247.18
           },
           "2080-2099": {
-            "pf": 211.67,
-            "pf_lower": 131.81,
-            "pf_upper": 405.23
+            "pf": 208.16,
+            "pf_lower": 163.51,
+            "pf_upper": 277.44
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 139.2,
-            "pf_lower": 66.67,
-            "pf_upper": 260.82
+            "pf": 131.82,
+            "pf_lower": 95.73,
+            "pf_upper": 197.25
           },
           "2050-2079": {
-            "pf": 185.58,
-            "pf_lower": 82.06,
-            "pf_upper": 351.13
+            "pf": 112.42,
+            "pf_lower": 96.95,
+            "pf_upper": 135.99
           },
           "2080-2099": {
-            "pf": 183.97,
-            "pf_lower": 68.85,
-            "pf_upper": 464.02
+            "pf": 137.97,
+            "pf_lower": 95.41,
+            "pf_upper": 203.0
+          }
+        }
+      }
+    },
+    "100": {
+      "10d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 242.62,
+            "pf_lower": 190.46,
+            "pf_upper": 365.68
+          },
+          "2050-2079": {
+            "pf": 245.3,
+            "pf_lower": 215.37,
+            "pf_upper": 327.55
+          },
+          "2080-2099": {
+            "pf": 258.48,
+            "pf_lower": 205.89,
+            "pf_upper": 370.55
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 204.82,
+            "pf_lower": 134.13,
+            "pf_upper": 325.66
+          },
+          "2050-2079": {
+            "pf": 161.67,
+            "pf_lower": 128.08,
+            "pf_upper": 208.55
+          },
+          "2080-2099": {
+            "pf": 195.64,
+            "pf_lower": 125.6,
+            "pf_upper": 325.78
+          }
+        }
+      },
+      "12h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 79.28,
+            "pf_lower": 63.79,
+            "pf_upper": 106.35
+          },
+          "2050-2079": {
+            "pf": 90.84,
+            "pf_lower": 73.79,
+            "pf_upper": 120.03
+          },
+          "2080-2099": {
+            "pf": 83.52,
+            "pf_lower": 71.07,
+            "pf_upper": 102.43
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 71.16,
+            "pf_lower": 58.57,
+            "pf_upper": 91.33
+          },
+          "2050-2079": {
+            "pf": 73.03,
+            "pf_lower": 61.74,
+            "pf_upper": 91.13
+          },
+          "2080-2099": {
+            "pf": 73.11,
+            "pf_lower": 61.51,
+            "pf_upper": 92.82
+          }
+        }
+      },
+      "20d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 290.6,
+            "pf_lower": 215.05,
+            "pf_upper": 424.74
+          },
+          "2050-2079": {
+            "pf": 282.72,
+            "pf_lower": 227.95,
+            "pf_upper": 371.95
+          },
+          "2080-2099": {
+            "pf": 372.09,
+            "pf_lower": 265.66,
+            "pf_upper": 564.27
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 311.22,
+            "pf_lower": 193.43,
+            "pf_upper": 526.06
+          },
+          "2050-2079": {
+            "pf": 202.2,
+            "pf_lower": 179.5,
+            "pf_upper": 230.55
+          },
+          "2080-2099": {
+            "pf": 226.25,
+            "pf_lower": 167.9,
+            "pf_upper": 326.1
+          }
+        }
+      },
+      "24h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 108.46,
+            "pf_lower": 87.27,
+            "pf_upper": 146.85
+          },
+          "2050-2079": {
+            "pf": 154.82,
+            "pf_lower": 119.97,
+            "pf_upper": 221.1
+          },
+          "2080-2099": {
+            "pf": 104.33,
+            "pf_lower": 91.24,
+            "pf_upper": 124.07
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 96.24,
+            "pf_lower": 78.48,
+            "pf_upper": 123.44
+          },
+          "2050-2079": {
+            "pf": 85.93,
+            "pf_lower": 72.53,
+            "pf_upper": 106.42
+          },
+          "2080-2099": {
+            "pf": 94.29,
+            "pf_lower": 75.39,
+            "pf_upper": 129.63
+          }
+        }
+      },
+      "2d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 157.67,
+            "pf_lower": 124.87,
+            "pf_upper": 217.37
+          },
+          "2050-2079": {
+            "pf": 186.26,
+            "pf_lower": 146.91,
+            "pf_upper": 258.89
+          },
+          "2080-2099": {
+            "pf": 145.84,
+            "pf_lower": 122.45,
+            "pf_upper": 184.76
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 120.74,
+            "pf_lower": 92.18,
+            "pf_upper": 165.23
+          },
+          "2050-2079": {
+            "pf": 101.31,
+            "pf_lower": 84.13,
+            "pf_upper": 126.16
+          },
+          "2080-2099": {
+            "pf": 126.85,
+            "pf_lower": 92.85,
+            "pf_upper": 192.11
+          }
+        }
+      },
+      "2h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 35.84,
+            "pf_lower": 31.91,
+            "pf_upper": 42.3
+          },
+          "2050-2079": {
+            "pf": 43.26,
+            "pf_lower": 38.84,
+            "pf_upper": 50.58
+          },
+          "2080-2099": {
+            "pf": 65.89,
+            "pf_lower": 55.86,
+            "pf_upper": 84.44
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 31.22,
+            "pf_lower": 25.04,
+            "pf_upper": 42.84
+          },
+          "2050-2079": {
+            "pf": 29.86,
+            "pf_lower": 25.41,
+            "pf_upper": 37.81
+          },
+          "2080-2099": {
+            "pf": 26.44,
+            "pf_lower": 23.16,
+            "pf_upper": 32.25
+          }
+        }
+      },
+      "30d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 313.47,
+            "pf_lower": 250.43,
+            "pf_upper": 425.17
+          },
+          "2050-2079": {
+            "pf": 360.35,
+            "pf_lower": 299.71,
+            "pf_upper": 458.05
+          },
+          "2080-2099": {
+            "pf": 456.5,
+            "pf_lower": 328.01,
+            "pf_upper": 693.54
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 329.87,
+            "pf_lower": 198.87,
+            "pf_upper": 558.3
+          },
+          "2050-2079": {
+            "pf": 223.67,
+            "pf_lower": 188.15,
+            "pf_upper": 269.67
+          },
+          "2080-2099": {
+            "pf": 228.57,
+            "pf_lower": 179.85,
+            "pf_upper": 326.43
+          }
+        }
+      },
+      "3d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 178.11,
+            "pf_lower": 144.6,
+            "pf_upper": 237.44
+          },
+          "2050-2079": {
+            "pf": 238.09,
+            "pf_lower": 190.17,
+            "pf_upper": 326.56
+          },
+          "2080-2099": {
+            "pf": 201.84,
+            "pf_lower": 161.92,
+            "pf_upper": 274.15
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 123.16,
+            "pf_lower": 92.27,
+            "pf_upper": 201.31
+          },
+          "2050-2079": {
+            "pf": 102.32,
+            "pf_lower": 84.22,
+            "pf_upper": 127.31
+          },
+          "2080-2099": {
+            "pf": 128.12,
+            "pf_lower": 92.94,
+            "pf_upper": 200.35
+          }
+        }
+      },
+      "3h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 39.44,
+            "pf_lower": 33.71,
+            "pf_upper": 49.28
+          },
+          "2050-2079": {
+            "pf": 48.69,
+            "pf_lower": 42.07,
+            "pf_upper": 59.85
+          },
+          "2080-2099": {
+            "pf": 66.55,
+            "pf_lower": 57.66,
+            "pf_upper": 84.53
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 34.89,
+            "pf_lower": 27.0,
+            "pf_upper": 49.46
+          },
+          "2050-2079": {
+            "pf": 33.54,
+            "pf_lower": 27.82,
+            "pf_upper": 43.26
+          },
+          "2080-2099": {
+            "pf": 30.09,
+            "pf_lower": 26.32,
+            "pf_upper": 36.23
+          }
+        }
+      },
+      "45d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 348.08,
+            "pf_lower": 264.26,
+            "pf_upper": 487.86
+          },
+          "2050-2079": {
+            "pf": 363.95,
+            "pf_lower": 311.7,
+            "pf_upper": 458.51
+          },
+          "2080-2099": {
+            "pf": 485.68,
+            "pf_lower": 350.12,
+            "pf_upper": 724.65
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 347.4,
+            "pf_lower": 229.24,
+            "pf_upper": 558.86
+          },
+          "2050-2079": {
+            "pf": 279.47,
+            "pf_lower": 229.21,
+            "pf_upper": 344.72
+          },
+          "2080-2099": {
+            "pf": 300.87,
+            "pf_lower": 221.38,
+            "pf_upper": 416.54
+          }
+        }
+      },
+      "4d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 237.84,
+            "pf_lower": 173.61,
+            "pf_upper": 364.95
+          },
+          "2050-2079": {
+            "pf": 240.47,
+            "pf_lower": 209.6,
+            "pf_upper": 326.89
+          },
+          "2080-2099": {
+            "pf": 207.37,
+            "pf_lower": 168.43,
+            "pf_upper": 276.16
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 161.8,
+            "pf_lower": 116.01,
+            "pf_upper": 239.6
+          },
+          "2050-2079": {
+            "pf": 130.6,
+            "pf_lower": 106.28,
+            "pf_upper": 165.07
+          },
+          "2080-2099": {
+            "pf": 149.06,
+            "pf_lower": 111.77,
+            "pf_upper": 210.78
+          }
+        }
+      },
+      "60d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 367.09,
+            "pf_lower": 264.7,
+            "pf_upper": 532.83
+          },
+          "2050-2079": {
+            "pf": 393.58,
+            "pf_lower": 312.02,
+            "pf_upper": 520.81
+          },
+          "2080-2099": {
+            "pf": 508.1,
+            "pf_lower": 350.47,
+            "pf_upper": 825.02
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 350.87,
+            "pf_lower": 267.33,
+            "pf_upper": 559.41
+          },
+          "2050-2079": {
+            "pf": 346.06,
+            "pf_lower": 261.04,
+            "pf_upper": 459.78
+          },
+          "2080-2099": {
+            "pf": 303.88,
+            "pf_lower": 248.49,
+            "pf_upper": 416.96
+          }
+        }
+      },
+      "60m": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 33.31,
+            "pf_lower": 30.54,
+            "pf_upper": 38.05
+          },
+          "2050-2079": {
+            "pf": 41.42,
+            "pf_lower": 38.11,
+            "pf_upper": 47.24
+          },
+          "2080-2099": {
+            "pf": 62.95,
+            "pf_lower": 55.81,
+            "pf_upper": 76.5
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 23.52,
+            "pf_lower": 19.24,
+            "pf_upper": 31.75
+          },
+          "2050-2079": {
+            "pf": 22.11,
+            "pf_lower": 19.3,
+            "pf_upper": 27.46
+          },
+          "2080-2099": {
+            "pf": 19.43,
+            "pf_lower": 17.97,
+            "pf_upper": 22.35
+          }
+        }
+      },
+      "6h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 53.22,
+            "pf_lower": 42.71,
+            "pf_upper": 72.03
+          },
+          "2050-2079": {
+            "pf": 62.6,
+            "pf_lower": 51.17,
+            "pf_upper": 82.17
+          },
+          "2080-2099": {
+            "pf": 67.22,
+            "pf_lower": 57.71,
+            "pf_upper": 84.71
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 46.49,
+            "pf_lower": 37.34,
+            "pf_upper": 61.99
+          },
+          "2050-2079": {
+            "pf": 50.32,
+            "pf_lower": 40.92,
+            "pf_upper": 65.8
+          },
+          "2080-2099": {
+            "pf": 45.23,
+            "pf_lower": 37.51,
+            "pf_upper": 58.48
+          }
+        }
+      },
+      "7d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 240.21,
+            "pf_lower": 190.27,
+            "pf_upper": 365.32
+          },
+          "2050-2079": {
+            "pf": 242.88,
+            "pf_lower": 209.81,
+            "pf_upper": 327.22
+          },
+          "2080-2099": {
+            "pf": 255.92,
+            "pf_lower": 195.15,
+            "pf_upper": 370.18
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 163.42,
+            "pf_lower": 116.13,
+            "pf_upper": 266.21
+          },
+          "2050-2079": {
+            "pf": 131.9,
+            "pf_lower": 113.38,
+            "pf_upper": 165.24
+          },
+          "2080-2099": {
+            "pf": 160.68,
+            "pf_lower": 111.88,
+            "pf_upper": 258.33
+          }
+        }
+      }
+    },
+    "200": {
+      "10d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 334.45,
+            "pf_lower": 264.53,
+            "pf_upper": 549.32
+          },
+          "2050-2079": {
+            "pf": 317.65,
+            "pf_lower": 281.49,
+            "pf_upper": 450.0
+          },
+          "2080-2099": {
+            "pf": 323.59,
+            "pf_lower": 257.55,
+            "pf_upper": 505.49
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 254.72,
+            "pf_lower": 162.4,
+            "pf_upper": 438.35
+          },
+          "2050-2079": {
+            "pf": 187.57,
+            "pf_lower": 147.29,
+            "pf_upper": 251.24
+          },
+          "2080-2099": {
+            "pf": 239.6,
+            "pf_lower": 150.19,
+            "pf_upper": 438.37
+          }
+        }
+      },
+      "12h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 97.0,
+            "pf_lower": 76.74,
+            "pf_upper": 138.03
+          },
+          "2050-2079": {
+            "pf": 110.59,
+            "pf_lower": 88.29,
+            "pf_upper": 155.27
+          },
+          "2080-2099": {
+            "pf": 96.11,
+            "pf_lower": 81.19,
+            "pf_upper": 122.4
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 87.65,
+            "pf_lower": 71.69,
+            "pf_upper": 117.15
+          },
+          "2050-2079": {
+            "pf": 89.04,
+            "pf_lower": 74.85,
+            "pf_upper": 115.39
+          },
+          "2080-2099": {
+            "pf": 88.6,
+            "pf_lower": 74.25,
+            "pf_upper": 117.77
+          }
+        }
+      },
+      "20d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 352.31,
+            "pf_lower": 264.79,
+            "pf_upper": 558.56
+          },
+          "2050-2079": {
+            "pf": 328.49,
+            "pf_lower": 281.77,
+            "pf_upper": 459.12
+          },
+          "2080-2099": {
+            "pf": 447.65,
+            "pf_lower": 311.12,
+            "pf_upper": 740.3
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 399.81,
+            "pf_lower": 242.41,
+            "pf_upper": 735.91
+          },
+          "2050-2079": {
+            "pf": 227.11,
+            "pf_lower": 202.04,
+            "pf_upper": 262.66
+          },
+          "2080-2099": {
+            "pf": 267.73,
+            "pf_lower": 196.3,
+            "pf_upper": 438.81
+          }
+        }
+      },
+      "24h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 137.09,
+            "pf_lower": 108.95,
+            "pf_upper": 196.7
+          },
+          "2050-2079": {
+            "pf": 201.65,
+            "pf_lower": 154.0,
+            "pf_upper": 308.73
+          },
+          "2080-2099": {
+            "pf": 121.05,
+            "pf_lower": 105.53,
+            "pf_upper": 147.9
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 118.01,
+            "pf_lower": 95.96,
+            "pf_upper": 156.69
+          },
+          "2050-2079": {
+            "pf": 103.83,
+            "pf_lower": 87.23,
+            "pf_upper": 132.94
+          },
+          "2080-2099": {
+            "pf": 116.66,
+            "pf_lower": 92.37,
+            "pf_upper": 171.63
+          }
+        }
+      },
+      "2d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 203.0,
+            "pf_lower": 158.97,
+            "pf_upper": 297.56
+          },
+          "2050-2079": {
+            "pf": 239.56,
+            "pf_lower": 186.53,
+            "pf_upper": 354.67
+          },
+          "2080-2099": {
+            "pf": 173.89,
+            "pf_lower": 144.9,
+            "pf_upper": 230.66
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 144.76,
+            "pf_lower": 108.94,
+            "pf_upper": 208.8
+          },
+          "2050-2079": {
+            "pf": 116.93,
+            "pf_lower": 96.03,
+            "pf_upper": 151.09
+          },
+          "2080-2099": {
+            "pf": 155.83,
+            "pf_lower": 111.03,
+            "pf_upper": 261.05
+          }
+        }
+      },
+      "2h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 44.04,
+            "pf_lower": 38.94,
+            "pf_upper": 53.82
+          },
+          "2050-2079": {
+            "pf": 52.28,
+            "pf_lower": 47.16,
+            "pf_upper": 63.19
+          },
+          "2080-2099": {
+            "pf": 82.94,
+            "pf_lower": 70.88,
+            "pf_upper": 111.94
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 36.82,
+            "pf_lower": 28.38,
+            "pf_upper": 55.33
+          },
+          "2050-2079": {
+            "pf": 33.97,
+            "pf_lower": 28.05,
+            "pf_upper": 46.75
+          },
+          "2080-2099": {
+            "pf": 28.19,
+            "pf_lower": 23.82,
+            "pf_upper": 36.6
+          }
+        }
+      },
+      "30d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 371.2,
+            "pf_lower": 291.35,
+            "pf_upper": 559.12
+          },
+          "2050-2079": {
+            "pf": 421.31,
+            "pf_lower": 344.76,
+            "pf_upper": 562.68
+          },
+          "2080-2099": {
+            "pf": 561.77,
+            "pf_lower": 394.75,
+            "pf_upper": 930.08
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 404.85,
+            "pf_lower": 242.65,
+            "pf_upper": 754.58
+          },
+          "2050-2079": {
+            "pf": 247.47,
+            "pf_lower": 206.66,
+            "pf_upper": 307.2
+          },
+          "2080-2099": {
+            "pf": 270.41,
+            "pf_lower": 214.81,
+            "pf_upper": 439.25
+          }
+        }
+      },
+      "3d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 226.4,
+            "pf_lower": 182.05,
+            "pf_upper": 318.09
+          },
+          "2050-2079": {
+            "pf": 308.31,
+            "pf_lower": 243.53,
+            "pf_upper": 448.65
+          },
+          "2080-2099": {
+            "pf": 252.9,
+            "pf_lower": 201.24,
+            "pf_upper": 366.52
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 151.64,
+            "pf_lower": 109.05,
+            "pf_upper": 273.52
+          },
+          "2050-2079": {
+            "pf": 118.09,
+            "pf_lower": 96.12,
+            "pf_upper": 151.24
+          },
+          "2080-2099": {
+            "pf": 157.39,
+            "pf_lower": 111.14,
+            "pf_upper": 269.3
+          }
+        }
+      },
+      "3h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 48.35,
+            "pf_lower": 40.75,
+            "pf_upper": 63.81
+          },
+          "2050-2079": {
+            "pf": 58.66,
+            "pf_lower": 50.12,
+            "pf_upper": 75.57
+          },
+          "2080-2099": {
+            "pf": 83.77,
+            "pf_lower": 72.56,
+            "pf_upper": 112.05
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 41.35,
+            "pf_lower": 30.65,
+            "pf_upper": 64.64
+          },
+          "2050-2079": {
+            "pf": 37.81,
+            "pf_lower": 30.44,
+            "pf_upper": 52.48
+          },
+          "2080-2099": {
+            "pf": 31.97,
+            "pf_lower": 27.13,
+            "pf_upper": 40.46
+          }
+        }
+      },
+      "45d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 403.7,
+            "pf_lower": 295.87,
+            "pf_upper": 614.19
+          },
+          "2050-2079": {
+            "pf": 425.52,
+            "pf_lower": 364.16,
+            "pf_upper": 563.25
+          },
+          "2080-2099": {
+            "pf": 566.36,
+            "pf_lower": 395.15,
+            "pf_upper": 931.01
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 408.9,
+            "pf_lower": 261.37,
+            "pf_upper": 755.34
+          },
+          "2050-2079": {
+            "pf": 303.95,
+            "pf_lower": 246.01,
+            "pf_upper": 389.23
+          },
+          "2080-2099": {
+            "pf": 331.25,
+            "pf_lower": 238.71,
+            "pf_upper": 487.77
+          }
+        }
+      },
+      "4d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 327.86,
+            "pf_lower": 235.84,
+            "pf_upper": 548.23
+          },
+          "2050-2079": {
+            "pf": 311.39,
+            "pf_lower": 271.88,
+            "pf_upper": 449.1
+          },
+          "2080-2099": {
+            "pf": 255.3,
+            "pf_lower": 205.89,
+            "pf_upper": 366.89
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 203.87,
+            "pf_lower": 144.44,
+            "pf_upper": 321.03
+          },
+          "2050-2079": {
+            "pf": 154.78,
+            "pf_lower": 125.45,
+            "pf_upper": 201.63
+          },
+          "2080-2099": {
+            "pf": 179.95,
+            "pf_lower": 134.03,
+            "pf_upper": 269.88
+          }
+        }
+      },
+      "60d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 405.95,
+            "pf_lower": 296.16,
+            "pf_upper": 649.43
+          },
+          "2050-2079": {
+            "pf": 429.78,
+            "pf_lower": 364.52,
+            "pf_upper": 612.21
+          },
+          "2080-2099": {
+            "pf": 573.98,
+            "pf_lower": 395.54,
+            "pf_upper": 1057.37
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 412.99,
+            "pf_lower": 314.18,
+            "pf_upper": 756.09
+          },
+          "2050-2079": {
+            "pf": 375.73,
+            "pf_lower": 274.13,
+            "pf_upper": 527.92
+          },
+          "2080-2099": {
+            "pf": 334.57,
+            "pf_lower": 273.47,
+            "pf_upper": 488.26
+          }
+        }
+      },
+      "60m": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 41.69,
+            "pf_lower": 37.99,
+            "pf_upper": 49.21
+          },
+          "2050-2079": {
+            "pf": 51.45,
+            "pf_lower": 47.11,
+            "pf_upper": 60.58
+          },
+          "2080-2099": {
+            "pf": 80.31,
+            "pf_lower": 70.81,
+            "pf_upper": 101.96
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 26.25,
+            "pf_lower": 20.25,
+            "pf_upper": 40.05
+          },
+          "2050-2079": {
+            "pf": 24.4,
+            "pf_lower": 20.27,
+            "pf_upper": 33.11
+          },
+          "2080-2099": {
+            "pf": 19.62,
+            "pf_lower": 17.99,
+            "pf_upper": 23.81
+          }
+        }
+      },
+      "6h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 65.38,
+            "pf_lower": 51.3,
+            "pf_upper": 95.09
+          },
+          "2050-2079": {
+            "pf": 75.27,
+            "pf_lower": 60.46,
+            "pf_upper": 104.75
+          },
+          "2080-2099": {
+            "pf": 84.61,
+            "pf_lower": 72.63,
+            "pf_upper": 112.17
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 54.95,
+            "pf_lower": 43.24,
+            "pf_upper": 78.07
+          },
+          "2050-2079": {
+            "pf": 59.11,
+            "pf_lower": 47.14,
+            "pf_upper": 82.23
+          },
+          "2080-2099": {
+            "pf": 51.42,
+            "pf_lower": 41.94,
+            "pf_upper": 70.63
+          }
+        }
+      },
+      "7d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 331.14,
+            "pf_lower": 263.03,
+            "pf_upper": 548.77
+          },
+          "2050-2079": {
+            "pf": 314.51,
+            "pf_lower": 272.15,
+            "pf_upper": 449.55
+          },
+          "2080-2099": {
+            "pf": 320.39,
+            "pf_lower": 239.95,
+            "pf_upper": 504.98
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 205.91,
+            "pf_lower": 144.59,
+            "pf_upper": 360.13
+          },
+          "2050-2079": {
+            "pf": 156.33,
+            "pf_lower": 134.77,
+            "pf_upper": 201.83
+          },
+          "2080-2099": {
+            "pf": 189.32,
+            "pf_lower": 134.16,
+            "pf_upper": 334.37
           }
         }
       }
@@ -4551,678 +4009,2501 @@
       "10d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 176.76,
-            "pf_lower": 105.79,
-            "pf_upper": 595.55
+            "pf": 502.49,
+            "pf_lower": 406.79,
+            "pf_upper": 931.96
           },
           "2050-2079": {
-            "pf": 171.0,
-            "pf_lower": 112.02,
-            "pf_upper": 577.17
+            "pf": 436.68,
+            "pf_lower": 391.94,
+            "pf_upper": 678.52
           },
           "2080-2099": {
-            "pf": 275.21,
-            "pf_lower": 144.42,
-            "pf_upper": 1107.48
+            "pf": 426.2,
+            "pf_lower": 339.85,
+            "pf_upper": 764.53
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 285.7,
-            "pf_lower": 91.55,
-            "pf_upper": 866.35
+            "pf": 329.72,
+            "pf_lower": 204.07,
+            "pf_upper": 639.42
           },
           "2050-2079": {
-            "pf": 297.48,
-            "pf_lower": 105.27,
-            "pf_upper": 898.52
+            "pf": 221.25,
+            "pf_lower": 171.98,
+            "pf_upper": 312.06
           },
           "2080-2099": {
-            "pf": 390.42,
-            "pf_lower": 92.25,
-            "pf_upper": 2427.9
+            "pf": 304.05,
+            "pf_lower": 185.54,
+            "pf_upper": 638.83
           }
         }
       },
       "12h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 83.18,
-            "pf_lower": 43.08,
-            "pf_upper": 207.87
+            "pf": 122.17,
+            "pf_lower": 94.43,
+            "pf_upper": 191.89
           },
           "2050-2079": {
-            "pf": 82.75,
-            "pf_lower": 52.62,
-            "pf_upper": 166.86
+            "pf": 138.66,
+            "pf_lower": 108.12,
+            "pf_upper": 214.89
           },
           "2080-2099": {
-            "pf": 130.78,
-            "pf_lower": 64.4,
-            "pf_upper": 362.95
+            "pf": 111.32,
+            "pf_lower": 95.33,
+            "pf_upper": 159.72
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 97.68,
-            "pf_lower": 44.1,
-            "pf_upper": 215.56
+            "pf": 111.18,
+            "pf_lower": 90.1,
+            "pf_upper": 159.01
           },
           "2050-2079": {
-            "pf": 120.04,
-            "pf_lower": 54.22,
-            "pf_upper": 270.33
+            "pf": 111.85,
+            "pf_lower": 93.31,
+            "pf_upper": 154.15
           },
           "2080-2099": {
-            "pf": 118.45,
-            "pf_lower": 43.95,
-            "pf_upper": 328.81
+            "pf": 110.67,
+            "pf_lower": 92.33,
+            "pf_upper": 158.12
           }
         }
       },
       "20d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 320.74,
-            "pf_lower": 141.75,
-            "pf_upper": 762.37
+            "pf": 507.51,
+            "pf_lower": 407.2,
+            "pf_upper": 932.89
           },
           "2050-2079": {
-            "pf": 262.5,
-            "pf_lower": 158.84,
-            "pf_upper": 577.75
+            "pf": 441.05,
+            "pf_lower": 392.34,
+            "pf_upper": 679.2
           },
           "2080-2099": {
-            "pf": 690.75,
-            "pf_lower": 168.52,
-            "pf_upper": 2820.33
+            "pf": 559.01,
+            "pf_lower": 376.13,
+            "pf_upper": 1056.85
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 534.48,
-            "pf_lower": 144.28,
-            "pf_upper": 1520.35
+            "pf": 544.11,
+            "pf_lower": 322.22,
+            "pf_upper": 1141.63
           },
           "2050-2079": {
-            "pf": 402.8,
-            "pf_lower": 196.33,
-            "pf_upper": 899.42
+            "pf": 258.72,
+            "pf_lower": 231.04,
+            "pf_upper": 312.37
           },
           "2080-2099": {
-            "pf": 654.12,
-            "pf_lower": 130.03,
-            "pf_upper": 2430.33
+            "pf": 326.75,
+            "pf_lower": 237.6,
+            "pf_upper": 639.47
           }
         }
       },
       "24h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 97.11,
-            "pf_lower": 43.83,
-            "pf_upper": 318.78
+            "pf": 181.24,
+            "pf_lower": 141.8,
+            "pf_upper": 286.1
           },
           "2050-2079": {
-            "pf": 86.45,
-            "pf_lower": 54.9,
-            "pf_upper": 197.47
+            "pf": 277.86,
+            "pf_lower": 208.59,
+            "pf_upper": 474.29
           },
           "2080-2099": {
-            "pf": 132.09,
-            "pf_lower": 69.12,
-            "pf_upper": 406.81
+            "pf": 142.37,
+            "pf_lower": 123.69,
+            "pf_upper": 182.28
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 98.65,
-            "pf_lower": 44.14,
-            "pf_upper": 232.74
+            "pf": 148.53,
+            "pf_lower": 120.3,
+            "pf_upper": 207.86
           },
           "2050-2079": {
-            "pf": 150.59,
-            "pf_lower": 54.28,
-            "pf_upper": 445.95
+            "pf": 128.59,
+            "pf_lower": 107.41,
+            "pf_upper": 173.34
           },
           "2080-2099": {
-            "pf": 210.64,
-            "pf_lower": 43.99,
-            "pf_upper": 1008.2
+            "pf": 149.76,
+            "pf_lower": 117.07,
+            "pf_upper": 244.28
           }
         }
       },
       "2d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 121.6,
-            "pf_lower": 56.87,
-            "pf_upper": 482.03
+            "pf": 276.59,
+            "pf_lower": 214.1,
+            "pf_upper": 445.39
           },
           "2050-2079": {
-            "pf": 107.26,
-            "pf_lower": 72.65,
-            "pf_upper": 278.88
+            "pf": 325.11,
+            "pf_lower": 249.66,
+            "pf_upper": 529.31
           },
           "2080-2099": {
-            "pf": 155.32,
-            "pf_lower": 94.95,
-            "pf_upper": 503.41
+            "pf": 212.82,
+            "pf_lower": 175.62,
+            "pf_upper": 305.4
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 110.58,
-            "pf_lower": 48.03,
-            "pf_upper": 494.12
+            "pf": 177.1,
+            "pf_lower": 130.47,
+            "pf_upper": 277.75
           },
           "2050-2079": {
-            "pf": 152.1,
-            "pf_lower": 58.83,
-            "pf_upper": 510.23
+            "pf": 136.21,
+            "pf_lower": 110.23,
+            "pf_upper": 186.46
           },
           "2080-2099": {
-            "pf": 261.34,
-            "pf_lower": 48.55,
-            "pf_upper": 2190.15
+            "pf": 199.9,
+            "pf_lower": 137.43,
+            "pf_upper": 392.51
           }
         }
       },
       "2h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 36.37,
-            "pf_lower": 23.94,
-            "pf_upper": 69.81
+            "pf": 56.1,
+            "pf_lower": 49.5,
+            "pf_upper": 72.5
           },
           "2050-2079": {
-            "pf": 47.34,
-            "pf_lower": 31.03,
-            "pf_upper": 90.03
+            "pf": 67.45,
+            "pf_lower": 60.81,
+            "pf_upper": 85.6
           },
           "2080-2099": {
-            "pf": 52.84,
-            "pf_lower": 33.78,
-            "pf_upper": 106.1
+            "pf": 108.68,
+            "pf_lower": 94.02,
+            "pf_upper": 159.24
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 49.01,
-            "pf_lower": 33.11,
-            "pf_upper": 108.37
+            "pf": 44.21,
+            "pf_lower": 32.0,
+            "pf_upper": 78.13
           },
           "2050-2079": {
-            "pf": 57.32,
-            "pf_lower": 32.8,
-            "pf_upper": 130.92
+            "pf": 39.41,
+            "pf_lower": 31.05,
+            "pf_upper": 62.6
           },
           "2080-2099": {
-            "pf": 32.77,
-            "pf_lower": 25.19,
-            "pf_upper": 48.0
+            "pf": 29.35,
+            "pf_lower": 23.9,
+            "pf_upper": 42.37
           }
         }
       },
       "30d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 458.12,
-            "pf_lower": 161.6,
-            "pf_upper": 1400.16
+            "pf": 512.59,
+            "pf_lower": 407.89,
+            "pf_upper": 933.82
           },
           "2050-2079": {
-            "pf": 416.13,
-            "pf_lower": 191.72,
-            "pf_upper": 1031.21
+            "pf": 509.78,
+            "pf_lower": 409.15,
+            "pf_upper": 737.22
           },
           "2080-2099": {
-            "pf": 697.66,
-            "pf_lower": 213.35,
-            "pf_upper": 2823.15
+            "pf": 728.6,
+            "pf_lower": 501.02,
+            "pf_upper": 1371.65
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 631.42,
-            "pf_lower": 225.29,
-            "pf_upper": 1552.82
+            "pf": 549.56,
+            "pf_lower": 322.54,
+            "pf_upper": 1142.11
           },
           "2050-2079": {
-            "pf": 433.23,
-            "pf_lower": 290.17,
-            "pf_upper": 900.32
+            "pf": 277.53,
+            "pf_lower": 231.27,
+            "pf_upper": 358.53
           },
           "2080-2099": {
-            "pf": 660.66,
-            "pf_lower": 351.72,
-            "pf_upper": 2432.76
+            "pf": 330.02,
+            "pf_lower": 265.99,
+            "pf_upper": 640.11
           }
         }
       },
       "3d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 152.19,
-            "pf_lower": 74.48,
-            "pf_upper": 500.51
+            "pf": 302.98,
+            "pf_lower": 241.35,
+            "pf_upper": 461.52
           },
           "2050-2079": {
-            "pf": 138.23,
-            "pf_lower": 93.46,
-            "pf_upper": 321.09
+            "pf": 423.84,
+            "pf_lower": 331.4,
+            "pf_upper": 676.49
           },
           "2080-2099": {
-            "pf": 267.11,
-            "pf_lower": 109.23,
-            "pf_upper": 1104.17
+            "pf": 332.61,
+            "pf_lower": 262.12,
+            "pf_upper": 533.44
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 111.68,
-            "pf_lower": 55.58,
-            "pf_upper": 494.62
+            "pf": 193.88,
+            "pf_lower": 130.6,
+            "pf_upper": 406.6
           },
           "2050-2079": {
-            "pf": 170.89,
-            "pf_lower": 63.5,
-            "pf_upper": 784.15
+            "pf": 137.57,
+            "pf_lower": 111.43,
+            "pf_upper": 186.64
           },
           "2080-2099": {
-            "pf": 296.19,
-            "pf_lower": 54.89,
-            "pf_upper": 2420.63
+            "pf": 201.9,
+            "pf_lower": 137.57,
+            "pf_upper": 394.31
           }
         }
       },
       "3h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 60.72,
-            "pf_lower": 37.35,
-            "pf_upper": 133.9
+            "pf": 61.53,
+            "pf_lower": 50.94,
+            "pf_upper": 88.38
           },
           "2050-2079": {
-            "pf": 63.9,
-            "pf_lower": 44.28,
-            "pf_upper": 113.26
+            "pf": 72.81,
+            "pf_lower": 61.26,
+            "pf_upper": 101.36
           },
           "2080-2099": {
-            "pf": 91.5,
-            "pf_lower": 53.83,
-            "pf_upper": 209.74
+            "pf": 109.77,
+            "pf_lower": 95.14,
+            "pf_upper": 159.4
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 52.93,
-            "pf_lower": 33.15,
-            "pf_upper": 119.35
+            "pf": 50.01,
+            "pf_lower": 34.63,
+            "pf_upper": 92.32
           },
           "2050-2079": {
-            "pf": 67.09,
-            "pf_lower": 32.83,
-            "pf_upper": 165.35
+            "pf": 42.65,
+            "pf_lower": 32.74,
+            "pf_upper": 66.95
           },
           "2080-2099": {
-            "pf": 42.28,
-            "pf_lower": 29.8,
-            "pf_upper": 67.89
+            "pf": 33.06,
+            "pf_lower": 27.31,
+            "pf_upper": 45.69
           }
         }
       },
       "45d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 462.7,
-            "pf_lower": 261.59,
-            "pf_upper": 1401.56
+            "pf": 517.71,
+            "pf_lower": 408.3,
+            "pf_upper": 934.76
           },
           "2050-2079": {
-            "pf": 420.29,
-            "pf_lower": 312.03,
-            "pf_upper": 1032.24
+            "pf": 514.88,
+            "pf_lower": 442.07,
+            "pf_upper": 737.95
           },
           "2080-2099": {
-            "pf": 704.64,
-            "pf_lower": 235.11,
-            "pf_upper": 2902.36
+            "pf": 735.88,
+            "pf_lower": 505.48,
+            "pf_upper": 1373.03
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 667.84,
-            "pf_lower": 352.81,
-            "pf_upper": 1554.37
+            "pf": 555.05,
+            "pf_lower": 364.44,
+            "pf_upper": 1143.26
           },
           "2050-2079": {
-            "pf": 525.95,
-            "pf_lower": 379.55,
-            "pf_upper": 901.22
+            "pf": 334.92,
+            "pf_lower": 267.46,
+            "pf_upper": 450.95
           },
           "2080-2099": {
-            "pf": 667.26,
-            "pf_lower": 462.4,
-            "pf_upper": 2435.19
+            "pf": 370.24,
+            "pf_lower": 266.25,
+            "pf_upper": 640.75
           }
         }
       },
       "4d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 153.71,
-            "pf_lower": 77.19,
-            "pf_upper": 501.01
+            "pf": 492.59,
+            "pf_lower": 350.47,
+            "pf_upper": 930.1
           },
           "2050-2079": {
-            "pf": 139.61,
-            "pf_lower": 93.56,
-            "pf_upper": 576.02
+            "pf": 428.08,
+            "pf_lower": 375.38,
+            "pf_upper": 677.17
           },
           "2080-2099": {
-            "pf": 269.78,
-            "pf_lower": 111.65,
-            "pf_upper": 1105.27
+            "pf": 335.94,
+            "pf_lower": 270.39,
+            "pf_upper": 533.97
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 168.98,
-            "pf_lower": 62.73,
-            "pf_upper": 746.55
+            "pf": 268.45,
+            "pf_lower": 188.02,
+            "pf_upper": 462.21
           },
           "2050-2079": {
-            "pf": 172.6,
-            "pf_lower": 77.44,
-            "pf_upper": 784.93
+            "pf": 187.63,
+            "pf_lower": 151.3,
+            "pf_upper": 256.32
           },
           "2080-2099": {
-            "pf": 299.16,
-            "pf_lower": 64.97,
-            "pf_upper": 2423.05
+            "pf": 223.67,
+            "pf_lower": 165.93,
+            "pf_upper": 394.7
           }
         }
       },
       "60d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 467.33,
-            "pf_lower": 261.86,
-            "pf_upper": 1402.96
+            "pf": 522.89,
+            "pf_lower": 408.7,
+            "pf_upper": 935.69
           },
           "2050-2079": {
-            "pf": 424.49,
-            "pf_lower": 328.95,
-            "pf_upper": 1033.27
+            "pf": 520.03,
+            "pf_lower": 442.52,
+            "pf_upper": 801.91
           },
           "2080-2099": {
-            "pf": 711.68,
-            "pf_lower": 313.42,
-            "pf_upper": 2905.26
+            "pf": 743.24,
+            "pf_lower": 505.99,
+            "pf_upper": 1579.18
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 674.52,
-            "pf_lower": 370.13,
-            "pf_upper": 1555.93
+            "pf": 560.6,
+            "pf_lower": 442.41,
+            "pf_upper": 1144.4
           },
           "2050-2079": {
-            "pf": 531.21,
-            "pf_lower": 400.98,
-            "pf_upper": 902.12
+            "pf": 414.93,
+            "pf_lower": 292.44,
+            "pf_upper": 633.66
           },
           "2080-2099": {
-            "pf": 673.94,
-            "pf_lower": 509.03,
-            "pf_upper": 2437.63
+            "pf": 373.95,
+            "pf_lower": 306.95,
+            "pf_upper": 641.39
           }
         }
       },
       "60m": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 23.65,
-            "pf_lower": 16.15,
-            "pf_upper": 45.07
+            "pf": 54.65,
+            "pf_lower": 49.45,
+            "pf_upper": 68.18
           },
           "2050-2079": {
-            "pf": 24.66,
-            "pf_lower": 18.79,
-            "pf_upper": 38.02
+            "pf": 66.78,
+            "pf_lower": 60.75,
+            "pf_upper": 82.86
           },
           "2080-2099": {
-            "pf": 29.28,
-            "pf_lower": 22.45,
-            "pf_upper": 48.01
+            "pf": 107.34,
+            "pf_lower": 93.93,
+            "pf_upper": 147.15
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 48.53,
-            "pf_lower": 33.08,
-            "pf_upper": 91.22
+            "pf": 29.26,
+            "pf_lower": 20.28,
+            "pf_upper": 55.54
           },
           "2050-2079": {
-            "pf": 45.61,
-            "pf_lower": 32.77,
-            "pf_upper": 78.86
+            "pf": 27.71,
+            "pf_lower": 21.61,
+            "pf_upper": 44.78
           },
           "2080-2099": {
-            "pf": 25.75,
-            "pf_lower": 22.93,
-            "pf_upper": 31.06
+            "pf": 19.82,
+            "pf_lower": 18.0,
+            "pf_upper": 26.31
           }
         }
       },
       "6h": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 82.36,
-            "pf_lower": 42.29,
-            "pf_upper": 207.67
+            "pf": 83.29,
+            "pf_lower": 63.38,
+            "pf_upper": 135.96
           },
           "2050-2079": {
-            "pf": 72.66,
-            "pf_lower": 48.38,
-            "pf_upper": 127.7
+            "pf": 92.72,
+            "pf_lower": 72.56,
+            "pf_upper": 142.34
           },
           "2080-2099": {
-            "pf": 110.4,
-            "pf_lower": 57.78,
-            "pf_upper": 263.08
+            "pf": 110.87,
+            "pf_lower": 95.23,
+            "pf_upper": 159.56
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 64.47,
-            "pf_lower": 33.18,
-            "pf_upper": 142.25
+            "pf": 65.9,
+            "pf_lower": 50.27,
+            "pf_upper": 104.22
           },
           "2050-2079": {
-            "pf": 96.43,
-            "pf_lower": 37.21,
-            "pf_upper": 248.24
+            "pf": 70.43,
+            "pf_lower": 54.54,
+            "pf_upper": 107.65
           },
           "2080-2099": {
-            "pf": 65.49,
-            "pf_lower": 37.66,
-            "pf_upper": 127.69
+            "pf": 58.61,
+            "pf_lower": 46.61,
+            "pf_upper": 90.16
           }
         }
       },
       "7d": {
         "GFDL-CM3": {
           "2020-2049": {
-            "pf": 155.25,
-            "pf_lower": 100.56,
-            "pf_upper": 501.51
+            "pf": 497.51,
+            "pf_lower": 398.85,
+            "pf_upper": 931.03
           },
           "2050-2079": {
-            "pf": 151.42,
-            "pf_lower": 111.33,
-            "pf_upper": 576.6
+            "pf": 432.36,
+            "pf_lower": 375.76,
+            "pf_upper": 677.84
           },
           "2080-2099": {
-            "pf": 272.48,
-            "pf_lower": 132.2,
-            "pf_upper": 1106.38
+            "pf": 421.98,
+            "pf_lower": 308.67,
+            "pf_upper": 763.76
           }
         },
         "NCAR-CCSM4": {
           "2020-2049": {
-            "pf": 210.2,
-            "pf_lower": 66.87,
-            "pf_upper": 747.3
+            "pf": 271.13,
+            "pf_lower": 188.21,
+            "pf_upper": 530.83
           },
           "2050-2079": {
-            "pf": 278.15,
-            "pf_lower": 82.31,
-            "pf_upper": 897.63
+            "pf": 189.5,
+            "pf_lower": 164.21,
+            "pf_upper": 256.57
           },
           "2080-2099": {
-            "pf": 307.18,
-            "pf_lower": 69.05,
-            "pf_upper": 2425.47
+            "pf": 228.02,
+            "pf_lower": 166.1,
+            "pf_upper": 466.01
+          }
+        }
+      }
+    },
+    "1000": {
+      "10d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 677.74,
+            "pf_lower": 559.5,
+            "pf_upper": 1392.53
+          },
+          "2050-2079": {
+            "pf": 548.86,
+            "pf_lower": 497.57,
+            "pf_upper": 924.91
+          },
+          "2080-2099": {
+            "pf": 519.41,
+            "pf_lower": 415.66,
+            "pf_upper": 1046.66
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 394.05,
+            "pf_lower": 239.07,
+            "pf_upper": 839.15
+          },
+          "2050-2079": {
+            "pf": 246.3,
+            "pf_lower": 190.33,
+            "pf_upper": 364.42
+          },
+          "2080-2099": {
+            "pf": 358.01,
+            "pf_lower": 215.1,
+            "pf_upper": 848.97
+          }
+        }
+      },
+      "12h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 142.74,
+            "pf_lower": 108.37,
+            "pf_upper": 243.63
+          },
+          "2050-2079": {
+            "pf": 161.7,
+            "pf_lower": 123.75,
+            "pf_upper": 272.84
+          },
+          "2080-2099": {
+            "pf": 136.82,
+            "pf_lower": 116.8,
+            "pf_upper": 209.27
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 130.45,
+            "pf_lower": 105.13,
+            "pf_upper": 198.0
+          },
+          "2050-2079": {
+            "pf": 130.67,
+            "pf_lower": 108.54,
+            "pf_upper": 190.35
+          },
+          "2080-2099": {
+            "pf": 128.95,
+            "pf_lower": 107.23,
+            "pf_upper": 196.19
+          }
+        }
+      },
+      "20d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 684.52,
+            "pf_lower": 560.06,
+            "pf_upper": 1393.92
+          },
+          "2050-2079": {
+            "pf": 554.35,
+            "pf_lower": 498.07,
+            "pf_upper": 925.83
+          },
+          "2080-2099": {
+            "pf": 653.12,
+            "pf_lower": 429.85,
+            "pf_upper": 1383.8
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 677.91,
+            "pf_lower": 397.4,
+            "pf_upper": 1569.31
+          },
+          "2050-2079": {
+            "pf": 281.83,
+            "pf_lower": 252.54,
+            "pf_upper": 364.78
+          },
+          "2080-2099": {
+            "pf": 374.86,
+            "pf_lower": 271.9,
+            "pf_upper": 849.82
+          }
+        }
+      },
+      "24h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 220.34,
+            "pf_lower": 170.69,
+            "pf_upper": 377.3
+          },
+          "2050-2079": {
+            "pf": 348.94,
+            "pf_lower": 259.11,
+            "pf_upper": 657.01
+          },
+          "2080-2099": {
+            "pf": 158.05,
+            "pf_lower": 136.89,
+            "pf_upper": 210.96
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 172.94,
+            "pf_lower": 139.81,
+            "pf_upper": 253.1
+          },
+          "2050-2079": {
+            "pf": 148.24,
+            "pf_lower": 123.38,
+            "pf_upper": 209.49
+          },
+          "2080-2099": {
+            "pf": 177.91,
+            "pf_lower": 137.86,
+            "pf_upper": 320.1
+          }
+        }
+      },
+      "2d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 345.37,
+            "pf_lower": 265.67,
+            "pf_upper": 602.62
+          },
+          "2050-2079": {
+            "pf": 403.83,
+            "pf_lower": 307.55,
+            "pf_upper": 717.6
+          },
+          "2080-2099": {
+            "pf": 244.01,
+            "pf_lower": 199.88,
+            "pf_upper": 375.8
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 202.04,
+            "pf_lower": 146.7,
+            "pf_upper": 340.93
+          },
+          "2050-2079": {
+            "pf": 149.86,
+            "pf_lower": 123.51,
+            "pf_upper": 216.34
+          },
+          "2080-2099": {
+            "pf": 239.12,
+            "pf_lower": 160.1,
+            "pf_upper": 548.1
+          }
+        }
+      },
+      "2h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 66.33,
+            "pf_lower": 59.67,
+            "pf_upper": 90.29
+          },
+          "2050-2079": {
+            "pf": 81.2,
+            "pf_lower": 72.87,
+            "pf_upper": 107.68
+          },
+          "2080-2099": {
+            "pf": 132.8,
+            "pf_lower": 114.51,
+            "pf_upper": 208.64
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 49.88,
+            "pf_lower": 34.09,
+            "pf_upper": 102.38
+          },
+          "2050-2079": {
+            "pf": 43.84,
+            "pf_lower": 33.21,
+            "pf_upper": 79.67
+          },
+          "2080-2099": {
+            "pf": 29.53,
+            "pf_lower": 23.92,
+            "pf_upper": 47.68
+          }
+        }
+      },
+      "30d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 691.37,
+            "pf_lower": 566.08,
+            "pf_upper": 1395.31
+          },
+          "2050-2079": {
+            "pf": 583.43,
+            "pf_lower": 498.57,
+            "pf_upper": 926.76
+          },
+          "2080-2099": {
+            "pf": 880.12,
+            "pf_lower": 599.05,
+            "pf_upper": 1838.16
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 684.69,
+            "pf_lower": 397.79,
+            "pf_upper": 1570.88
+          },
+          "2050-2079": {
+            "pf": 299.36,
+            "pf_lower": 252.79,
+            "pf_upper": 399.13
+          },
+          "2080-2099": {
+            "pf": 378.61,
+            "pf_lower": 308.96,
+            "pf_upper": 850.67
+          }
+        }
+      },
+      "3d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 372.5,
+            "pf_lower": 295.12,
+            "pf_upper": 607.38
+          },
+          "2050-2079": {
+            "pf": 532.72,
+            "pf_lower": 414.09,
+            "pf_upper": 922.14
+          },
+          "2080-2099": {
+            "pf": 404.18,
+            "pf_lower": 316.95,
+            "pf_upper": 708.19
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 229.85,
+            "pf_lower": 146.85,
+            "pf_upper": 549.38
+          },
+          "2050-2079": {
+            "pf": 151.35,
+            "pf_lower": 123.63,
+            "pf_upper": 216.55
+          },
+          "2080-2099": {
+            "pf": 241.51,
+            "pf_lower": 160.99,
+            "pf_upper": 548.64
+          }
+        }
+      },
+      "3h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 72.82,
+            "pf_lower": 59.73,
+            "pf_upper": 113.18
+          },
+          "2050-2079": {
+            "pf": 84.44,
+            "pf_lower": 72.94,
+            "pf_upper": 126.69
+          },
+          "2080-2099": {
+            "pf": 134.13,
+            "pf_lower": 116.56,
+            "pf_upper": 208.85
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 56.76,
+            "pf_lower": 36.98,
+            "pf_upper": 121.62
+          },
+          "2050-2079": {
+            "pf": 45.78,
+            "pf_lower": 33.66,
+            "pf_upper": 81.0
+          },
+          "2080-2099": {
+            "pf": 33.39,
+            "pf_lower": 27.33,
+            "pf_upper": 49.85
+          }
+        }
+      },
+      "45d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 698.28,
+            "pf_lower": 566.64,
+            "pf_upper": 1396.71
+          },
+          "2050-2079": {
+            "pf": 589.27,
+            "pf_lower": 508.09,
+            "pf_upper": 927.69
+          },
+          "2080-2099": {
+            "pf": 888.92,
+            "pf_lower": 607.4,
+            "pf_upper": 1840.0
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 691.54,
+            "pf_lower": 466.65,
+            "pf_upper": 1572.45
+          },
+          "2050-2079": {
+            "pf": 357.49,
+            "pf_lower": 283.17,
+            "pf_upper": 501.1
+          },
+          "2080-2099": {
+            "pf": 398.94,
+            "pf_lower": 309.27,
+            "pf_upper": 851.52
+          }
+        }
+      },
+      "4d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 664.39,
+            "pf_lower": 471.14,
+            "pf_upper": 1389.75
+          },
+          "2050-2079": {
+            "pf": 538.04,
+            "pf_lower": 474.17,
+            "pf_upper": 923.06
+          },
+          "2080-2099": {
+            "pf": 408.22,
+            "pf_lower": 328.75,
+            "pf_upper": 708.9
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 325.02,
+            "pf_lower": 226.41,
+            "pf_upper": 602.28
+          },
+          "2050-2079": {
+            "pf": 213.15,
+            "pf_lower": 171.56,
+            "pf_upper": 302.4
+          },
+          "2080-2099": {
+            "pf": 259.08,
+            "pf_lower": 192.08,
+            "pf_upper": 549.19
+          }
+        }
+      },
+      "60d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 705.26,
+            "pf_lower": 567.21,
+            "pf_upper": 1398.11
+          },
+          "2050-2079": {
+            "pf": 595.16,
+            "pf_lower": 508.6,
+            "pf_upper": 975.73
+          },
+          "2080-2099": {
+            "pf": 897.81,
+            "pf_lower": 608.01,
+            "pf_upper": 2149.68
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 698.45,
+            "pf_lower": 566.69,
+            "pf_upper": 1574.02
+          },
+          "2050-2079": {
+            "pf": 444.62,
+            "pf_lower": 306.45,
+            "pf_upper": 724.74
+          },
+          "2080-2099": {
+            "pf": 402.93,
+            "pf_lower": 331.91,
+            "pf_upper": 852.37
+          }
+        }
+      },
+      "60m": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 66.26,
+            "pf_lower": 59.62,
+            "pf_upper": 87.21
+          },
+          "2050-2079": {
+            "pf": 80.4,
+            "pf_lower": 72.8,
+            "pf_upper": 104.63
+          },
+          "2080-2099": {
+            "pf": 131.48,
+            "pf_lower": 114.4,
+            "pf_upper": 194.06
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 31.22,
+            "pf_lower": 20.3,
+            "pf_upper": 73.2
+          },
+          "2050-2079": {
+            "pf": 30.81,
+            "pf_lower": 22.73,
+            "pf_upper": 58.11
+          },
+          "2080-2099": {
+            "pf": 20.01,
+            "pf_lower": 18.02,
+            "pf_upper": 28.84
+          }
+        }
+      },
+      "6h": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 98.52,
+            "pf_lower": 73.18,
+            "pf_upper": 178.32
+          },
+          "2050-2079": {
+            "pf": 106.56,
+            "pf_lower": 81.76,
+            "pf_upper": 178.53
+          },
+          "2080-2099": {
+            "pf": 135.47,
+            "pf_lower": 116.68,
+            "pf_upper": 209.06
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 74.05,
+            "pf_lower": 55.06,
+            "pf_upper": 129.26
+          },
+          "2050-2079": {
+            "pf": 78.84,
+            "pf_lower": 59.65,
+            "pf_upper": 131.24
+          },
+          "2080-2099": {
+            "pf": 63.41,
+            "pf_lower": 49.31,
+            "pf_upper": 109.06
+          }
+        }
+      },
+      "7d": {
+        "GFDL-CM3": {
+          "2020-2049": {
+            "pf": 671.03,
+            "pf_lower": 543.27,
+            "pf_upper": 1391.14
+          },
+          "2050-2079": {
+            "pf": 543.42,
+            "pf_lower": 474.64,
+            "pf_upper": 923.98
+          },
+          "2080-2099": {
+            "pf": 514.27,
+            "pf_lower": 370.49,
+            "pf_upper": 1045.61
+          }
+        },
+        "NCAR-CCSM4": {
+          "2020-2049": {
+            "pf": 328.27,
+            "pf_lower": 226.64,
+            "pf_upper": 706.32
+          },
+          "2050-2079": {
+            "pf": 215.28,
+            "pf_lower": 187.36,
+            "pf_upper": 302.7
+          },
+          "2080-2099": {
+            "pf": 261.67,
+            "pf_lower": 192.27,
+            "pf_upper": 600.63
           }
         }
       }
     }
   },
   "snowfall": {
-    "preview": "model,scenario,decade,SFE\r\nCRU-TS,historical,1910-1919,140\r\nCRU-TS,historical,1920-1929,146\r\nCRU-TS,historical,1930-1939,164\r\nCRU-TS,historical,1940-1949,123\r\nCRU-TS,historical,1950-1959,131\r\nNCAR-CCSM4,rcp85,2050-2059,105\r\nNCAR-CCSM4,rcp85,2060-2069,89\r\nNCAR-CCSM4,rcp85,2070-2079,67\r\nNCAR-CCSM4,rcp85,2080-2089,60\r\nNCAR-CCSM4,rcp85,2090-2099,50\r\n",
+    "preview": "model,scenario,decade,SFE\r\nCRU-TS,historical,1910-1919,117\r\nCRU-TS,historical,1920-1929,118\r\nCRU-TS,historical,1930-1939,99\r\nCRU-TS,historical,1940-1949,82\r\nCRU-TS,historical,1950-1959,90\r\nNCAR-CCSM4,rcp85,2050-2059,120\r\nNCAR-CCSM4,rcp85,2060-2069,113\r\nNCAR-CCSM4,rcp85,2070-2079,95\r\nNCAR-CCSM4,rcp85,2080-2089,104\r\nNCAR-CCSM4,rcp85,2090-2099,107\r\n",
     "summary": {
       "historical": {
-        "sfemax": 164,
-        "sfemean": 132,
-        "sfemin": 105
+        "sfemax": 150,
+        "sfemean": 99,
+        "sfemin": 64
       },
       "projected": {
-        "sfemax": 135,
-        "sfemean": 104,
-        "sfemin": 50
+        "sfemax": 140,
+        "sfemean": 114,
+        "sfemin": 92
       }
     }
   },
   "temperature": {
-    "preview": "model,scenario,year,tas\r\nCRU-TS,historical,1901,0.2\r\nCRU-TS,historical,1902,-0.3\r\nCRU-TS,historical,1903,-0.6\r\nCRU-TS,historical,1904,-0.7\r\nCRU-TS,historical,1905,2\r\nNCAR-CCSM4,rcp85,2096,9.6\r\nNCAR-CCSM4,rcp85,2097,7.6\r\nNCAR-CCSM4,rcp85,2098,11\r\nNCAR-CCSM4,rcp85,2099,7.5\r\nNCAR-CCSM4,rcp85,2100,8\r\n",
+    "preview": "model,scenario,month,year,tasmin,tasmean,tasmax\r\nCRU-TS,historical,January,1901,-29.6,-24.8,-18.9\r\nCRU-TS,historical,January,1902,-26.5,-21.6,-15.5\r\nCRU-TS,historical,January,1903,-32.1,-27,-20.7\r\nCRU-TS,historical,January,1904,-30.4,-26.4,-21\r\nCRU-TS,historical,January,1905,-23.4,-20.1,-15.6\r\nNCAR-CCSM4,rcp85,December,2096,-4.5,-9.9,-0.6\r\nNCAR-CCSM4,rcp85,December,2097,-20.1,-9.9,-12.4\r\nNCAR-CCSM4,rcp85,December,2098,-8.2,-5.2,-3\r\nNCAR-CCSM4,rcp85,December,2099,-10,-12.5,-4.7\r\nNCAR-CCSM4,rcp85,December,2100,-14.5,-17.9,-9.6\r\n",
     "summary": {
-      "2010-2039": {
-        "all": {
-          "tasmax": 6.6,
-          "tasmean": 2.9,
-          "tasmin": -0.5
-        },
-        "jan": {
-          "tasmax": 4.5,
-          "tasmean": -7.8,
-          "tasmin": -38.3
-        },
-        "july": {
-          "tasmax": 26.7,
-          "tasmean": 14.8,
-          "tasmin": 3.3
-        }
-      },
-      "2040-2069": {
-        "all": {
-          "tasmax": 8.8,
-          "tasmean": 4.3,
-          "tasmin": 0.9
-        },
-        "jan": {
-          "tasmax": 6.3,
-          "tasmean": -6.0,
-          "tasmin": -36
-        },
-        "july": {
-          "tasmax": 28.5,
-          "tasmean": 15.9,
-          "tasmin": 5
-        }
-      },
-      "2070-2099": {
-        "all": {
-          "tasmax": 11,
-          "tasmean": 5.6,
-          "tasmin": 1.4
-        },
-        "jan": {
-          "tasmax": 8.7,
-          "tasmean": -4.5,
-          "tasmin": -34.2
-        },
-        "july": {
-          "tasmax": 31,
-          "tasmean": 16.9,
-          "tasmin": 6
-        }
-      },
       "historical": {
-        "all": {
-          "tasmax": 3.5,
-          "tasmean": 1.0,
-          "tasmin": -1.4
+        "CRU-TS": {
+          "historical": {
+            "Annual": {
+              "tasmax": 24.9,
+              "tasmean": -2.6,
+              "tasmin": -38.9
+            },
+            "April": {
+              "tasmax": 11.7,
+              "tasmean": -0.8,
+              "tasmin": -13.4
+            },
+            "August": {
+              "tasmax": 23.2,
+              "tasmean": 13.3,
+              "tasmin": 4.5
+            },
+            "December": {
+              "tasmax": -7.7,
+              "tasmean": -21.7,
+              "tasmin": -35.5
+            },
+            "February": {
+              "tasmax": -4.4,
+              "tasmean": -18.2,
+              "tasmin": -35.5
+            },
+            "January": {
+              "tasmax": -2.4,
+              "tasmean": -22.4,
+              "tasmin": -38.9
+            },
+            "July": {
+              "tasmax": 24.3,
+              "tasmean": 16.2,
+              "tasmin": 8.3
+            },
+            "June": {
+              "tasmax": 24.9,
+              "tasmean": 15.3,
+              "tasmin": 6.1
+            },
+            "March": {
+              "tasmax": 2.9,
+              "tasmean": -11.9,
+              "tasmin": -27.2
+            },
+            "May": {
+              "tasmax": 20.2,
+              "tasmean": 9.1,
+              "tasmin": -1.0
+            },
+            "November": {
+              "tasmax": -1.4,
+              "tasmean": -14.5,
+              "tasmin": -26.1
+            },
+            "October": {
+              "tasmax": 6.6,
+              "tasmean": -3.1,
+              "tasmin": -14.1
+            },
+            "September": {
+              "tasmax": 15.6,
+              "tasmean": 6.9,
+              "tasmin": -1.7
+            }
+          }
+        }
+      },
+      "projected": {
+        "5ModelAvg": {
+          "rcp45": {
+            "Annual": {
+              "2010-2039": {
+                "tasmax": 24.4,
+                "tasmean": -0.6,
+                "tasmin": -28.7
+              },
+              "2040-2069": {
+                "tasmax": 25.2,
+                "tasmean": 0.7,
+                "tasmin": -28.6
+              },
+              "2070-2099": {
+                "tasmax": 25.3,
+                "tasmean": 1.4,
+                "tasmin": -26.1
+              }
+            },
+            "April": {
+              "2010-2039": {
+                "tasmax": 10.2,
+                "tasmean": 1.0,
+                "tasmin": -9.1
+              },
+              "2040-2069": {
+                "tasmax": 10.3,
+                "tasmean": 2.4,
+                "tasmin": -7.3
+              },
+              "2070-2099": {
+                "tasmax": 12.1,
+                "tasmean": 2.9,
+                "tasmin": -5.6
+              }
+            },
+            "August": {
+              "2010-2039": {
+                "tasmax": 22.3,
+                "tasmean": 14.8,
+                "tasmin": 8.5
+              },
+              "2040-2069": {
+                "tasmax": 22.3,
+                "tasmean": 15.8,
+                "tasmin": 9.5
+              },
+              "2070-2099": {
+                "tasmax": 22.9,
+                "tasmean": 16.3,
+                "tasmin": 10.3
+              }
+            },
+            "December": {
+              "2010-2039": {
+                "tasmax": -9.3,
+                "tasmean": -19.1,
+                "tasmin": -28.4
+              },
+              "2040-2069": {
+                "tasmax": -9.1,
+                "tasmean": -17.2,
+                "tasmin": -28.6
+              },
+              "2070-2099": {
+                "tasmax": -6.9,
+                "tasmean": -15.8,
+                "tasmin": -23.8
+              }
+            },
+            "February": {
+              "2010-2039": {
+                "tasmax": -6.3,
+                "tasmean": -15.6,
+                "tasmin": -27.1
+              },
+              "2040-2069": {
+                "tasmax": -3.7,
+                "tasmean": -14.1,
+                "tasmin": -24.7
+              },
+              "2070-2099": {
+                "tasmax": -4.1,
+                "tasmean": -13.4,
+                "tasmin": -23.7
+              }
+            },
+            "January": {
+              "2010-2039": {
+                "tasmax": -10.3,
+                "tasmean": -20.4,
+                "tasmin": -28.7
+              },
+              "2040-2069": {
+                "tasmax": -9.2,
+                "tasmean": -18.3,
+                "tasmin": -26.9
+              },
+              "2070-2099": {
+                "tasmax": -7.5,
+                "tasmean": -17.3,
+                "tasmin": -26.1
+              }
+            },
+            "July": {
+              "2010-2039": {
+                "tasmax": 24.1,
+                "tasmean": 17.8,
+                "tasmin": 11.3
+              },
+              "2040-2069": {
+                "tasmax": 25.2,
+                "tasmean": 18.7,
+                "tasmin": 12.1
+              },
+              "2070-2099": {
+                "tasmax": 25.2,
+                "tasmean": 19.1,
+                "tasmin": 13.0
+              }
+            },
+            "June": {
+              "2010-2039": {
+                "tasmax": 24.4,
+                "tasmean": 16.8,
+                "tasmin": 9.0
+              },
+              "2040-2069": {
+                "tasmax": 24.3,
+                "tasmean": 17.6,
+                "tasmin": 9.8
+              },
+              "2070-2099": {
+                "tasmax": 25.3,
+                "tasmean": 18.1,
+                "tasmin": 10.0
+              }
+            },
+            "March": {
+              "2010-2039": {
+                "tasmax": 2.5,
+                "tasmean": -8.5,
+                "tasmin": -17.7
+              },
+              "2040-2069": {
+                "tasmax": 2.5,
+                "tasmean": -7.2,
+                "tasmin": -17.1
+              },
+              "2070-2099": {
+                "tasmax": 3.2,
+                "tasmean": -6.8,
+                "tasmin": -17.2
+              }
+            },
+            "May": {
+              "2010-2039": {
+                "tasmax": 18.7,
+                "tasmean": 10.6,
+                "tasmin": 1.8
+              },
+              "2040-2069": {
+                "tasmax": 20.4,
+                "tasmean": 11.9,
+                "tasmin": 2.8
+              },
+              "2070-2099": {
+                "tasmax": 19.9,
+                "tasmean": 11.9,
+                "tasmin": 3.6
+              }
+            },
+            "November": {
+              "2010-2039": {
+                "tasmax": -3.3,
+                "tasmean": -12.5,
+                "tasmin": -21.1
+              },
+              "2040-2069": {
+                "tasmax": -3.5,
+                "tasmean": -10.7,
+                "tasmin": -19.8
+              },
+              "2070-2099": {
+                "tasmax": -2.5,
+                "tasmean": -9.4,
+                "tasmin": -16.8
+              }
+            },
+            "October": {
+              "2010-2039": {
+                "tasmax": 5.7,
+                "tasmean": -1.5,
+                "tasmin": -8.9
+              },
+              "2040-2069": {
+                "tasmax": 6.8,
+                "tasmean": -0.2,
+                "tasmin": -6.8
+              },
+              "2070-2099": {
+                "tasmax": 6.8,
+                "tasmean": 0.7,
+                "tasmin": -5.5
+              }
+            },
+            "September": {
+              "2010-2039": {
+                "tasmax": 15.5,
+                "tasmean": 8.7,
+                "tasmin": 2.5
+              },
+              "2040-2069": {
+                "tasmax": 16.7,
+                "tasmean": 9.7,
+                "tasmin": 3.7
+              },
+              "2070-2099": {
+                "tasmax": 16.7,
+                "tasmean": 10.4,
+                "tasmin": 5.0
+              }
+            }
+          },
+          "rcp85": {
+            "Annual": {
+              "2010-2039": {
+                "tasmax": 24.4,
+                "tasmean": -0.3,
+                "tasmin": -30.5
+              },
+              "2040-2069": {
+                "tasmax": 26.6,
+                "tasmean": 1.6,
+                "tasmin": -26.6
+              },
+              "2070-2099": {
+                "tasmax": 27.2,
+                "tasmean": 3.6,
+                "tasmin": -22.7
+              }
+            },
+            "April": {
+              "2010-2039": {
+                "tasmax": 11.9,
+                "tasmean": 1.0,
+                "tasmin": -8.0
+              },
+              "2040-2069": {
+                "tasmax": 11.4,
+                "tasmean": 3.0,
+                "tasmin": -6.5
+              },
+              "2070-2099": {
+                "tasmax": 12.9,
+                "tasmean": 4.6,
+                "tasmin": -3.2
+              }
+            },
+            "August": {
+              "2010-2039": {
+                "tasmax": 22.3,
+                "tasmean": 15.1,
+                "tasmin": 9.1
+              },
+              "2040-2069": {
+                "tasmax": 23.1,
+                "tasmean": 16.6,
+                "tasmin": 10.2
+              },
+              "2070-2099": {
+                "tasmax": 24.9,
+                "tasmean": 18.2,
+                "tasmin": 11.2
+              }
+            },
+            "December": {
+              "2010-2039": {
+                "tasmax": -8.1,
+                "tasmean": -18.3,
+                "tasmin": -28.9
+              },
+              "2040-2069": {
+                "tasmax": -7.6,
+                "tasmean": -16.0,
+                "tasmin": -26.6
+              },
+              "2070-2099": {
+                "tasmax": -5.9,
+                "tasmean": -12.6,
+                "tasmin": -21.6
+              }
+            },
+            "February": {
+              "2010-2039": {
+                "tasmax": -4.8,
+                "tasmean": -14.6,
+                "tasmin": -25.1
+              },
+              "2040-2069": {
+                "tasmax": -2.8,
+                "tasmean": -13.2,
+                "tasmin": -22.3
+              },
+              "2070-2099": {
+                "tasmax": -2.2,
+                "tasmean": -11.3,
+                "tasmin": -19.4
+              }
+            },
+            "January": {
+              "2010-2039": {
+                "tasmax": -8.0,
+                "tasmean": -18.9,
+                "tasmin": -30.5
+              },
+              "2040-2069": {
+                "tasmax": -6.3,
+                "tasmean": -16.4,
+                "tasmin": -25.2
+              },
+              "2070-2099": {
+                "tasmax": -5.9,
+                "tasmean": -13.4,
+                "tasmin": -22.7
+              }
+            },
+            "July": {
+              "2010-2039": {
+                "tasmax": 24.4,
+                "tasmean": 17.8,
+                "tasmin": 11.6
+              },
+              "2040-2069": {
+                "tasmax": 26.6,
+                "tasmean": 19.4,
+                "tasmin": 12.4
+              },
+              "2070-2099": {
+                "tasmax": 27.2,
+                "tasmean": 20.8,
+                "tasmin": 14.3
+              }
+            },
+            "June": {
+              "2010-2039": {
+                "tasmax": 24.3,
+                "tasmean": 16.5,
+                "tasmin": 8.1
+              },
+              "2040-2069": {
+                "tasmax": 26.5,
+                "tasmean": 18.2,
+                "tasmin": 10.4
+              },
+              "2070-2099": {
+                "tasmax": 26.7,
+                "tasmean": 19.7,
+                "tasmin": 12.2
+              }
+            },
+            "March": {
+              "2010-2039": {
+                "tasmax": 2.3,
+                "tasmean": -8.4,
+                "tasmin": -19.0
+              },
+              "2040-2069": {
+                "tasmax": 3.7,
+                "tasmean": -6.1,
+                "tasmin": -17.6
+              },
+              "2070-2099": {
+                "tasmax": 3.7,
+                "tasmean": -4.4,
+                "tasmin": -12.8
+              }
+            },
+            "May": {
+              "2010-2039": {
+                "tasmax": 19.2,
+                "tasmean": 10.7,
+                "tasmin": 0.0
+              },
+              "2040-2069": {
+                "tasmax": 21.3,
+                "tasmean": 12.1,
+                "tasmin": 2.4
+              },
+              "2070-2099": {
+                "tasmax": 22.2,
+                "tasmean": 13.7,
+                "tasmin": 5.8
+              }
+            },
+            "November": {
+              "2010-2039": {
+                "tasmax": -3.7,
+                "tasmean": -12.1,
+                "tasmin": -21.8
+              },
+              "2040-2069": {
+                "tasmax": -1.5,
+                "tasmean": -9.3,
+                "tasmin": -18.8
+              },
+              "2070-2099": {
+                "tasmax": -0.7,
+                "tasmean": -6.3,
+                "tasmin": -13.7
+              }
+            },
+            "October": {
+              "2010-2039": {
+                "tasmax": 5.1,
+                "tasmean": -1.4,
+                "tasmin": -7.7
+              },
+              "2040-2069": {
+                "tasmax": 6.7,
+                "tasmean": 0.5,
+                "tasmin": -7.7
+              },
+              "2070-2099": {
+                "tasmax": 8.2,
+                "tasmean": 2.5,
+                "tasmin": -4.9
+              }
+            },
+            "September": {
+              "2010-2039": {
+                "tasmax": 15.3,
+                "tasmean": 8.8,
+                "tasmin": 2.8
+              },
+              "2040-2069": {
+                "tasmax": 17.0,
+                "tasmean": 10.4,
+                "tasmin": 4.4
+              },
+              "2070-2099": {
+                "tasmax": 19.1,
+                "tasmean": 12.1,
+                "tasmin": 6.9
+              }
+            }
+          }
         },
-        "jan": {
-          "tasmax": 4.1,
-          "tasmean": -10.4,
-          "tasmin": -26.6
+        "GFDL-CM3": {
+          "rcp45": {
+            "April": {
+              "2010-2039": {
+                "tasmax": 12.4,
+                "tasmean": 3.0,
+                "tasmin": -7.2
+              },
+              "2040-2069": {
+                "tasmax": 14.4,
+                "tasmean": 4.8,
+                "tasmin": -5.2
+              },
+              "2070-2099": {
+                "tasmax": 14.9,
+                "tasmean": 5.6,
+                "tasmin": -4.2
+              }
+            },
+            "August": {
+              "2010-2039": {
+                "tasmax": 22.2,
+                "tasmean": 15.8,
+                "tasmin": 10.1
+              },
+              "2040-2069": {
+                "tasmax": 23.5,
+                "tasmean": 17.1,
+                "tasmin": 11.4
+              },
+              "2070-2099": {
+                "tasmax": 23.7,
+                "tasmean": 17.8,
+                "tasmin": 11.9
+              }
+            },
+            "December": {
+              "2010-2039": {
+                "tasmax": -6.8,
+                "tasmean": -17.8,
+                "tasmin": -30.3
+              },
+              "2040-2069": {
+                "tasmax": -4.1,
+                "tasmean": -14.6,
+                "tasmin": -26.3
+              },
+              "2070-2099": {
+                "tasmax": -6.1,
+                "tasmean": -12.8,
+                "tasmin": -19.2
+              }
+            },
+            "February": {
+              "2010-2039": {
+                "tasmax": -2.9,
+                "tasmean": -14.9,
+                "tasmin": -29.0
+              },
+              "2040-2069": {
+                "tasmax": -1.8,
+                "tasmean": -11.9,
+                "tasmin": -27.3
+              },
+              "2070-2099": {
+                "tasmax": -0.6,
+                "tasmean": -10.9,
+                "tasmin": -18.3
+              }
+            },
+            "January": {
+              "2010-2039": {
+                "tasmax": -7.9,
+                "tasmean": -19.1,
+                "tasmin": -33.2
+              },
+              "2040-2069": {
+                "tasmax": -4.8,
+                "tasmean": -14.8,
+                "tasmin": -28.2
+              },
+              "2070-2099": {
+                "tasmax": -4.4,
+                "tasmean": -14.5,
+                "tasmin": -25.7
+              }
+            },
+            "July": {
+              "2010-2039": {
+                "tasmax": 24.5,
+                "tasmean": 18.4,
+                "tasmin": 11.8
+              },
+              "2040-2069": {
+                "tasmax": 26.0,
+                "tasmean": 20.2,
+                "tasmin": 13.5
+              },
+              "2070-2099": {
+                "tasmax": 26.1,
+                "tasmean": 20.8,
+                "tasmin": 15.0
+              }
+            },
+            "June": {
+              "2010-2039": {
+                "tasmax": 24.5,
+                "tasmean": 17.5,
+                "tasmin": 10.2
+              },
+              "2040-2069": {
+                "tasmax": 25.6,
+                "tasmean": 19.4,
+                "tasmin": 12.2
+              },
+              "2070-2099": {
+                "tasmax": 26.3,
+                "tasmean": 20.3,
+                "tasmin": 13.2
+              }
+            },
+            "March": {
+              "2010-2039": {
+                "tasmax": 3.7,
+                "tasmean": -7.9,
+                "tasmin": -18.1
+              },
+              "2040-2069": {
+                "tasmax": 4.9,
+                "tasmean": -4.6,
+                "tasmin": -13.5
+              },
+              "2070-2099": {
+                "tasmax": 6.6,
+                "tasmean": -4.8,
+                "tasmin": -14.6
+              }
+            },
+            "May": {
+              "2010-2039": {
+                "tasmax": 20.2,
+                "tasmean": 12.1,
+                "tasmin": 4.2
+              },
+              "2040-2069": {
+                "tasmax": 23.3,
+                "tasmean": 13.8,
+                "tasmin": 3.5
+              },
+              "2070-2099": {
+                "tasmax": 22.9,
+                "tasmean": 15.2,
+                "tasmin": 7.5
+              }
+            },
+            "November": {
+              "2010-2039": {
+                "tasmax": -2.3,
+                "tasmean": -11.4,
+                "tasmin": -24.5
+              },
+              "2040-2069": {
+                "tasmax": -1.9,
+                "tasmean": -8.5,
+                "tasmin": -14.6
+              },
+              "2070-2099": {
+                "tasmax": -0.9,
+                "tasmean": -6.4,
+                "tasmin": -14.4
+              }
+            },
+            "October": {
+              "2010-2039": {
+                "tasmax": 6.8,
+                "tasmean": -1.4,
+                "tasmin": -9.1
+              },
+              "2040-2069": {
+                "tasmax": 8.7,
+                "tasmean": 1.1,
+                "tasmin": -4.1
+              },
+              "2070-2099": {
+                "tasmax": 9.1,
+                "tasmean": 1.8,
+                "tasmin": -4.9
+              }
+            },
+            "September": {
+              "2010-2039": {
+                "tasmax": 16.4,
+                "tasmean": 9.8,
+                "tasmin": 3.9
+              },
+              "2040-2069": {
+                "tasmax": 19.0,
+                "tasmean": 11.6,
+                "tasmin": 5.1
+              },
+              "2070-2099": {
+                "tasmax": 18.6,
+                "tasmean": 11.9,
+                "tasmin": 6.4
+              }
+            }
+          },
+          "rcp85": {
+            "April": {
+              "2010-2039": {
+                "tasmax": 13.5,
+                "tasmean": 2.5,
+                "tasmin": -7.2
+              },
+              "2040-2069": {
+                "tasmax": 14.9,
+                "tasmean": 5.4,
+                "tasmin": -4.4
+              },
+              "2070-2099": {
+                "tasmax": 15.1,
+                "tasmean": 7.3,
+                "tasmin": -2.8
+              }
+            },
+            "August": {
+              "2010-2039": {
+                "tasmax": 22.3,
+                "tasmean": 15.9,
+                "tasmin": 9.5
+              },
+              "2040-2069": {
+                "tasmax": 25.0,
+                "tasmean": 18.0,
+                "tasmin": 10.9
+              },
+              "2070-2099": {
+                "tasmax": 27.5,
+                "tasmean": 20.0,
+                "tasmin": 13.2
+              }
+            },
+            "December": {
+              "2010-2039": {
+                "tasmax": -7.3,
+                "tasmean": -16.9,
+                "tasmin": -30.4
+              },
+              "2040-2069": {
+                "tasmax": -5.4,
+                "tasmean": -13.3,
+                "tasmin": -21.7
+              },
+              "2070-2099": {
+                "tasmax": -3.3,
+                "tasmean": -9.7,
+                "tasmin": -15.6
+              }
+            },
+            "February": {
+              "2010-2039": {
+                "tasmax": -1.7,
+                "tasmean": -13.2,
+                "tasmin": -25.5
+              },
+              "2040-2069": {
+                "tasmax": -2.6,
+                "tasmean": -10.9,
+                "tasmin": -20.1
+              },
+              "2070-2099": {
+                "tasmax": 1.2,
+                "tasmean": -7.9,
+                "tasmin": -21.2
+              }
+            },
+            "January": {
+              "2010-2039": {
+                "tasmax": -6.8,
+                "tasmean": -16.0,
+                "tasmin": -32.5
+              },
+              "2040-2069": {
+                "tasmax": -4.6,
+                "tasmean": -12.5,
+                "tasmin": -27.8
+              },
+              "2070-2099": {
+                "tasmax": -1.6,
+                "tasmean": -9.6,
+                "tasmin": -17.3
+              }
+            },
+            "July": {
+              "2010-2039": {
+                "tasmax": 25.8,
+                "tasmean": 18.8,
+                "tasmin": 12.1
+              },
+              "2040-2069": {
+                "tasmax": 26.8,
+                "tasmean": 20.9,
+                "tasmin": 14.3
+              },
+              "2070-2099": {
+                "tasmax": 30.4,
+                "tasmean": 23.4,
+                "tasmin": 17.1
+              }
+            },
+            "June": {
+              "2010-2039": {
+                "tasmax": 23.7,
+                "tasmean": 17.4,
+                "tasmin": 9.2
+              },
+              "2040-2069": {
+                "tasmax": 26.7,
+                "tasmean": 20.6,
+                "tasmin": 13.1
+              },
+              "2070-2099": {
+                "tasmax": 29.7,
+                "tasmean": 22.5,
+                "tasmin": 15.0
+              }
+            },
+            "March": {
+              "2010-2039": {
+                "tasmax": 4.9,
+                "tasmean": -7.3,
+                "tasmin": -20.5
+              },
+              "2040-2069": {
+                "tasmax": 5.5,
+                "tasmean": -4.9,
+                "tasmin": -15.0
+              },
+              "2070-2099": {
+                "tasmax": 6.7,
+                "tasmean": -2.1,
+                "tasmin": -10.0
+              }
+            },
+            "May": {
+              "2010-2039": {
+                "tasmax": 21.2,
+                "tasmean": 11.8,
+                "tasmin": 2.6
+              },
+              "2040-2069": {
+                "tasmax": 22.0,
+                "tasmean": 14.8,
+                "tasmin": 6.8
+              },
+              "2070-2099": {
+                "tasmax": 25.7,
+                "tasmean": 17.0,
+                "tasmin": 7.7
+              }
+            },
+            "November": {
+              "2010-2039": {
+                "tasmax": -0.5,
+                "tasmean": -10.2,
+                "tasmin": -17.4
+              },
+              "2040-2069": {
+                "tasmax": -1.1,
+                "tasmean": -7.8,
+                "tasmin": -14.0
+              },
+              "2070-2099": {
+                "tasmax": 1.1,
+                "tasmean": -3.8,
+                "tasmin": -8.1
+              }
+            },
+            "October": {
+              "2010-2039": {
+                "tasmax": 5.4,
+                "tasmean": -1.5,
+                "tasmin": -7.3
+              },
+              "2040-2069": {
+                "tasmax": 8.7,
+                "tasmean": 1.7,
+                "tasmin": -4.2
+              },
+              "2070-2099": {
+                "tasmax": 9.5,
+                "tasmean": 4.1,
+                "tasmin": -1.6
+              }
+            },
+            "September": {
+              "2010-2039": {
+                "tasmax": 16.6,
+                "tasmean": 9.5,
+                "tasmin": 1.2
+              },
+              "2040-2069": {
+                "tasmax": 19.2,
+                "tasmean": 12.2,
+                "tasmin": 6.7
+              },
+              "2070-2099": {
+                "tasmax": 21.1,
+                "tasmean": 13.9,
+                "tasmin": 7.9
+              }
+            }
+          }
         },
-        "july": {
-          "tasmax": 21.2,
-          "tasmean": 13.0,
-          "tasmin": 6
+        "NCAR-CCSM4": {
+          "rcp45": {
+            "April": {
+              "2010-2039": {
+                "tasmax": 11.3,
+                "tasmean": 1.4,
+                "tasmin": -9.6
+              },
+              "2040-2069": {
+                "tasmax": 12.5,
+                "tasmean": 2.4,
+                "tasmin": -9.3
+              },
+              "2070-2099": {
+                "tasmax": 15.0,
+                "tasmean": 2.8,
+                "tasmin": -5.9
+              }
+            },
+            "August": {
+              "2010-2039": {
+                "tasmax": 26.5,
+                "tasmean": 14.2,
+                "tasmin": 7.2
+              },
+              "2040-2069": {
+                "tasmax": 26.7,
+                "tasmean": 15.6,
+                "tasmin": 8.8
+              },
+              "2070-2099": {
+                "tasmax": 27.5,
+                "tasmean": 16.2,
+                "tasmin": 8.3
+              }
+            },
+            "December": {
+              "2010-2039": {
+                "tasmax": -6.1,
+                "tasmean": -20.4,
+                "tasmin": -33.5
+              },
+              "2040-2069": {
+                "tasmax": -6.9,
+                "tasmean": -18.6,
+                "tasmin": -33.8
+              },
+              "2070-2099": {
+                "tasmax": -5.1,
+                "tasmean": -16.8,
+                "tasmin": -28.5
+              }
+            },
+            "February": {
+              "2010-2039": {
+                "tasmax": 2.3,
+                "tasmean": -12.2,
+                "tasmin": -32.0
+              },
+              "2040-2069": {
+                "tasmax": 0.7,
+                "tasmean": -12.1,
+                "tasmin": -31.9
+              },
+              "2070-2099": {
+                "tasmax": 3.5,
+                "tasmean": -11.5,
+                "tasmin": -27.1
+              }
+            },
+            "January": {
+              "2010-2039": {
+                "tasmax": -5.7,
+                "tasmean": -20.0,
+                "tasmin": -35.9
+              },
+              "2040-2069": {
+                "tasmax": -5.3,
+                "tasmean": -19.0,
+                "tasmin": -31.9
+              },
+              "2070-2099": {
+                "tasmax": -4.6,
+                "tasmean": -17.3,
+                "tasmin": -33.4
+              }
+            },
+            "July": {
+              "2010-2039": {
+                "tasmax": 28.9,
+                "tasmean": 18.0,
+                "tasmin": 11.6
+              },
+              "2040-2069": {
+                "tasmax": 31.1,
+                "tasmean": 19.0,
+                "tasmin": 11.0
+              },
+              "2070-2099": {
+                "tasmax": 31.0,
+                "tasmean": 19.7,
+                "tasmin": 10.6
+              }
+            },
+            "June": {
+              "2010-2039": {
+                "tasmax": 32.4,
+                "tasmean": 18.0,
+                "tasmin": 8.4
+              },
+              "2040-2069": {
+                "tasmax": 29.9,
+                "tasmean": 18.3,
+                "tasmin": 7.5
+              },
+              "2070-2099": {
+                "tasmax": 33.8,
+                "tasmean": 19.3,
+                "tasmin": 10.7
+              }
+            },
+            "March": {
+              "2010-2039": {
+                "tasmax": 5.2,
+                "tasmean": -7.1,
+                "tasmin": -20.5
+              },
+              "2040-2069": {
+                "tasmax": 2.8,
+                "tasmean": -7.1,
+                "tasmin": -19.3
+              },
+              "2070-2099": {
+                "tasmax": 6.7,
+                "tasmean": -5.2,
+                "tasmin": -21.0
+              }
+            },
+            "May": {
+              "2010-2039": {
+                "tasmax": 22.3,
+                "tasmean": 11.0,
+                "tasmin": 1.1
+              },
+              "2040-2069": {
+                "tasmax": 21.7,
+                "tasmean": 12.0,
+                "tasmin": 2.0
+              },
+              "2070-2099": {
+                "tasmax": 24.7,
+                "tasmean": 12.4,
+                "tasmin": 4.9
+              }
+            },
+            "November": {
+              "2010-2039": {
+                "tasmax": -2.1,
+                "tasmean": -11.9,
+                "tasmin": -22.3
+              },
+              "2040-2069": {
+                "tasmax": -1.3,
+                "tasmean": -11.2,
+                "tasmin": -26.3
+              },
+              "2070-2099": {
+                "tasmax": 2.4,
+                "tasmean": -9.7,
+                "tasmin": -18.3
+              }
+            },
+            "October": {
+              "2010-2039": {
+                "tasmax": 7.2,
+                "tasmean": -0.6,
+                "tasmin": -7.2
+              },
+              "2040-2069": {
+                "tasmax": 11.3,
+                "tasmean": 0.2,
+                "tasmin": -8.8
+              },
+              "2070-2099": {
+                "tasmax": 7.7,
+                "tasmean": 0.9,
+                "tasmin": -7.6
+              }
+            },
+            "September": {
+              "2010-2039": {
+                "tasmax": 20.0,
+                "tasmean": 8.9,
+                "tasmin": 3.4
+              },
+              "2040-2069": {
+                "tasmax": 18.9,
+                "tasmean": 9.4,
+                "tasmin": 3.3
+              },
+              "2070-2099": {
+                "tasmax": 19.9,
+                "tasmean": 10.4,
+                "tasmin": 2.0
+              }
+            }
+          },
+          "rcp85": {
+            "April": {
+              "2010-2039": {
+                "tasmax": 12.5,
+                "tasmean": 0.7,
+                "tasmin": -7.5
+              },
+              "2040-2069": {
+                "tasmax": 14.5,
+                "tasmean": 2.4,
+                "tasmin": -12.5
+              },
+              "2070-2099": {
+                "tasmax": 18.2,
+                "tasmean": 5.7,
+                "tasmin": -7.9
+              }
+            },
+            "August": {
+              "2010-2039": {
+                "tasmax": 26.4,
+                "tasmean": 14.7,
+                "tasmin": 8.3
+              },
+              "2040-2069": {
+                "tasmax": 25.8,
+                "tasmean": 16.4,
+                "tasmin": 10.7
+              },
+              "2070-2099": {
+                "tasmax": 28.5,
+                "tasmean": 18.4,
+                "tasmin": 9.3
+              }
+            },
+            "December": {
+              "2010-2039": {
+                "tasmax": -2.6,
+                "tasmean": -19.3,
+                "tasmin": -35.6
+              },
+              "2040-2069": {
+                "tasmax": -3.4,
+                "tasmean": -17.1,
+                "tasmin": -36.1
+              },
+              "2070-2099": {
+                "tasmax": -0.6,
+                "tasmean": -11.7,
+                "tasmin": -25.3
+              }
+            },
+            "February": {
+              "2010-2039": {
+                "tasmax": 0.0,
+                "tasmean": -12.3,
+                "tasmin": -30.6
+              },
+              "2040-2069": {
+                "tasmax": 2.5,
+                "tasmean": -10.7,
+                "tasmin": -27.9
+              },
+              "2070-2099": {
+                "tasmax": 4.9,
+                "tasmean": -8.5,
+                "tasmin": -22.9
+              }
+            },
+            "January": {
+              "2010-2039": {
+                "tasmax": -4.8,
+                "tasmean": -20.2,
+                "tasmin": -42.8
+              },
+              "2040-2069": {
+                "tasmax": -2.0,
+                "tasmean": -16.8,
+                "tasmin": -30.5
+              },
+              "2070-2099": {
+                "tasmax": -1.1,
+                "tasmean": -12.6,
+                "tasmin": -28.0
+              }
+            },
+            "July": {
+              "2010-2039": {
+                "tasmax": 29.4,
+                "tasmean": 17.2,
+                "tasmin": 9.8
+              },
+              "2040-2069": {
+                "tasmax": 32.9,
+                "tasmean": 19.7,
+                "tasmin": 11.4
+              },
+              "2070-2099": {
+                "tasmax": 32.8,
+                "tasmean": 20.8,
+                "tasmin": 13.0
+              }
+            },
+            "June": {
+              "2010-2039": {
+                "tasmax": 31.7,
+                "tasmean": 16.9,
+                "tasmin": 7.6
+              },
+              "2040-2069": {
+                "tasmax": 33.8,
+                "tasmean": 19.2,
+                "tasmin": 8.5
+              },
+              "2070-2099": {
+                "tasmax": 32.5,
+                "tasmean": 21.4,
+                "tasmin": 11.4
+              }
+            },
+            "March": {
+              "2010-2039": {
+                "tasmax": 6.4,
+                "tasmean": -8.4,
+                "tasmin": -27.1
+              },
+              "2040-2069": {
+                "tasmax": 6.1,
+                "tasmean": -5.7,
+                "tasmin": -23.2
+              },
+              "2070-2099": {
+                "tasmax": 10.8,
+                "tasmean": -3.0,
+                "tasmin": -16.2
+              }
+            },
+            "May": {
+              "2010-2039": {
+                "tasmax": 21.3,
+                "tasmean": 10.6,
+                "tasmin": 1.1
+              },
+              "2040-2069": {
+                "tasmax": 26.2,
+                "tasmean": 12.4,
+                "tasmin": 1.4
+              },
+              "2070-2099": {
+                "tasmax": 26.4,
+                "tasmean": 14.6,
+                "tasmin": 4.5
+              }
+            },
+            "November": {
+              "2010-2039": {
+                "tasmax": -1.1,
+                "tasmean": -11.7,
+                "tasmin": -25.9
+              },
+              "2040-2069": {
+                "tasmax": 3.7,
+                "tasmean": -9.3,
+                "tasmin": -22.0
+              },
+              "2070-2099": {
+                "tasmax": 4.4,
+                "tasmean": -6.3,
+                "tasmin": -18.0
+              }
+            },
+            "October": {
+              "2010-2039": {
+                "tasmax": 9.0,
+                "tasmean": -0.4,
+                "tasmin": -9.4
+              },
+              "2040-2069": {
+                "tasmax": 9.7,
+                "tasmean": 1.8,
+                "tasmin": -6.1
+              },
+              "2070-2099": {
+                "tasmax": 12.0,
+                "tasmean": 3.9,
+                "tasmin": -6.0
+              }
+            },
+            "September": {
+              "2010-2039": {
+                "tasmax": 18.5,
+                "tasmean": 8.4,
+                "tasmin": 2.7
+              },
+              "2040-2069": {
+                "tasmax": 18.2,
+                "tasmean": 10.1,
+                "tasmin": 3.7
+              },
+              "2070-2099": {
+                "tasmax": 20.5,
+                "tasmean": 12.1,
+                "tasmin": 6.9
+              }
+            }
+          }
         }
       }
     }
   },
   "thawing_index": {
-    "preview": "model,year,dd\r\nERA-Interim,1980,717\r\nERA-Interim,1981,766\r\nERA-Interim,1982,625\r\nERA-Interim,1983,695\r\nERA-Interim,1984,716\r\nNCAR-CCSM4,2096,3765\r\nNCAR-CCSM4,2097,4572\r\nNCAR-CCSM4,2098,3394\r\nNCAR-CCSM4,2099,4167\r\nNCAR-CCSM4,2100,4272\r\n",
+    "preview": "model,year,dd\r\nERA-Interim,1980,3705\r\nERA-Interim,1981,3650\r\nERA-Interim,1982,3631\r\nERA-Interim,1983,3724\r\nERA-Interim,1984,3616\r\nNCAR-CCSM4,2096,4726\r\nNCAR-CCSM4,2097,4978\r\nNCAR-CCSM4,2098,3798\r\nNCAR-CCSM4,2099,4985\r\nNCAR-CCSM4,2100,4809\r\n",
     "summary": {
       "2010-2039": {
-        "ddmax": 3304,
-        "ddmean": 2330,
-        "ddmin": 1653
+        "ddmax": 4635,
+        "ddmean": 3412,
+        "ddmin": 2661
       },
       "2040-2069": {
-        "ddmax": 4566,
-        "ddmean": 3167,
-        "ddmin": 1658
+        "ddmax": 5358,
+        "ddmean": 4150,
+        "ddmin": 2612
       },
       "2070-2099": {
-        "ddmax": 5539,
-        "ddmean": 4203,
-        "ddmin": 2720
+        "ddmax": 6489,
+        "ddmean": 5061,
+        "ddmin": 3626
       },
       "historical": {
-        "ddmax": 881,
-        "ddmean": 737,
-        "ddmin": 589
+        "ddmax": 4581,
+        "ddmean": 3894,
+        "ddmin": 3248
       }
     }
   },
   "wet_days_per_year": {
     "2010-2039": {
-      "wdpymax": 218,
-      "wdpymean": 173,
-      "wdpymin": 132
+      "wdpymax": 167,
+      "wdpymean": 119,
+      "wdpymin": 88
     },
     "2040-2069": {
-      "wdpymax": 212,
-      "wdpymean": 178,
-      "wdpymin": 139
+      "wdpymax": 179,
+      "wdpymean": 128,
+      "wdpymin": 87
     },
     "2070-2099": {
-      "wdpymax": 213,
-      "wdpymean": 181,
-      "wdpymin": 132
+      "wdpymax": 177,
+      "wdpymean": 131,
+      "wdpymin": 88
     },
     "historical": {
-      "wdpymax": 175,
-      "wdpymean": 146,
-      "wdpymin": 118
+      "wdpymax": 129,
+      "wdpymean": 106,
+      "wdpymin": 83
     }
   }
 }

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -198,10 +198,8 @@ export default {
       currentURL: '',
     }
   },
-  created() {
-    this.currentURL = window.location.href
-  },
   mounted() {
+    this.currentURL = window.location.href
     this.$fetch()
   },
 

--- a/components/reports/PrecipitationFrequency.vue
+++ b/components/reports/PrecipitationFrequency.vue
@@ -63,14 +63,19 @@
         </tr>
         <tr>
           <th></th>
-          <th v-for="interval in [2, 5, 10, 25, 50, 100, 200, 500, 1000]">
+          <th
+            v-for="(interval, intIndex) in [
+              2, 5, 10, 25, 50, 100, 200, 500, 1000,
+            ]"
+            :key="intIndex"
+          >
             1 / {{ interval }}
           </th>
         </tr>
       </thead>
       <tbody>
         <tr
-          v-for="duration in [
+          v-for="(duration, durIndex) in [
             '60m',
             '2h',
             '3h',
@@ -87,9 +92,15 @@
             '45d',
             '60d',
           ]"
+          :key="durIndex"
         >
           <td>{{ duration }}</td>
-          <td v-for="interval in [2, 5, 10, 25, 50, 100, 200, 500, 1000]">
+          <td
+            v-for="(interval, intIndex) in [
+              2, 5, 10, 25, 50, 100, 200, 500, 1000,
+            ]"
+            :key="intIndex"
+          >
             {{
               results.proj_precip[
                 `pr_${interval}_${duration}_${radioModel}_${radioEra}_mean`

--- a/components/reports/Temperature.vue
+++ b/components/reports/Temperature.vue
@@ -141,6 +141,53 @@
     </div>
 
     <h4 class="title is-5 mb-1">Mean Monthly Temperatures</h4>
+    <div class="radio-units no-print">
+      <div>
+        <b-field label="Model">
+          <b-radio
+            v-model="radioModel"
+            name="radioModel"
+            native-value="5ModelAvg"
+          >
+            5 Model Average
+          </b-radio>
+          <b-radio
+            v-model="radioModel"
+            name="radioModel"
+            native-value="GFDL-CM3"
+          >
+            GFDL-CM3
+          </b-radio>
+          <b-radio
+            v-model="radioModel"
+            name="radioModel"
+            native-value="NCAR-CCSM4"
+          >
+            NCAR-CCSM4
+          </b-radio>
+        </b-field>
+      </div>
+    </div>
+    <div class="radio-units no-print">
+      <div>
+        <b-field label="Scenario">
+          <b-radio
+            v-model="radioScenario"
+            name="radioScenario"
+            native-value="rcp45"
+          >
+            RCP 4.5
+          </b-radio>
+          <b-radio
+            v-model="radioScenario"
+            name="radioScenario"
+            native-value="rcp85"
+          >
+            RCP 8.5
+          </b-radio>
+        </b-field>
+      </div>
+    </div>
     <div class="block">
       <table class="table">
         <thead>
@@ -218,21 +265,21 @@
               ]"
             >
               {{
-                results.temperature.summary.projected['5ModelAvg'].rcp85[
-                  `${month}`
-                ]['2010-2039'].tasmean
+                results.temperature.summary.projected[`${radioModel}`][
+                  `${radioScenario}`
+                ][`${month}`]['2010-2039'].tasmean
               }}<UnitWidget /><br />
               <span class="small-text">
                 ({{
-                  results.temperature.summary.projected['5ModelAvg'].rcp85[
-                    `${month}`
-                  ]['2010-2039'].tasmin
+                  results.temperature.summary.projected[`${radioModel}`][
+                    `${radioScenario}`
+                  ][`${month}`]['2010-2039'].tasmin
                 }}
                 &mdash;
                 {{
-                  results.temperature.summary.projected['5ModelAvg'].rcp85[
-                    `${month}`
-                  ]['2010-2039'].tasmax
+                  results.temperature.summary.projected[`${radioModel}`][
+                    `${radioScenario}`
+                  ][`${month}`]['2010-2039'].tasmax
                 }})
               </span>
             </td>
@@ -256,21 +303,21 @@
               ]"
             >
               {{
-                results.temperature.summary.projected['5ModelAvg'].rcp85[
-                  `${month}`
-                ]['2040-2069'].tasmean
+                results.temperature.summary.projected[`${radioModel}`][
+                  `${radioScenario}`
+                ][`${month}`]['2040-2069'].tasmean
               }}<UnitWidget /><br />
               <span class="small-text">
                 ({{
-                  results.temperature.summary.projected['5ModelAvg'].rcp85[
-                    `${month}`
-                  ]['2040-2069'].tasmin
+                  results.temperature.summary.projected[`${radioModel}`][
+                    `${radioScenario}`
+                  ][`${month}`]['2040-2069'].tasmin
                 }}
                 &mdash;
                 {{
-                  results.temperature.summary.projected['5ModelAvg'].rcp85[
-                    `${month}`
-                  ]['2040-2069'].tasmax
+                  results.temperature.summary.projected[`${radioModel}`][
+                    `${radioScenario}`
+                  ][`${month}`]['2040-2069'].tasmax
                 }})
               </span>
             </td>
@@ -294,21 +341,21 @@
               ]"
             >
               {{
-                results.temperature.summary.projected['5ModelAvg'].rcp85[
-                  `${month}`
-                ]['2070-2099'].tasmean
+                results.temperature.summary.projected[`${radioModel}`][
+                  `${radioScenario}`
+                ][`${month}`]['2070-2099'].tasmean
               }}<UnitWidget /><br />
               <span class="small-text">
                 ({{
-                  results.temperature.summary.projected['5ModelAvg'].rcp85[
-                    `${month}`
-                  ]['2070-2099'].tasmin
+                  results.temperature.summary.projected[`${radioModel}`][
+                    `${radioScenario}`
+                  ][`${month}`]['2070-2099'].tasmin
                 }}
                 &mdash;
                 {{
-                  results.temperature.summary.projected['5ModelAvg'].rcp85[
-                    `${month}`
-                  ]['2070-2099'].tasmax
+                  results.temperature.summary.projected[`${radioModel}`][
+                    `${radioScenario}`
+                  ][`${month}`]['2070-2099'].tasmax
                 }})
               </span>
             </td>
@@ -393,6 +440,12 @@ export default {
     DownloadCsvButton,
     UnitWidget,
     PreviewTable,
+  },
+  data() {
+    return {
+      radioModel: '5ModelAvg',
+      radioScenario: 'rcp45',
+    }
   },
   computed: {
     ...mapGetters({

--- a/components/reports/Temperature.vue
+++ b/components/reports/Temperature.vue
@@ -31,6 +31,7 @@
       </div>
     </div>
 
+    <h4 class="title is-5 mb-1">Mean Annual Temperature, 5 Model Average</h4>
     <div class="block">
       <table class="table">
         <thead>
@@ -139,14 +140,189 @@
       </table>
     </div>
 
+    <h4 class="title is-5 mb-1">Mean Monthly Temperatures</h4>
+    <div class="block">
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">January</th>
+            <th scope="col">February</th>
+            <th scope="col">March</th>
+            <th scope="col">April</th>
+            <th scope="col">May</th>
+            <th scope="col">June</th>
+            <th scope="col">July</th>
+            <th scope="col">August</th>
+            <th scope="col">September</th>
+            <th scope="col">October</th>
+            <th scope="col">November</th>
+            <th scope="col">December</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Historical (1901&ndash;2015)</th>
+            <td
+              v-for="month in [
+                'January',
+                'February',
+                'March',
+                'April',
+                'May',
+                'June',
+                'July',
+                'August',
+                'September',
+                'October',
+                'November',
+                'December',
+              ]"
+            >
+              {{
+                results.temperature.summary.historical['CRU-TS'].historical[
+                  `${month}`
+                ].tasmean
+              }}<UnitWidget /><br />
+              <span class="small-text">
+                ({{
+                  results.temperature.summary.historical['CRU-TS'].historical[
+                    `${month}`
+                  ].tasmin
+                }}
+                &mdash;
+                {{
+                  results.temperature.summary.historical['CRU-TS'].historical[
+                    `${month}`
+                  ].tasmax
+                }})
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Early Century (2010&ndash;2039)</th>
+            <td
+              v-for="month in [
+                'January',
+                'February',
+                'March',
+                'April',
+                'May',
+                'June',
+                'July',
+                'August',
+                'September',
+                'October',
+                'November',
+                'December',
+              ]"
+            >
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85[
+                  `${month}`
+                ]['2010-2039'].tasmean
+              }}<UnitWidget /><br />
+              <span class="small-text">
+                ({{
+                  results.temperature.summary.projected['5ModelAvg'].rcp85[
+                    `${month}`
+                  ]['2010-2039'].tasmin
+                }}
+                &mdash;
+                {{
+                  results.temperature.summary.projected['5ModelAvg'].rcp85[
+                    `${month}`
+                  ]['2010-2039'].tasmax
+                }})
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Mid Century (2040&ndash;2069)</th>
+            <td
+              v-for="month in [
+                'January',
+                'February',
+                'March',
+                'April',
+                'May',
+                'June',
+                'July',
+                'August',
+                'September',
+                'October',
+                'November',
+                'December',
+              ]"
+            >
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85[
+                  `${month}`
+                ]['2040-2069'].tasmean
+              }}<UnitWidget /><br />
+              <span class="small-text">
+                ({{
+                  results.temperature.summary.projected['5ModelAvg'].rcp85[
+                    `${month}`
+                  ]['2040-2069'].tasmin
+                }}
+                &mdash;
+                {{
+                  results.temperature.summary.projected['5ModelAvg'].rcp85[
+                    `${month}`
+                  ]['2040-2069'].tasmax
+                }})
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Late Century (2070&ndash;2099)</th>
+            <td
+              v-for="month in [
+                'January',
+                'February',
+                'March',
+                'April',
+                'May',
+                'June',
+                'July',
+                'August',
+                'September',
+                'October',
+                'November',
+                'December',
+              ]"
+            >
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85[
+                  `${month}`
+                ]['2070-2099'].tasmean
+              }}<UnitWidget /><br />
+              <span class="small-text">
+                ({{
+                  results.temperature.summary.projected['5ModelAvg'].rcp85[
+                    `${month}`
+                  ]['2070-2099'].tasmin
+                }}
+                &mdash;
+                {{
+                  results.temperature.summary.projected['5ModelAvg'].rcp85[
+                    `${month}`
+                  ]['2070-2099'].tasmax
+                }})
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
     <div class="block">
       <h4 class="title is-5 mb-1">Data preview</h4>
 
       <p class="content is-size-5 mb-1">
         CSV download includes annual values for both historical CRU TS
-        (1901&ndash;2015) and modeled projected (2006&ndash;2099) datasets.
-        January and July data also include minimums and maximums for each year.
-        Data are provided in metric units.
+        (1901&ndash;2015) and modeled projected (2006&ndash;2100) datasets.
       </p>
       <PreviewTable
         :csvString="results.temperature.preview"
@@ -228,4 +404,8 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.small-text {
+  font-size: 60%;
+}
+</style>

--- a/components/reports/Temperature.vue
+++ b/components/reports/Temperature.vue
@@ -238,7 +238,7 @@
                     `${month}`
                   ].tasmin
                 }}
-                &mdash;
+                &ndash;
                 {{
                   results.temperature.summary.historical['CRU-TS'].historical[
                     `${month}`
@@ -277,7 +277,7 @@
                     `${radioScenario}`
                   ][`${month}`]['2010-2039'].tasmin
                 }}
-                &mdash;
+                &ndash;
                 {{
                   results.temperature.summary.projected[`${radioModel}`][
                     `${radioScenario}`
@@ -316,7 +316,7 @@
                     `${radioScenario}`
                   ][`${month}`]['2040-2069'].tasmin
                 }}
-                &mdash;
+                &ndash;
                 {{
                   results.temperature.summary.projected[`${radioModel}`][
                     `${radioScenario}`
@@ -355,7 +355,7 @@
                     `${radioScenario}`
                   ][`${month}`]['2070-2099'].tasmin
                 }}
-                &mdash;
+                &ndash;
                 {{
                   results.temperature.summary.projected[`${radioModel}`][
                     `${radioScenario}`

--- a/components/reports/Temperature.vue
+++ b/components/reports/Temperature.vue
@@ -209,9 +209,9 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row">Historical (1901&ndash;2015)</th>
+            <th scope="row">Historical <br />(1901&ndash;2015)</th>
             <td
-              v-for="month in [
+              v-for="(month, index) in [
                 'January',
                 'February',
                 'March',
@@ -225,6 +225,7 @@
                 'November',
                 'December',
               ]"
+              :key="index"
             >
               {{
                 results.temperature.summary.historical['CRU-TS'].historical[
@@ -247,9 +248,9 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Early Century (2010&ndash;2039)</th>
+            <th scope="row">Early Century <br />(2010&ndash;2039)</th>
             <td
-              v-for="month in [
+              v-for="(month, index) in [
                 'January',
                 'February',
                 'March',
@@ -263,6 +264,7 @@
                 'November',
                 'December',
               ]"
+              :key="index"
             >
               {{
                 results.temperature.summary.projected[`${radioModel}`][
@@ -285,9 +287,9 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Mid Century (2040&ndash;2069)</th>
+            <th scope="row">Mid Century <br />(2040&ndash;2069)</th>
             <td
-              v-for="month in [
+              v-for="(month, index) in [
                 'January',
                 'February',
                 'March',
@@ -301,6 +303,7 @@
                 'November',
                 'December',
               ]"
+              :key="index"
             >
               {{
                 results.temperature.summary.projected[`${radioModel}`][
@@ -323,9 +326,9 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Late Century (2070&ndash;2099)</th>
+            <th scope="row">Late Century <br />(2070&ndash;2099)</th>
             <td
-              v-for="month in [
+              v-for="(month, index) in [
                 'January',
                 'February',
                 'March',
@@ -339,6 +342,7 @@
                 'November',
                 'December',
               ]"
+              :key="index"
             >
               {{
                 results.temperature.summary.projected[`${radioModel}`][
@@ -459,6 +463,6 @@ export default {
 
 <style lang="scss" scoped>
 .small-text {
-  font-size: 60%;
+  font-size: 55%;
 }
 </style>

--- a/components/reports/Temperature.vue
+++ b/components/reports/Temperature.vue
@@ -233,17 +233,15 @@
                 ].tasmean
               }}<UnitWidget /><br />
               <span class="small-text">
-                ({{
-                  results.temperature.summary.historical['CRU-TS'].historical[
-                    `${month}`
-                  ].tasmin
-                }}
-                &ndash;
                 {{
                   results.temperature.summary.historical['CRU-TS'].historical[
                     `${month}`
+                  ].tasmin
+                }}&ndash;{{
+                  results.temperature.summary.historical['CRU-TS'].historical[
+                    `${month}`
                   ].tasmax
-                }})
+                }}
               </span>
             </td>
           </tr>
@@ -272,17 +270,15 @@
                 ][`${month}`]['2010-2039'].tasmean
               }}<UnitWidget /><br />
               <span class="small-text">
-                ({{
-                  results.temperature.summary.projected[`${radioModel}`][
-                    `${radioScenario}`
-                  ][`${month}`]['2010-2039'].tasmin
-                }}
-                &ndash;
                 {{
                   results.temperature.summary.projected[`${radioModel}`][
                     `${radioScenario}`
+                  ][`${month}`]['2010-2039'].tasmin
+                }}&ndash;{{
+                  results.temperature.summary.projected[`${radioModel}`][
+                    `${radioScenario}`
                   ][`${month}`]['2010-2039'].tasmax
-                }})
+                }}
               </span>
             </td>
           </tr>
@@ -311,17 +307,15 @@
                 ][`${month}`]['2040-2069'].tasmean
               }}<UnitWidget /><br />
               <span class="small-text">
-                ({{
-                  results.temperature.summary.projected[`${radioModel}`][
-                    `${radioScenario}`
-                  ][`${month}`]['2040-2069'].tasmin
-                }}
-                &ndash;
                 {{
                   results.temperature.summary.projected[`${radioModel}`][
                     `${radioScenario}`
+                  ][`${month}`]['2040-2069'].tasmin
+                }}&ndash;{{
+                  results.temperature.summary.projected[`${radioModel}`][
+                    `${radioScenario}`
                   ][`${month}`]['2040-2069'].tasmax
-                }})
+                }}
               </span>
             </td>
           </tr>
@@ -350,17 +344,15 @@
                 ][`${month}`]['2070-2099'].tasmean
               }}<UnitWidget /><br />
               <span class="small-text">
-                ({{
-                  results.temperature.summary.projected[`${radioModel}`][
-                    `${radioScenario}`
-                  ][`${month}`]['2070-2099'].tasmin
-                }}
-                &ndash;
                 {{
                   results.temperature.summary.projected[`${radioModel}`][
                     `${radioScenario}`
+                  ][`${month}`]['2070-2099'].tasmin
+                }}&ndash;{{
+                  results.temperature.summary.projected[`${radioModel}`][
+                    `${radioScenario}`
                   ][`${month}`]['2070-2099'].tasmax
-                }})
+                }}
               </span>
             </td>
           </tr>
@@ -463,6 +455,6 @@ export default {
 
 <style lang="scss" scoped>
 .small-text {
-  font-size: 55%;
+  font-size: 80%;
 }
 </style>

--- a/components/reports/Temperature.vue
+++ b/components/reports/Temperature.vue
@@ -4,8 +4,8 @@
       <p>
         These data come from two types of data sources: historical modeled data
         (CRU TS), and projected downscaled GCM data from across five different
-        climate models (NCAR CCSM4, GFDL CM3, GISS E2-R, MRI CGCM3, and IPSL
-        CM5A-LR) and three climate scenarios (RCP 4.5, 6.0 and 8.5).
+        climate models averaged together (NCAR CCSM4, GFDL CM3, GISS E2-R, MRI
+        CGCM3, and IPSL CM5A-LR) and two climate scenarios (RCP 4.5 and 8.5).
       </p>
       <p>
         Projected data (2010&ndash;2039) can show more variability than the
@@ -14,19 +14,20 @@
       </p>
       <p>
         Both historical and projected data for temperature are at a 2&#x202F;km
-        spatial resolution. Data are available as annual means, and monthly
-        means for January and July.
+        spatial resolution. Data are available as monthly min-mean-max values.
       </p>
     </div>
 
     <div class="block">
       <h4 class="title is-5 mb-1">Data Summary</h4>
       <div class="content is-size-5">
-        The summary table below shows the minimum, mean and maximum values
-        across three scenarios (RCP 4.5, RCP 6.0 and RCP 8.5) and five models
-        (NCAR CCSM4, GFDL CM3, GISS E2-R, MRI CGCM3, and IPSL CM5A-LR) for the
-        specified era, which can be helpful to assess broad trends and
-        variation.
+        The summary table below presents the minimum, mean, and maximum values
+        for two scenarios (RCP 4.5 and RCP 8.5), utilizing three distinct
+        models: the 5-model average (an average derived from the NCAR CCSM4,
+        GFDL CM3, GISS E2-R, MRI CGCM3, and IPSL CM5A-LR models), the NCAR CCSM4
+        model, and the GFDL CM3 model. This information is provided for the
+        specified era and can be valuable for evaluating overall trends and
+        variability.
       </div>
     </div>
 
@@ -34,19 +35,7 @@
       <table class="table">
         <thead>
           <tr>
-            <th></th>
-            <th scope="col" colspan="3">Annual</th>
-            <th scope="col" colspan="3">January</th>
-            <th scope="col" colspan="3">July</th>
-          </tr>
-          <tr>
             <th scope="col"></th>
-            <th scope="col">Min</th>
-            <th scope="col">Mean</th>
-            <th scope="col">Max</th>
-            <th scope="col">Min</th>
-            <th scope="col">Mean</th>
-            <th scope="col">Max</th>
             <th scope="col">Min</th>
             <th scope="col">Mean</th>
             <th scope="col">Max</th>
@@ -56,156 +45,93 @@
           <tr>
             <th scope="row">Historical (1901&ndash;2015)</th>
             <td>
-              {{ results.temperature.summary.historical.all.tasmin
+              {{
+                results.temperature.summary.historical['CRU-TS'].historical
+                  .Annual.tasmin
               }}<UnitWidget />
             </td>
             <td>
-              {{ results.temperature.summary.historical.all.tasmean
+              {{
+                results.temperature.summary.historical['CRU-TS'].historical
+                  .Annual.tasmean
               }}<UnitWidget />
             </td>
             <td>
-              {{ results.temperature.summary.historical.all.tasmax
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary.historical.jan.tasmin
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary.historical.jan.tasmean
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary.historical.jan.tasmax
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary.historical.july.tasmin
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary.historical.july.tasmean
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary.historical.july.tasmax
+              {{
+                results.temperature.summary.historical['CRU-TS'].historical
+                  .Annual.tasmax
               }}<UnitWidget />
             </td>
           </tr>
           <tr>
-            <th scope="row">Early Century (2010-2039)</th>
+            <th scope="row">Early Century (2010&ndash;2039)</th>
             <td>
-              {{ results.temperature.summary['2010-2039'].all.tasmin
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85.Annual[
+                  '2010-2039'
+                ].tasmin
               }}<UnitWidget />
             </td>
             <td>
-              {{ results.temperature.summary['2010-2039'].all.tasmean
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85.Annual[
+                  '2010-2039'
+                ].tasmean
               }}<UnitWidget />
             </td>
             <td>
-              {{ results.temperature.summary['2010-2039'].all.tasmax
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2010-2039'].jan.tasmin
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2010-2039'].jan.tasmean
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2010-2039'].jan.tasmax
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2010-2039'].july.tasmin
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2010-2039'].july.tasmean
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2010-2039'].july.tasmax
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85.Annual[
+                  '2010-2039'
+                ].tasmax
               }}<UnitWidget />
             </td>
           </tr>
           <tr>
-            <th scope="row">Mid Century (2040-2069)</th>
+            <th scope="row">Mid Century (2040&ndash;2069)</th>
             <td>
-              {{ results.temperature.summary['2040-2069'].all.tasmin
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85.Annual[
+                  '2040-2069'
+                ].tasmin
               }}<UnitWidget />
             </td>
             <td>
-              {{ results.temperature.summary['2040-2069'].all.tasmean
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85.Annual[
+                  '2040-2069'
+                ].tasmean
               }}<UnitWidget />
             </td>
             <td>
-              {{ results.temperature.summary['2040-2069'].all.tasmax
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2040-2069'].jan.tasmin
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2040-2069'].jan.tasmean
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2040-2069'].jan.tasmax
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2040-2069'].july.tasmin
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2040-2069'].july.tasmean
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2040-2069'].july.tasmax
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85.Annual[
+                  '2040-2069'
+                ].tasmax
               }}<UnitWidget />
             </td>
           </tr>
           <tr>
-            <th scope="row">Late Century (2070-2099)</th>
+            <th scope="row">Late Century (2070&ndash;2099)</th>
             <td>
-              {{ results.temperature.summary['2070-2099'].all.tasmin
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85.Annual[
+                  '2070-2099'
+                ].tasmin
               }}<UnitWidget />
             </td>
             <td>
-              {{ results.temperature.summary['2070-2099'].all.tasmean
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85.Annual[
+                  '2070-2099'
+                ].tasmean
               }}<UnitWidget />
             </td>
             <td>
-              {{ results.temperature.summary['2070-2099'].all.tasmax
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2070-2099'].jan.tasmin
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2070-2099'].jan.tasmean
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2070-2099'].jan.tasmax
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2070-2099'].july.tasmin
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2070-2099'].july.tasmean
-              }}<UnitWidget />
-            </td>
-            <td>
-              {{ results.temperature.summary['2070-2099'].july.tasmax
+              {{
+                results.temperature.summary.projected['5ModelAvg'].rcp85.Annual[
+                  '2070-2099'
+                ].tasmax
               }}<UnitWidget />
             </td>
           </tr>
@@ -218,13 +144,13 @@
 
       <p class="content is-size-5 mb-1">
         CSV download includes annual values for both historical CRU TS
-        (1901&ndash;2015) and modeled projected (2010&ndash;2099) datasets.
+        (1901&ndash;2015) and modeled projected (2006&ndash;2099) datasets.
         January and July data also include minimums and maximums for each year.
         Data are provided in metric units.
       </p>
       <PreviewTable
         :csvString="results.temperature.preview"
-        sizeBlurb="~1525 rows, 4 columns, ~42kb"
+        sizeBlurb="~8227 rows, 7 columns, ~363kb"
       />
     </div>
 
@@ -239,20 +165,8 @@
           <ul>
             <li>
               <DownloadCsvButton
-                text="Download annual temperature mean data as CSV"
-                endpoint="temperature"
-              />
-            </li>
-            <li>
-              <DownloadCsvButton
-                text="Download annual January temperature min-mean-max as CSV"
-                endpoint="temperature/jan"
-              />
-            </li>
-            <li>
-              <DownloadCsvButton
-                text="Download annual July temperature min-mean-max as CSV"
-                endpoint="temperature/july"
+                text="Download monthly temperature min-mean-max data as CSV"
+                endpoint="tas2km/point"
               />
             </li>
           </ul>


### PR DESCRIPTION
This PR updates the temperature report section with a new annual min-mean-max table, along with a monthly min-mean-max table across 4 eras: historical, early century (2010-2039), mid century (2040-2069), and late century (2070-2099). This table has the ability to switch between all of the models and the scenarios to display different projected data.

It also has the new CSV preview along with pointing the CSV download link to the new monthly temperature data.

To run this, use the API branch: temperature_2km and set your env vars:
export SNAP_API_URL=http://localhost:5000
export RASDAMAN_URL=https://apollo.snap.uaf.edu/rasdaman/ows