### PR TITLE
Fix conversion bug when loading new reports with stored metric mode

### DIFF
--- a/components/UnitRadio.vue
+++ b/components/UnitRadio.vue
@@ -30,18 +30,22 @@ export default {
     }),
   },
   mounted() {
-    this.radioUnits = this.storeRadioUnits
+    if (this.storeRadioUnits == undefined) {
+      this.radioUnits = 'imperial'
+    } else {
+      this.radioUnits = this.storeRadioUnits
+    }
   },
   watch: {
     radioUnits: function () {
-      if (this.radioUnits == 'metric') {
-        if (this.storeRadioUnits != 'metric') {
+      if (this.radioUnits != this.storeRadioUnits) {
+        if (this.radioUnits == 'metric') {
           this.$store.commit('report/setMetric')
+        } else {
+          this.$store.commit('report/setImperial')
         }
-      } else {
-        this.$store.commit('report/setImperial')
+        this.$store.commit('report/convertResults')
       }
-      this.$store.commit('report/convertResults')
     },
   },
 }

--- a/components/UnitRadio.vue
+++ b/components/UnitRadio.vue
@@ -30,11 +30,7 @@ export default {
     }),
   },
   mounted() {
-    if (this.storeRadioUnits == undefined) {
-      this.radioUnits = 'imperial'
-    } else {
-      this.radioUnits = this.storeRadioUnits
-    }
+    this.radioUnits = this.storeRadioUnits
   },
   watch: {
     radioUnits: function () {

--- a/store/report.js
+++ b/store/report.js
@@ -67,7 +67,7 @@ export default {
     return {
       places: undefined,
       results: {},
-      units: 'imperial',
+      units: undefined,
     }
   },
   getters: {

--- a/store/report.js
+++ b/store/report.js
@@ -229,7 +229,9 @@ export default {
       let results
       if (process.env.mockApi) {
         const mock = require('~/assets/mock.json')
-        results = mock
+
+        // Copy mock to results so we don't modify mock directly.
+        results = { ...mock }
       } else {
         results = await this.$axios.$get(url)
       }

--- a/store/report.js
+++ b/store/report.js
@@ -67,7 +67,7 @@ export default {
     return {
       places: undefined,
       results: {},
-      units: undefined,
+      units: 'imperial',
     }
   },
   getters: {
@@ -234,6 +234,9 @@ export default {
         results = await this.$axios.$get(url)
       }
       context.commit('setResults', results)
+      if (context.state.units == 'imperial') {
+        context.commit('convertResults')
+      }
     },
     async fetchPlaces(context) {
       // If we've already fetched this, don't do that again.


### PR DESCRIPTION
Closes #350.

This PR fixes the issue described in #350.

After digging into the code a bit, the problem is that the `radioUnits` watcher function fires when the report page first loads, and the `radioUnits` watcher function performs a data conversion unconditionally. Unconditional conversion works fine when the source data is received in metric units and the data needs to be converted to imperial units (i.e., the default behavior, or if a user has specifically selected imperial mode before loading a new report page for a location). But if the user selected metric units before loading a new report page, it had the effect of converting the already-metric units to metric once again (and drastically inflating some numbers in the process).

To solve this, I've modified the UnitRadio component to call the conversion function only when the radio input and store values differ from each other to avoid double-metric-conversion. I've also updated `store/report.js` to perform imperial conversions immediately after the data is fetched, if the store's `units` are set to imperial. Since the store's default `units` value is imperial, this moves the conversion closer to the source and reduces the amount of time that the store's `units` and `results` are out of sync.

To test:
- Load a report for a location and switch back and forth between imperial and metric mode to verify that the numbers stay the same for their respective units
- Navigate back to the front page either via navigation menu or your browser's back button
- Select either the same location or a new location and verify that the numbers look sane
- Switch back and forth between imperial and metric units again to make sure the numbers don't get disorted