### PR TITLE
Adapts language in report when it's a community v. direct lat/lng

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -46,7 +46,9 @@
           <div class="content is-size-4">
             <p v-if="isElevationPresent">
               <strong>Elevation -</strong> The elevation within 1&#8239;km of
-              this point ranges between
+              <span v-if="placeIsLatLng">this point</span>
+              <span v-else>{{ placeName }}, centered at {{ latLng.lat }}, {{ latLng.lng }}</span>
+               ranges between
               <strong>
                 {{ results.elevation.min }}&ndash;{{ results.elevation.max }}
               </strong>
@@ -247,6 +249,7 @@ export default {
       results: 'report/results',
       placeName: 'report/placeName',
       isPlaceDefined: 'report/isPlaceDefined',
+      placeIsLatLng: 'report/placeIsLatLng',
       latLng: 'report/latLng',
       isElevationPresent: 'report/isElevationPresent',
       isGeologyPresent: 'report/isGeologyPresent',

--- a/store/report.js
+++ b/store/report.js
@@ -97,15 +97,21 @@ export default {
     isPlaceDefined(state, getters) {
       return getters.latLng || getters.placeId
     },
+    getPlaceById(state, getters, rootState) {
+      return _.find(state.places, {
+        id: rootState.route.params.communityId,
+      })
+    },
+    placeIsLatLng(state, getters, rootState) {
+      return rootState.route.params.lat && rootState.route.params.lng
+    },
     placeName(state, getters, rootState) {
-      if (rootState.route.params.lat && rootState.route.params.lng) {
+      if (getters.placeIsLatLng) {
         return rootState.route.params.lat + ', ' + rootState.route.params.lng
       }
 
       if (rootState.route.params.communityId) {
-        let place = _.find(state.places, {
-          id: rootState.route.params.communityId,
-        })
+        let place = getters.getPlaceById
         if (place) {
           let placeName = place.name + ', ' + place.region
           if (place.alt_name) {


### PR DESCRIPTION
Closes #346

Testing -- enable the API mock, then

- Pick a named community.  The report section on elevation should read something like `...within 1 km of Anchor Point, Alaska, centered at 59.7766, -151.831 ranges between...`
- Go back and pick a valid Lat/Lng.  Now the report just reads `...within 1 km of this point ranges between...`
