### PR TITLE
Use store getters to determine presence of data and hide TOC entry + section when dataset is missing

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -44,7 +44,7 @@
           </div>
           <h3 class="subtitle is-3 pt-4">Point-specific notes</h3>
           <div class="content is-size-4">
-            <p v-if="Object.keys(results.elevation).length != 0">
+            <p v-if="isElevationPresent">
               <strong>Elevation -</strong> The elevation within 1&#8239;km of
               this point ranges between
               <strong>
@@ -55,12 +55,8 @@
               variation should be kept in mind when interpreting the variables
               below.
             </p>
-            <p
-              v-if="
-                Object.keys(results.geology).length != 0 &&
-                Object.keys(results.physiography).length != 0
-              "
-            >
+
+            <p v-if="isGeologyPresent && isPhysiographyPresent">
               <strong>Geology &amp; ecology -</strong> The geology type of this
               point is <em>{{ results.geology.name }}</em
               >, and this place lies within the
@@ -92,72 +88,111 @@
           <h2 class="title is-3">Table of Contents</h2>
           <div class="content is-size-4">
             <ul>
-              <li>
+              <li
+                v-if="
+                  isPrecipitationPresent ||
+                  isPrecipitationFrequencyPresent ||
+                  isSnowfallPresent
+                "
+              >
                 <a href="#precipitation">Precipitation</a>
                 <ul>
-                  <li>
+                  <li v-if="isPrecipitationPresent">
                     <a href="#annual-precipitation"
                       >Annual Total Precipitation</a
                     >
                   </li>
-                  <li>
+                  <li v-if="isPrecipitationFrequencyPresent">
                     <a href="#precipitation-frequency"
                       >Precipitation Frequency</a
                     >
                   </li>
-                  <li>
+                  <li v-if="isSnowfallPresent">
                     <a href="#snowfall">Snowfall</a>
                   </li>
                 </ul>
               </li>
 
-              <li><a href="#temperature">Temperature</a></li>
-              <li>
+              <li v-if="isTemperaturePresent">
+                <a href="#temperature">Temperature</a>
+              </li>
+              <li
+                v-if="
+                  isHeatingDegreeDaysPresent ||
+                  isFreezingIndexPresent ||
+                  isThawingIndexPresent
+                "
+              >
                 <a href="#temperature-indices">Temperature Indices</a>
                 <ul>
-                  <li>
+                  <li v-if="isHeatingDegreeDaysPresent">
                     <a href="#heating-degree-days">Heating Degree Days</a>
                   </li>
-                  <li><a href="#freezing-index">Freezing Index</a></li>
-                  <li><a href="#thawing-index">Thawing Index</a></li>
+                  <li v-if="isFreezingIndexPresent">
+                    <a href="#freezing-index">Freezing Index</a>
+                  </li>
+                  <li v-if="isThawingIndexPresent">
+                    <a href="#thawing-index">Thawing Index</a>
+                  </li>
                 </ul>
               </li>
 
-              <li><a href="#permafrost">Permafrost</a></li>
+              <li v-if="isPermafrostPresent">
+                <a href="#permafrost">Permafrost</a>
+              </li>
             </ul>
           </div>
         </div>
       </section>
-      <section class="section precipitation">
+      <section
+        class="section precipitation"
+        v-if="
+          isPrecipitationPresent ||
+          isPrecipitationFrequencyPresent ||
+          isSnowfallPresent
+        "
+      >
         <div class="container">
           <h2 id="precipitation" class="title is-2">Precipitation</h2>
 
-          <h3 id="annual-precipitation" class="title is-3 mt-6">
-            Total annual precipitation
-          </h3>
+          <div v-if="isPrecipitationPresent">
+            <h3 id="annual-precipitation" class="title is-3 mt-6">
+              Total annual precipitation
+            </h3>
+            <PrecipitationReport />
+          </div>
 
-          <PrecipitationReport />
+          <div v-if="isPrecipitationFrequencyPresent">
+            <h3 id="precipitation-frequency" class="title is-3 mt-6">
+              Precipitation Frequency
+            </h3>
+            <PrecipitationFrequency />
+          </div>
 
-          <h3 id="precipitation-frequency" class="title is-3 mt-6">
-            Precipitation Frequency
-          </h3>
-          <PrecipitationFrequency />
-
-          <h3 id="snowfall" class="title is-3 mt-6">
-            Snowfall (Water) Equivalent
-          </h3>
-          <SnowfallReport />
+          <div v-if="isSnowfallPresent">
+            <h3 id="snowfall" class="title is-3 mt-6">
+              Snowfall (Water) Equivalent
+            </h3>
+            <SnowfallReport />
+          </div>
         </div>
       </section>
 
-      <section class="section temperature">
+      <section class="section temperature" v-if="isTemperaturePresent">
         <div class="container">
           <h2 id="temperature" class="title is-2">Temperature</h2>
           <TemperatureReport />
         </div>
       </section>
 
-      <section class="section temperature-index">
+      <section
+        class="section temperature-index"
+        v-if="
+          isHeatingDegreeDaysPresent ||
+          isFreezingIndexPresent ||
+          isThawingIndexPresent
+        "
+      >
         <div class="container">
           <h2 id="temperature-indices" class="title is-2">
             Temperature Indices
@@ -165,7 +200,7 @@
           <TemperatureIndices />
         </div>
       </section>
-      <section class="section permafrost">
+      <section class="section permafrost" v-if="isPermafrostPresent">
         <div class="container">
           <PermafrostReport />
         </div>
@@ -213,6 +248,18 @@ export default {
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       latLng: 'report/latLng',
+      isElevationPresent: 'report/isElevationPresent',
+      isGeologyPresent: 'report/isGeologyPresent',
+      isPhysiographyPresent: 'report/isPhysiographyPresent',
+      isPrecipitationPresent: 'report/isPrecipitationPresent',
+      isPrecipitationFrequencyPresent: 'report/isPrecipitationFrequencyPresent',
+      isSnowfallPresent: 'report/isSnowfallPresent',
+      isTemperaturePresent: 'report/isTemperaturePresent',
+      isHeatingDegreeDaysPresent: 'report/isHeatingDegreeDaysPresent',
+      isFreezingIndexPresent: 'report/isFreezingIndexPresent',
+      isThawingIndexPresent: 'report/isThawingIndexPresent',
+      isPermafrostPresent: 'report/isPermafrostPresent',
+      isWetDaysPerYearPresent: 'report/isWetDaysPerYearPresent',
     }),
   },
   data: function () {

--- a/components/reports/FreezingIndex.vue
+++ b/components/reports/FreezingIndex.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="Object.keys(results.freezing_index).length != 0">
+  <div>
     <div class="block">
       <h4 class="title is-5 mb-1">Summary</h4>
       <div class="content is-size-5">

--- a/components/reports/HeatingDegreeDays.vue
+++ b/components/reports/HeatingDegreeDays.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="Object.keys(results.heating_degree_days).length != 0">
+  <div>
     <div class="block">
       <h4 class="title is-5 mb-1">Summary</h4>
       <div class="content is-size-5">

--- a/components/reports/Permafrost.vue
+++ b/components/reports/Permafrost.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isDataLoaded">
+  <div v-if="isPermafrostPresent">
     <div class="block">
       <h2 id="permafrost" class="title is-2">Permafrost</h2>
       <div class="content is-size-5">
@@ -355,13 +355,11 @@ export default {
     PreviewTable,
   },
   computed: {
-    isDataLoaded() {
-      return this.results.permafrost.summary != undefined
-    },
     ...mapGetters({
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
+      isPermafrostPresent: 'report/isPermafrostPresent',
     }),
   },
 }

--- a/components/reports/PrecipitationFrequency.vue
+++ b/components/reports/PrecipitationFrequency.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="pf" v-if="Object.keys(results.precip_frequency).length != 0">
+  <div class="pf" v-if="isPrecipitationFrequencyPresent">
     <div class="data-intro content is-size-5">
       <p>
         Below are projected precipitation frequencies by duration and return
@@ -189,6 +189,7 @@ export default {
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
       units: 'report/units',
+      isPrecipitationFrequencyPresent: 'report/isPrecipitationFrequencyPresent',
     }),
     getUnits() {
       return this.units === 'imperial' ? 'inches' : 'mm'

--- a/components/reports/Snowfall.vue
+++ b/components/reports/Snowfall.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="Object.keys(results.snowfall.summary).length != 0">
+  <div v-if="isSnowfallPresent">
     <div class="block content is-size-5">
       <p>
         These data show downscaled projections of decadal average monthly
@@ -154,6 +154,7 @@ export default {
   computed: {
     ...mapGetters({
       results: 'report/results',
+      isSnowfallPresent: 'report/isSnowfallPresent',
     }),
   },
 }

--- a/components/reports/Temperature.vue
+++ b/components/reports/Temperature.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="Object.keys(results.temperature).length != 0">
+  <div v-if="isTemperaturePresent">
     <div class="block content is-size-5">
       <p>
         These data come from two types of data sources: historical modeled data
@@ -448,6 +448,7 @@ export default {
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
+      isTemperaturePresent: 'report/isTemperaturePresent',
     }),
   },
 }

--- a/components/reports/TemperatureIndices.vue
+++ b/components/reports/TemperatureIndices.vue
@@ -13,17 +13,17 @@
       </p>
     </div>
     <div class="ml-5 mb-5">
-      <div class="block">
+      <div class="block" v-if="isHeatingDegreeDaysPresent">
         <h3 id="heating-degree-days" class="title is-4 mb-3">
           Heating Degree Days
         </h3>
         <HeatingDegreeDaysReport />
       </div>
-      <div class="block mt-6">
+      <div class="block mt-6" v-if="isFreezingIndexPresent">
         <h3 id="freezing-index" class="title is-4">Freezing Index</h3>
         <FreezingIndexReport />
       </div>
-      <div class="block mt-6">
+      <div class="block mt-6" v-if="isThawingIndexPresent">
         <h3 id="thawing-index" class="title is-4">Thawing Index</h3>
         <ThawingIndexReport />
       </div>
@@ -73,6 +73,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import HeatingDegreeDaysReport from '~/components/reports/HeatingDegreeDays'
 import FreezingIndexReport from '~/components/reports/FreezingIndex'
 import ThawingIndexReport from '~/components/reports/ThawingIndex'
@@ -83,6 +84,13 @@ export default {
     HeatingDegreeDaysReport,
     FreezingIndexReport,
     ThawingIndexReport,
+  },
+  computed: {
+    ...mapGetters({
+      isHeatingDegreeDaysPresent: 'report/isHeatingDegreeDaysPresent',
+      isFreezingIndexPresent: 'report/isFreezingIndexPresent',
+      isThawingIndexPresent: 'report/isThawingIndexPresent',
+    }),
   },
 }
 </script>

--- a/components/reports/ThawingIndex.vue
+++ b/components/reports/ThawingIndex.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="Object.keys(results.thawing_index).length != 0">
+  <div>
     <div class="block">
       <h4 class="title is-5 mb-1">Summary</h4>
       <div class="content is-size-5">

--- a/store/report.js
+++ b/store/report.js
@@ -136,6 +136,42 @@ export default {
     units(state) {
       return state.units
     },
+    isElevationPresent(state) {
+      return Object.keys(state.results.elevation).length != 0
+    },
+    isGeologyPresent(state) {
+      return Object.keys(state.results.geology).length != 0
+    },
+    isPhysiographyPresent(state) {
+      return Object.keys(state.results.physiography).length != 0
+    },
+    isPrecipitationPresent(state) {
+      return Object.keys(state.results.precipitation).length != 0
+    },
+    isPrecipitationFrequencyPresent(state) {
+      return Object.keys(state.results.precip_frequency).length != 0
+    },
+    isSnowfallPresent(state) {
+      return Object.keys(state.results.snowfall).length != 0
+    },
+    isTemperaturePresent(state) {
+      return Object.keys(state.results.temperature).length != 0
+    },
+    isHeatingDegreeDaysPresent(state) {
+      return Object.keys(state.results.heating_degree_days).length != 0
+    },
+    isFreezingIndexPresent(state) {
+      return Object.keys(state.results.freezing_index).length != 0
+    },
+    isThawingIndexPresent(state) {
+      return Object.keys(state.results.thawing_index).length != 0
+    },
+    isPermafrostPresent(state) {
+      return Object.keys(state.results.permafrost).length != 0
+    },
+    isWetDaysPerYearPresent(state) {
+      return Object.keys(state.results.wet_days_per_year).length != 0
+    },
   },
 
   mutations: {


### PR DESCRIPTION
Closes #280.
Closes #338.

This PR does two things:

- Consolidates checks for the presence of each dataset into store getters, so components can use simple checks like `v-if="isDataVariablePresent"` to decide when to show/hide elements.
- Adds `v-if="isDataVariablePresent"` style checks to the report page's table of contents and data sections to hide datasets that are not available.

To test, set the webapp to mock API mode (`export MOCK_API=True`) and modify `assets/mock.json` to simulate missing datasets. For example, if the real API fails to load data for `freezing_index`, the freezing index will appear as an empty dictionary in the API output:

```
freezing_index: {},
```

Use this trick for each key (dataset) in `mock.json` to simulate missing datasets and make sure the table of contents entries and corresponding sections react accordingly on the report page.