### PR TITLE
Correct historical period for ERA-Interim for DD-WRF datasets

### DIFF
--- a/components/reports/FreezingIndex.vue
+++ b/components/reports/FreezingIndex.vue
@@ -21,7 +21,7 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row">Historical (1979-2015)</th>
+            <th scope="row">Historical (1980&ndash;2009)</th>
             <td>
               {{ results.freezing_index['summary']['historical']['ddmin']
               }}<UnitWidget unitType="dd" />
@@ -36,7 +36,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Early Century (2010-2039)</th>
+            <th scope="row">Early Century (2010&ndash;2039)</th>
             <td>
               {{ results.freezing_index['summary']['2010-2039']['ddmin']
               }}<UnitWidget unitType="dd" />
@@ -51,7 +51,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Mid Century (2040-2069)</th>
+            <th scope="row">Mid Century (2040&ndash;2069)</th>
             <td>
               {{ results.freezing_index['summary']['2040-2069']['ddmin']
               }}<UnitWidget unitType="dd" />
@@ -66,7 +66,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Late Century (2070-2099)</th>
+            <th scope="row">Late Century (2070&ndash;2099)</th>
             <td>
               {{ results.freezing_index['summary']['2070-2099']['ddmin']
               }}<UnitWidget unitType="dd" />

--- a/components/reports/HeatingDegreeDays.vue
+++ b/components/reports/HeatingDegreeDays.vue
@@ -21,7 +21,7 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row">Historical (1979&ndash;2015)</th>
+            <th scope="row">Historical (1980&ndash;2009)</th>
             <td>
               {{ results.heating_degree_days['summary']['historical']['ddmin']
               }}<UnitWidget unitType="dd" />

--- a/components/reports/Precipitation.vue
+++ b/components/reports/Precipitation.vue
@@ -42,7 +42,7 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row">Historical (1901-2015)</th>
+            <th scope="row">Historical (1901&ndash;2015)</th>
             <td>
               {{ results.precipitation['summary']['historical']['prmin']
               }}<UnitWidget unitType="mm_in" />
@@ -57,7 +57,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Early Century (2010-2039)</th>
+            <th scope="row">Early Century (2010&ndash;2039)</th>
             <td>
               {{ results.precipitation['summary']['2010-2039']['prmin']
               }}<UnitWidget unitType="mm_in" />
@@ -72,7 +72,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Mid Century (2040-2069)</th>
+            <th scope="row">Mid Century (2040&ndash;2069)</th>
             <td>
               {{ results.precipitation['summary']['2040-2069']['prmin']
               }}<UnitWidget unitType="mm_in" />
@@ -87,7 +87,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Late Century (2070-2099)</th>
+            <th scope="row">Late Century (2070&ndash;2099)</th>
             <td>
               {{ results.precipitation.summary['2070-2099'].prmin
               }}<UnitWidget unitType="mm_in" />

--- a/components/reports/ThawingIndex.vue
+++ b/components/reports/ThawingIndex.vue
@@ -21,7 +21,7 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row">Historical (1979-2015)</th>
+            <th scope="row">Historical (1980&ndash;2009)</th>
             <td>
               {{ results.thawing_index['summary']['historical']['ddmin']
               }}<UnitWidget />
@@ -36,7 +36,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Early Century (2010-2039)</th>
+            <th scope="row">Early Century (2010&ndash;2039)</th>
             <td>
               {{ results.thawing_index['summary']['2010-2039']['ddmin']
               }}<UnitWidget />
@@ -51,7 +51,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Mid Century (2040-2069)</th>
+            <th scope="row">Mid Century (2040&ndash;2069)</th>
             <td>
               {{ results.thawing_index['summary']['2040-2069']['ddmin']
               }}<UnitWidget />
@@ -66,7 +66,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row">Late Century (2070-2099)</th>
+            <th scope="row">Late Century (2070&ndash;2099)</th>
             <td>
               {{ results.thawing_index['summary']['2070-2099']['ddmin']
               }}<UnitWidget />


### PR DESCRIPTION
Closes #194

Testing:

 - For datasets derived from the dynamically-downscaled WRF stuff -- HDD, Freezing Index, Thawing Index -- sections in the Report should now correctly say 1980-2009.

Any corrections needed on map layers will be done in #348 