### PR TITLE
Add Umami and remove Google Analytics

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,6 +33,16 @@ export default {
       { property: 'og:site_name', content: metas.title },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+    script: [
+      {
+        async: true,
+        defer: true,
+        'data-website-id': '1f4a98e7-d5cb-4295-82fc-5a4d41328038',
+        src: 'https://umami.snap.uaf.edu/umami.js',
+        'data-domains': 'arcticeds.org',
+        'data-do-not-track': true,
+      },
+    ],
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css
@@ -48,11 +58,7 @@ export default {
   },
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
-  plugins: [
-    '~/plugins/leaflet.client.js',
-    '~/plugins/vuex-router-sync',
-    '~/plugins/gtag',
-  ],
+  plugins: ['~/plugins/leaflet.client.js', '~/plugins/vuex-router-sync'],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14391,11 +14391,6 @@
       "resolved": "https://registry.npmjs.org/vue-client-only/-/vue-client-only-2.1.0.tgz",
       "integrity": "sha512-vKl1skEKn8EK9f8P2ZzhRnuaRHLHrlt1sbRmazlvsx6EiC3A8oWF8YCBrMJzoN+W3OnElwIGbVjsx6/xelY1AA=="
     },
-    "vue-gtag": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/vue-gtag/-/vue-gtag-1.16.1.tgz",
-      "integrity": "sha512-5vs0pSGxdqrfXqN1Qwt0ZFXG0iTYjRMu/saddc7QIC5yp+DKgjWQRpGYVa7Pq+KbThxwzzMfo0sGi7ISa6NowA=="
-    },
     "vue-hot-reload-api": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "proj4": "^2.8.0",
     "proj4leaflet": "^1.0.2",
     "raw-loader": "^4.0.2",
-    "vue-gtag": "^1.16.1",
     "vuex-router-sync": "^5.0.0"
   },
   "devDependencies": {

--- a/plugins/gtag.js
+++ b/plugins/gtag.js
@@ -1,7 +1,0 @@
-import Vue from 'vue'
-import VueGtag from 'vue-gtag'
-
-// Arctic EDS Analytics 4 property
-Vue.use(VueGtag, {
-  config: { id: 'G-R41D87LY2F' },
-})


### PR DESCRIPTION
Closes #284.

This PR adds Umami and removes all remnants of Google Analytics, including the `vue-gtag` module and the `gtag` plugin file.

I took a different approach to including Umami for this webapp vs. what we did for Northern Climate Reports. I decided against using the [nuxt-umami](https://github.com/ijkml/nuxt-umami) module because:

- Nuxt 2 only works against an old version of the nuxt-umami module (v1, not v2), and I'm a little concerned about long-term support for this old version of nuxt-umami and whether we will be able to upgrade to Nuxt 3 before then.
- I ran into compilation problems using nuxt-umami (even the older version that supports Nuxt 2). After a lot of trial and error, I was only able to get it to work after setting `export DISABLE_V8_COMPILE_CACHE=1` and I'm not entirely sure why.
- Using the nuxt-umami module doesn't really give us anything that we don't already get just by including Umami through a `script` tag in the Nuxt config.

With all that out of the way, Umami is working very well in this PR.

To test, comment out domain enforcement in `nuxt.config.js` like so:

```
script: [
  {
    async: true,
    defer: true,
    'data-website-id': '1f4a98e7-d5cb-4295-82fc-5a4d41328038',
    src: 'https://umami.snap.uaf.edu/umami.js',
    // 'data-domains': 'arcticeds.org',
    'data-do-not-track': true,
  },
],
```

Then:
- Run the app locally and load the front page
- Observe that the number of page views increases in the Umami dashboard for Arctic EDS
- Load a report for a location in Arctic EDS
- View the "Climate Maps" page
- Observe that both the report page w/ location identifier and `/maps` path show up under the "Pages" section of the Arctic EDS Umami dashboard