### PR TITLE
Fix permafrost MAGT conversions

### DIFF
--- a/store/report.js
+++ b/store/report.js
@@ -200,7 +200,7 @@ export default {
       // Converts all convertible units at the same time for shared report
       let conversions = [
         // This needs to be adapted after the summarized data are restored.
-        { type: 'temperature', substring: 'magt_', variable: 'permafrost' },
+        { type: 'temperature', substring: 'magt', variable: 'permafrost' },
         { type: 'm_in', substring: 'permafrosttop', variable: 'permafrost' },
         { type: 'mm_in', substring: '', variable: 'precipitation' },
         { type: 'mm_in', substring: '', variable: 'snowfall' },


### PR DESCRIPTION
Closes #380.

This PR fixes the conversion of the MAGT summary tables under the Permafrost section. The problem was simply that the object leaf substring (`magt_`) we had been using for the GIPL 1.0 data during the conversion process no longer applied. Since all MAGT values from the GIPL 2.0 dataset start with `magt` (with no underscore), all I needed to do here is remove the underscore.

To test, load the report for Fort Greely and verify that the values are sane (close-to-freezing) for both Fahrenheit and Celsius.