### PR TITLE
Visually distinguish historical row in summary/interactive tables

### DIFF
--- a/assets/scss/bulma-overrides.scss
+++ b/assets/scss/bulma-overrides.scss
@@ -41,6 +41,15 @@ table {
     font-weight: 500;
     font-family: 'IBM Plex Sans', sans-serif;
   }
+
+  tr.historical {
+    & td,
+    & th {
+      border-width: 0 0 2px;
+      padding-top: 0.75em !important;
+      padding-bottom: 0.75em !important;
+    }
+  }
 }
 
 table.preview {

--- a/components/reports/FreezingIndex.vue
+++ b/components/reports/FreezingIndex.vue
@@ -20,7 +20,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="historical">
             <th scope="row">Historical (1979-2015)</th>
             <td>
               {{ results.freezing_index['summary']['historical']['ddmin']

--- a/components/reports/HeatingDegreeDays.vue
+++ b/components/reports/HeatingDegreeDays.vue
@@ -20,7 +20,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="historical">
             <th scope="row">Historical (1979&ndash;2015)</th>
             <td>
               {{ results.heating_degree_days['summary']['historical']['ddmin']

--- a/components/reports/Precipitation.vue
+++ b/components/reports/Precipitation.vue
@@ -41,7 +41,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="historical">
             <th scope="row">Historical (1901-2015)</th>
             <td>
               {{ results.precipitation['summary']['historical']['prmin']

--- a/components/reports/Snowfall.vue
+++ b/components/reports/Snowfall.vue
@@ -35,7 +35,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="historical">
             <th scope="row">Historical (1910&ndash;2009)</th>
             <td>
               {{ results.snowfall.summary.historical.sfemin

--- a/components/reports/Temperature.vue
+++ b/components/reports/Temperature.vue
@@ -43,7 +43,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="historical">
             <th scope="row">Historical (1901&ndash;2015)</th>
             <td>
               {{
@@ -208,7 +208,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="historical">
             <th scope="row">Historical <br />(1901&ndash;2015)</th>
             <td
               v-for="(month, index) in [
@@ -461,7 +461,8 @@ export default {
 table.months {
   width: 100%;
   table-layout: fixed;
-  td, th {
+  td,
+  th {
     padding: 0.5em 0.4em;
 
     &.eraCol {

--- a/components/reports/ThawingIndex.vue
+++ b/components/reports/ThawingIndex.vue
@@ -20,7 +20,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="historical">
             <th scope="row">Historical (1979-2015)</th>
             <td>
               {{ results.thawing_index['summary']['historical']['ddmin']


### PR DESCRIPTION
Closes #354 

Adds a subtle visual clue via spacing/border weight that the historical row is different from the projected rows in summary/interactive tables.