### PR TITLE
Use correct units for thawing index summary table

### DIFF
--- a/components/reports/ThawingIndex.vue
+++ b/components/reports/ThawingIndex.vue
@@ -35,60 +35,60 @@
             <th scope="row">Historical (1980&ndash;2009)</th>
             <td>
               {{ results.thawing_index['summary']['historical']['ddmin']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
             <td>
               {{ results.thawing_index['summary']['historical']['ddmean']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
             <td>
               {{ results.thawing_index['summary']['historical']['ddmax']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Early Century (2010&ndash;2039)</th>
             <td>
               {{ results.thawing_index['summary']['2010-2039']['ddmin']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
             <td>
               {{ results.thawing_index['summary']['2010-2039']['ddmean']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
             <td>
               {{ results.thawing_index['summary']['2010-2039']['ddmax']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040&ndash;2069)</th>
             <td>
               {{ results.thawing_index['summary']['2040-2069']['ddmin']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
             <td>
               {{ results.thawing_index['summary']['2040-2069']['ddmean']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
             <td>
               {{ results.thawing_index['summary']['2040-2069']['ddmax']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070&ndash;2099)</th>
             <td>
               {{ results.thawing_index['summary']['2070-2099']['ddmin']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
             <td>
               {{ results.thawing_index['summary']['2070-2099']['ddmean']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
             <td>
               {{ results.thawing_index['summary']['2070-2099']['ddmax']
-              }}<UnitWidget />
+              }}<UnitWidget unitType="dd" />
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
Closes #385 

See note there, but the issue was probably more that the wrong UnitWidget was being used here.  We aren't converting ºF•days, and that's probably the right call.  But we need the units labels to be correct.  Test by loading any location and checking that ºF•days are used for thawing index.