### PR TITLE
Use same WMS color map as Obu map layer for GIPL map layers

### DIFF
--- a/components/map_content.js
+++ b/components/map_content.js
@@ -170,7 +170,7 @@ export default {
           'Mean annual ground temperature at 1 m depth, 2021-2050 (5-Model Average, RCP 8.5), GIPL model',
         source: 'rasdaman',
         wmsLayerName: 'crrel_gipl_outputs_nc',
-        style: 'arctic_eds_gipl_magt1m_nearcentury',
+        style: 'arctic_eds_gipl_magt1m_nearcentury2',
         legend: 'magt',
       },
       {
@@ -179,7 +179,7 @@ export default {
           'Mean annual ground temperature at 1 m depth, 2071&ndash;2100 (5&ndash;Model Average, RCP 8.5), GIPL model',
         source: 'rasdaman',
         wmsLayerName: 'crrel_gipl_outputs_nc',
-        style: 'arctic_eds_gipl_magt1m_latecentury',
+        style: 'arctic_eds_gipl_magt1m_latecentury2',
         legend: 'magt',
       },
     ],


### PR DESCRIPTION
Closes #472.

This PR fixes #472, but in a different way than described in that issue. It keeps the map legends for the GIPL map layers as-is (the same legend as the Obu map layer), but changes the Rasdaman WMS styles for the two GIPL layers to use the same color map as the Obu layer. This seemed like the preferable approach since it makes comparisons between the Obu and GIPL map layers easier.