### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,7 +38,7 @@ export default {
         async: true,
         defer: true,
         'data-website-id': '1f4a98e7-d5cb-4295-82fc-5a4d41328038',
-        src: 'https://umami.snap.uaf.edu/umami.js',
+        src: 'https://umami.snap.uaf.edu/script.js',
         'data-domains': 'arcticeds.org',
         'data-do-not-track': true,
       },


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `nuxt.config.js` to:

```
{
  async: true,
  defer: true,
  'data-website-id': '1f4a98e7-d5cb-4295-82fc-5a4d41328038',
  src: 'http://localhost:9999/script.js',
  // 'data-domains': 'arcticeds.org',
  'data-do-not-track': true,
},
```

Then run Arctic-EDS locally and verify that your traffic shows up here: http://localhost:9999/websites/1f4a98e7-d5cb-4295-82fc-5a4d41328038