### PR TITLE
Limit places to EDS-specific spots (included DoD)

### DIFF
--- a/store/report.js
+++ b/store/report.js
@@ -285,7 +285,7 @@ export default {
       }
 
       // TODO: add error handling here for 404 (no data) etc.
-      let queryUrl = process.env.apiUrl + '/places/communities'
+      let queryUrl = process.env.apiUrl + '/places/communities?tags=eds'
       let places = await this.$http.$get(queryUrl)
       let filteredPlaces = _.filter(places, p => {
         return p.region == 'Alaska'


### PR DESCRIPTION
Closes #448 

Testing: set up a local API instance [per this ticket](https://github.com/ua-snap/data-api/pull/497) but you can run it from `main` at this point.

Then, in the place selector, search for `Nike`.  You should see two results.  Search for Eielson and you should see a number of results such as `Eielson Alpa Research (2-4)` etc.  Search for Whitehorse and you should not find that.