### PR TITLE
Adds the conversion of degree day indices from imperial to metric along with the rest of the report

### DIFF
--- a/components/UnitWidget.vue
+++ b/components/UnitWidget.vue
@@ -45,7 +45,8 @@ export default {
           space = '&#8239;'
           break
         case 'dd':
-          symbol = '&deg;F&sdot;days'
+          symbol =
+            this.units == 'metric' ? '&deg;C&sdot;days' : '&deg;F&sdot;days'
           break
       }
       return {


### PR DESCRIPTION
This PR adds the ability to convert the degree day units from imperial to metric units, along with changing the units shown by the UnitWidget component.

To test, simply choose a place, check that the units shown match the live site in Heating Degree Days, Freezing Index, and Thawing Index. Switch to metric units and confirm that the values and units change, and then go back to imperial to confirm that the values return to their original values.

Closes #432 