### PR TITLE
Filters so only Alaska communities can be selected through widget

### DIFF
--- a/store/report.js
+++ b/store/report.js
@@ -244,7 +244,8 @@ export default {
       // TODO: add error handling here for 404 (no data) etc.
       let queryUrl = process.env.apiUrl + '/places/communities'
       let places = await this.$http.$get(queryUrl)
-      context.commit('setPlaces', places)
+      let filteredPlaces = _.filter(places, p => { return p.region == 'Alaska' })
+      context.commit('setPlaces', filteredPlaces)
     },
   },
 }


### PR DESCRIPTION
Closes #314 

Testing:

 - Try the community selector out with places that aren't in Alaska.  You shouldn't be able to find any!
 - But all Alaska places should still be there.