### PR TITLE
Updates URLs for Jupyter notebooks with new location in ARDAC GitHub page.

### DIFF
--- a/components/reports/FreezingIndex.vue
+++ b/components/reports/FreezingIndex.vue
@@ -7,7 +7,7 @@
           <li>
             &nbsp;
             <a
-              href="https://ua-snap.github.io/ardac-notebooks/lab/?path=design_freezing_index%2Fdesign_freezing_index_module.ipynb"
+              href="https://ua-snap.github.io/ardac/lab/?path=design_freezing_index%2Fdesign_freezing_index_module.ipynb"
               target="_blank"
             >
               <strong>design freezing index</strong></a
@@ -16,7 +16,7 @@
           <li>
             &nbsp;
             <a
-              href="https://ua-snap.github.io/ardac-notebooks/lab?path=frost_depth%2FModified+Berggren+Frost+Depth.ipynb"
+              href="https://ua-snap.github.io/ardac/lab?path=frost_depth%2FModified+Berggren+Frost+Depth.ipynb"
               target="_blank"
             >
               <strong>Modified Berggren frost depth</strong> calculator</a

--- a/components/reports/PrecipitationFrequency.vue
+++ b/components/reports/PrecipitationFrequency.vue
@@ -29,7 +29,7 @@
         <li>
           Use this dataset in an
           <a
-            href="https://ua-snap.github.io/ardac-notebooks/lab?path=design_discharge%2Fdesign_discharge.ipynb"
+            href="https://ua-snap.github.io/ardac/lab?path=design_discharge%2Fdesign_discharge.ipynb"
             target="_blank"
             >interactive computational module for
             <strong>design discharge</strong>.</a

--- a/components/reports/Temperature.vue
+++ b/components/reports/Temperature.vue
@@ -38,7 +38,7 @@
         <li>
           Use this dataset in a
           <a
-            href="https://ua-snap.github.io/ardac-notebooks/lab?path=frost_depth%2FModified+Berggren+Frost+Depth.ipynb"
+            href="https://ua-snap.github.io/ardac/lab?path=frost_depth%2FModified+Berggren+Frost+Depth.ipynb"
             target="_blank"
           >
             <strong>Modified Berggren frost depth</strong> calculator.</a
@@ -51,9 +51,11 @@
       <h4 class="title is-5 mb-1">Data Summary</h4>
       <div class="content is-size-5">
         The summary table below presents the minimum, mean, and maximum values
-        for a single scenario (RCP 8.5) and a 5-model average (an average derived from
-        the NCAR CCSM4, GFDL CM3, GISS E2-R, MRI CGCM3, and IPSL CM5A-LR
-        models).  Data are rounded to two (imperial units) or three (metric) significant digits, and the relative change compared to the modeled baseline (1901-2015) is shown below the value.
+        for a single scenario (RCP 8.5) and a 5-model average (an average
+        derived from the NCAR CCSM4, GFDL CM3, GISS E2-R, MRI CGCM3, and IPSL
+        CM5A-LR models). Data are rounded to two (imperial units) or three
+        (metric) significant digits, and the relative change compared to the
+        modeled baseline (1901-2015) is shown below the value.
       </div>
     </div>
 
@@ -493,9 +495,9 @@
       <h4 class="title is-5 mb-1">Data preview</h4>
 
       <p class="content is-size-5 mb-1">
-        CSV download includes monthly values for both modeled baseline CRU TS 4.0
-        (1901&ndash;2015) and modeled projected (2006&ndash;2100) datasets. Data
-        are provided in metric units.
+        CSV download includes monthly values for both modeled baseline CRU TS
+        4.0 (1901&ndash;2015) and modeled projected (2006&ndash;2100) datasets.
+        Data are provided in metric units.
       </p>
       <PreviewTable
         :csvString="results.temperature.preview"

--- a/components/reports/ThawingIndex.vue
+++ b/components/reports/ThawingIndex.vue
@@ -6,7 +6,7 @@
           <li>
             Use this dataset in an
             <a
-              href="https://ua-snap.github.io/ardac-notebooks/lab?path=design_thawing_index%2Fdesign_thawing_index_module.ipynb"
+              href="https://ua-snap.github.io/ardac/lab?path=design_thawing_index%2Fdesign_thawing_index_module.ipynb"
               target="_blank"
               >interactive computational module for
               <strong>design thawing index</strong>.</a
@@ -36,20 +36,26 @@
           <tr>
             <th scope="row">Early Century (2010&ndash;2039)</th>
             <td>
-              {{ round(results.thawing_index['summary']['2010-2039']['ddmin'],2)
-              }}<UnitWidget unitType="dd" /><br><Diff
+              {{
+                round(
+                  results.thawing_index['summary']['2010-2039']['ddmin'],
+                  2
+                )
+              }}<UnitWidget unitType="dd" /><br /><Diff
                 kind="pct"
                 :past="
                   results.thawing_index['summary']['modeled_baseline']['ddmin']
                 "
-                :future="
-                  results.thawing_index['summary']['2010-2039']['ddmin']
-                "
+                :future="results.thawing_index['summary']['2010-2039']['ddmin']"
               />
             </td>
             <td>
-              {{ round(results.thawing_index['summary']['2010-2039']['ddmean'],2)
-              }}<UnitWidget unitType="dd" /><br><Diff
+              {{
+                round(
+                  results.thawing_index['summary']['2010-2039']['ddmean'],
+                  2
+                )
+              }}<UnitWidget unitType="dd" /><br /><Diff
                 kind="pct"
                 :past="
                   results.thawing_index['summary']['modeled_baseline']['ddmean']
@@ -60,35 +66,43 @@
               />
             </td>
             <td>
-              {{ round(results.thawing_index['summary']['2010-2039']['ddmax'],2)
-              }}<UnitWidget unitType="dd" /><br><Diff
+              {{
+                round(
+                  results.thawing_index['summary']['2010-2039']['ddmax'],
+                  2
+                )
+              }}<UnitWidget unitType="dd" /><br /><Diff
                 kind="pct"
                 :past="
                   results.thawing_index['summary']['modeled_baseline']['ddmax']
                 "
-                :future="
-                  results.thawing_index['summary']['2010-2039']['ddmax']
-                "
+                :future="results.thawing_index['summary']['2010-2039']['ddmax']"
               />
             </td>
           </tr>
           <tr>
             <th scope="row">Mid Century (2040&ndash;2069)</th>
             <td>
-              {{ round(results.thawing_index['summary']['2040-2069']['ddmin'],2)
-              }}<UnitWidget unitType="dd" /><br><Diff
+              {{
+                round(
+                  results.thawing_index['summary']['2040-2069']['ddmin'],
+                  2
+                )
+              }}<UnitWidget unitType="dd" /><br /><Diff
                 kind="pct"
                 :past="
                   results.thawing_index['summary']['modeled_baseline']['ddmin']
                 "
-                :future="
-                  results.thawing_index['summary']['2040-2069']['ddmin']
-                "
+                :future="results.thawing_index['summary']['2040-2069']['ddmin']"
               />
             </td>
             <td>
-              {{ round(results.thawing_index['summary']['2040-2069']['ddmean'],2)
-              }}<UnitWidget unitType="dd" /><br><Diff
+              {{
+                round(
+                  results.thawing_index['summary']['2040-2069']['ddmean'],
+                  2
+                )
+              }}<UnitWidget unitType="dd" /><br /><Diff
                 kind="pct"
                 :past="
                   results.thawing_index['summary']['modeled_baseline']['ddmean']
@@ -99,35 +113,43 @@
               />
             </td>
             <td>
-              {{ round(results.thawing_index['summary']['2040-2069']['ddmax'],2)
-              }}<UnitWidget unitType="dd" /><br><Diff
+              {{
+                round(
+                  results.thawing_index['summary']['2040-2069']['ddmax'],
+                  2
+                )
+              }}<UnitWidget unitType="dd" /><br /><Diff
                 kind="pct"
                 :past="
                   results.thawing_index['summary']['modeled_baseline']['ddmax']
                 "
-                :future="
-                  results.thawing_index['summary']['2040-2069']['ddmax']
-                "
+                :future="results.thawing_index['summary']['2040-2069']['ddmax']"
               />
             </td>
           </tr>
           <tr>
             <th scope="row">Late Century (2070&ndash;2099)</th>
             <td>
-              {{ round(results.thawing_index['summary']['2070-2099']['ddmin'],2)
-              }}<UnitWidget unitType="dd" /><br><Diff
+              {{
+                round(
+                  results.thawing_index['summary']['2070-2099']['ddmin'],
+                  2
+                )
+              }}<UnitWidget unitType="dd" /><br /><Diff
                 kind="pct"
                 :past="
                   results.thawing_index['summary']['modeled_baseline']['ddmin']
                 "
-                :future="
-                  results.thawing_index['summary']['2070-2099']['ddmin']
-                "
+                :future="results.thawing_index['summary']['2070-2099']['ddmin']"
               />
             </td>
             <td>
-              {{ round(results.thawing_index['summary']['2070-2099']['ddmean'],2)
-              }}<UnitWidget unitType="dd" /><br><Diff
+              {{
+                round(
+                  results.thawing_index['summary']['2070-2099']['ddmean'],
+                  2
+                )
+              }}<UnitWidget unitType="dd" /><br /><Diff
                 kind="pct"
                 :past="
                   results.thawing_index['summary']['modeled_baseline']['ddmean']
@@ -138,15 +160,17 @@
               />
             </td>
             <td>
-              {{ round(results.thawing_index['summary']['2070-2099']['ddmax'],2)
-              }}<UnitWidget unitType="dd" /><br><Diff
+              {{
+                round(
+                  results.thawing_index['summary']['2070-2099']['ddmax'],
+                  2
+                )
+              }}<UnitWidget unitType="dd" /><br /><Diff
                 kind="pct"
                 :past="
                   results.thawing_index['summary']['modeled_baseline']['ddmax']
                 "
-                :future="
-                  results.thawing_index['summary']['2070-2099']['ddmax']
-                "
+                :future="results.thawing_index['summary']['2070-2099']['ddmax']"
               />
             </td>
           </tr>


### PR DESCRIPTION
This PR updates the URLs for the notebooks shown in the ArcticEDS that are linked to the wrong place now that the notebooks are all part of the mono repo ardac. This was for the work that Charlie did today to get those notebooks to run again in the new repo location.