### PR TITLE
Adds catch-all that redirects unknown/invalid URLs to home

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -93,6 +93,11 @@ export default {
         path: '/report/:lat/:lng',
         component: resolve(__dirname, 'pages/report'),
       })
+      routes.push({
+        name: 'default',
+        path: '*',
+        redirect: '/',
+      })
     },
   },
 }


### PR DESCRIPTION
Closes #397 

To test:
- Run app (default production external env vars OK)
- Go to http://localhost:3000/) and http://localhost:3000/physiography/permafrost
- In both cases you should just get redirected to the home page
- Load a report for Fairbanks, confirm that it still works.
- Test direct-loading a URL (i.e. copy paste the report URL for FBX to a new tab)
