### PR TITLE
Adds padding to the bottom of the permafrost section to allow for background image to be fully displayed

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -158,7 +158,11 @@
     </div>
   </div>
 </template>
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.permafrost {
+  padding-bottom: 11rem;
+}
+</style>
 <script>
 import { mapGetters } from 'vuex'
 import UnitRadio from '~/components/UnitRadio'


### PR DESCRIPTION
This PR is a very simple change to the CSS to allow for more padding at the bottom of the permafrost section of the report to allow for the entirety of the background image to be displayed.

Fixes #332 