### PR TITLE
Add "slow loading" banner if SITE_SLOW environment variable is set

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -10,6 +10,26 @@
     </div>
     <Navbar />
     <section class="section">
+      <div v-if="siteSlow">
+        <div class="container">
+          <b-message
+            title="Arctic-EDS is experiencing slow load times"
+            type="is-warning"
+            aria-close-label="Close message"
+          >
+            <p>
+              We&rsquo;re sorry! Arctic-EDS is experiencing slower load times
+              than usual. We&rsquo;re working to improve performance as soon as
+              possible, but we don&rsquo;t have an estimated time for
+              completion. Please check back soon, or reach out to us at
+              <a href="mailto:uaf-snap-data-tools@alaska.edu"
+                >uaf-snap-data-tools@alaska.edu</a
+              >
+              with questions.
+            </p>
+          </b-message>
+        </div>
+      </div>
       <Nuxt />
     </section>
     <Footer />
@@ -46,5 +66,10 @@ import Footer from '~/components/Footer'
 
 export default {
   components: { HeaderBanner, Navbar, Footer },
+  computed: {
+    siteSlow() {
+      return process.env.siteSlow
+    },
+  },
 }
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -61,6 +61,7 @@ export default {
       process.env.RASDAMAN_URL || 'https://maps.earthmaps.io/rasdaman/ows',
     mockApi: process.env.MOCK_API || false,
     safeMode: process.env.EDS_SAFE_MODE || false,
+    siteSlow: process.env.SITE_SLOW || false,
   },
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins


### PR DESCRIPTION
This PR adds an "experiencing slow load times" banner to the top of all pages if the `SITE_SLOW` environment variable is set.

To test:

- Run `export SITE_SLOW=true`, run the app, and verify that the site-slow warning shows up where you expect.
- Run `unset SITE_SLOW`, run the app, and confirm that everything still looks good without the banner.