### PR TITLE
Fix freeze/thaw mixup

### DIFF
--- a/components/reports/FreezingIndex.vue
+++ b/components/reports/FreezingIndex.vue
@@ -7,10 +7,10 @@
           <li>
             &nbsp;
             <a
-              href="https://ua-snap.github.io/ardac-notebooks/lab?path=design_thawing_index%2Fdesign_thawing_index_module.ipynb"
+              href="https://ua-snap.github.io/ardac-notebooks/lab/?path=design_freezing_index%2Fdesign_freezing_index_module.ipynb"
               target="_blank"
             >
-              <strong>design thawing index</strong></a
+              <strong>design freezing index</strong></a
             >
           </li>
           <li>


### PR DESCRIPTION
Closes #401 

Testing:
- Load a report for a place, scroll down to the Freezing Index section.  Ensure that the link to the module reads "design freezing index" and the link goes to the correct module for freezing index.