### PR TITLE
Read Umami script URL from environment variable

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,7 +38,7 @@ export default {
         async: true,
         defer: true,
         'data-website-id': '1f4a98e7-d5cb-4295-82fc-5a4d41328038',
-        src: 'https://umami.snap.uaf.edu/script.js',
+        src: process.env.UMAMI_URL || 'https://umami.snap.uaf.edu/umami.js',
         'data-domains': 'arcticeds.org',
         'data-do-not-track': true,
       },


### PR DESCRIPTION
This PR sets the default Umami URL to the v1 version (the current production Umami server version), but allows us to override the Umami URL using an environment variable so that we can update the URL to Umami v2 without updating/redeploying the GitHub repo.

To test:

- Run your local Vagrant Umami VM (as described in https://github.com/ua-snap/nccwsc-projects/pull/154). Umami should be forwarding to port 9999 of your host.
- Comment out `'data-domains': 'arcticeds.org',` from the Umami configuration in `nuxt.config.js`.
- Set UMAMI_URL to the v2 version of Umami, which is what the Vagrant VM is running:
  ```export UMAMI_URL=http://localhost:9999/script.js```
- Run the Arctic-EDS app (`npm run dev`), interact with it, and verify that traffic shows up in Umami at this URL: http://localhost:9999/websites/1f4a98e7-d5cb-4295-82fc-5a4d41328038