### PR TITLE
Updates production Geoserver URL

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -50,7 +50,7 @@ export default {
 
   env: {
     geoserverUrl:
-      process.env.GEOSERVER_URL || 'https://gs.earthmaps.org/geoserver/wms',
+      process.env.GEOSERVER_URL || 'https://gs.earthmaps.io/geoserver/wms',
     apiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',
     rasdamanUrl:
       process.env.RASDAMAN_URL || 'https://maps.earthmaps.io/rasdaman/ows',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -50,7 +50,7 @@ export default {
 
   env: {
     geoserverUrl:
-      process.env.GEOSERVER_URL || 'https://gs.mapventure.org/geoserver/wms',
+      process.env.GEOSERVER_URL || 'https://gs.earthmaps.org/geoserver/wms',
     apiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',
     rasdamanUrl:
       process.env.RASDAMAN_URL || 'https://maps.earthmaps.io/rasdaman/ows',


### PR DESCRIPTION
This updates our default Geoserver URL to be our new Geoserver instance. This will be required to allow us to retire an old domain name and a much older version of Geoserver.